### PR TITLE
ci: Add CI/CD pipelines for build checks and website deployment

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,20 @@
+name: Build & Test
+
+on:
+  pull_request:
+    branches: [main]
+
+jobs:
+  build-and-test:
+    name: Build & Test
+    runs-on: macos-15
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Build
+        run: swift build
+
+      - name: Test
+        run: swift test

--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -1,0 +1,39 @@
+name: Deploy Website
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    name: Deploy to GitHub Pages
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Configure Pages
+        uses: actions/configure-pages@v5
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: web
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/web/CNAME
+++ b/web/CNAME
@@ -1,0 +1,1 @@
+vocamac.com


### PR DESCRIPTION
## Summary

Adds two GitHub Actions workflows to establish CI/CD for the project.

### Build & Test (`ci.yml`)
- Triggers on **pull requests to main**
- Runs on **macOS 15**
- Builds with `swift build` and runs tests with `swift test`
- Ensures every PR has a green build before merge

### Deploy Website (`deploy-website.yml`)
- Triggers on **GitHub releases** (published) and **manual dispatch**
- Deploys the `web/` folder to **GitHub Pages**
- Custom domain: **vocamac.com** (via CNAME file)
- Uses official GitHub Pages actions for deployment
- Concurrency protection to prevent overlapping deploys

### Also includes
- `web/CNAME` file for custom domain configuration