### PR TITLE
feat: Add colored menu bar icon states

### DIFF
--- a/Sources/VocaMac/App/VocaMacApp.swift
+++ b/Sources/VocaMac/App/VocaMacApp.swift
@@ -120,21 +120,53 @@ struct VocaMacApp: App {
 
 // MARK: - Menu Bar Icon
 
-/// Renders the appropriate icon in the menu bar based on app status
+/// Renders a mic icon in the menu bar with color changes based on app status.
+///
+/// Uses NSImage to create properly tinted menu bar icons because MenuBarExtra's
+/// label treats SwiftUI `.foregroundStyle()` colors as template images, stripping
+/// color. By setting `isTemplate = false` for non-idle states, macOS renders
+/// the actual color in the menu bar.
+///
+/// States:
+///   • idle       → system default (template mic, adapts to menu bar appearance)
+///   • recording  → red filled mic (non-template, colored)
+///   • processing → orange spinner (non-template, colored)
+///   • error      → yellow warning (non-template, colored)
 struct MenuBarIcon: View {
     let appStatus: AppStatus
     let audioLevel: Float
 
     var body: some View {
-        Image(systemName: iconName)
-            .symbolRenderingMode(.hierarchical)
-            .foregroundStyle(iconColor)
+        Image(nsImage: makeMenuBarIcon())
+    }
+
+    private func makeMenuBarIcon() -> NSImage {
+        let config = NSImage.SymbolConfiguration(pointSize: 16, weight: .regular)
+
+        guard let baseImage = NSImage(systemSymbolName: iconName, accessibilityDescription: "VocaMac")?
+            .withSymbolConfiguration(config) else {
+            // Fallback to a basic mic if symbol lookup fails
+            return NSImage(systemSymbolName: "mic", accessibilityDescription: "VocaMac") ?? NSImage()
+        }
+
+        // Tint the icon with the status color
+        let tintColor = nsColor
+        let size = baseImage.size
+
+        let tinted = NSImage(size: size, flipped: false) { rect in
+            baseImage.draw(in: rect)
+            tintColor.set()
+            rect.fill(using: .sourceAtop)
+            return true
+        }
+        tinted.isTemplate = false
+        return tinted
     }
 
     private var iconName: String {
         switch appStatus {
         case .idle:
-            return "mic"
+            return "mic.fill"
         case .recording:
             return "mic.fill"
         case .processing:
@@ -144,12 +176,12 @@ struct MenuBarIcon: View {
         }
     }
 
-    private var iconColor: Color {
+    private var nsColor: NSColor {
         switch appStatus {
-        case .idle:       return .primary
-        case .recording:  return .red
-        case .processing: return .orange
-        case .error:      return .yellow
+        case .idle:       return NSColor(red: 0, green: 0.478, blue: 1.0, alpha: 1.0)
+        case .recording:  return .systemRed
+        case .processing: return NSColor(red: 0.749, green: 0.353, blue: 0.949, alpha: 1.0) // #BF5AF2
+        case .error:      return .systemYellow
         }
     }
 }


### PR DESCRIPTION
## Summary

This PR adds colored menu bar icon states to provide clear visual feedback about VocaMac's current status directly in the menu bar.

## Problem Solved

Previously, the menu bar icon was monochrome and didn't change when recording or processing, making it unclear what the app was doing.

## Solution

Replaced the basic SwiftUI `Image` approach with `NSImage` + `sourceAtop` tinting because `MenuBarExtra` treats SwiftUI colors as template images, stripping out color information.

## Icon States

| State | Icon | Color | Purpose |
|-------|------|-------|---------|
| **Idle** | `mic.fill` | Blue (`#007AFF`) | Matches website branding |
| **Recording** | `mic.fill` | Red | Universal 'live/recording' signal |
| **Processing** | `ellipsis.circle` | Purple (`#BF5AF2`) | 'AI thinking' indicator |
| **Error** | `exclamationmark.triangle` | Yellow | Clear error state |

## Technical Implementation

- Uses `NSImage` with `isTemplate = false` for colored states
- `sourceAtop` compositing mode applies solid color tints
- All states use non-template rendering for consistent color display
- Maintains 16pt size optimized for menu bar display

## User Experience

Users now get immediate visual feedback when:
- 🔵 VocaMac is ready (blue)
- 🔴 Recording is active (red) 
- 🟣 Audio is being transcribed (purple)
- 🟡 An error occurred (yellow)

Much clearer than before! 🎉