### PR TITLE
docs: Add README badges and update license reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # 🎙️ VocaMac
 
+[![Build & Test](https://github.com/jatinkrmalik/vocamac/actions/workflows/ci.yml/badge.svg)](https://github.com/jatinkrmalik/vocamac/actions/workflows/ci.yml) [![License: AGPL-3.0](https://img.shields.io/badge/License-AGPL--3.0-blue.svg)](https://www.gnu.org/licenses/agpl-3.0) [![Platform: macOS](https://img.shields.io/badge/Platform-macOS%2013%2B-lightgrey.svg)](https://github.com/jatinkrmalik/vocamac) [![Swift 5.9+](https://img.shields.io/badge/Swift-5.9%2B-orange.svg)](https://swift.org) [![Website](https://img.shields.io/badge/Web-vocamac.com-007AFF.svg)](https://vocamac.com) [![GitHub stars](https://img.shields.io/github/stars/jatinkrmalik/vocamac?style=social)](https://github.com/jatinkrmalik/vocamac/stargazers)
+
+
 **Local voice-to-text for macOS — powered by [WhisperKit](https://github.com/argmaxinc/WhisperKit)**
 
 VocaMac is a native macOS menu bar application that transcribes your voice to text locally on your machine. No cloud, no subscriptions, no data leaves your device. Just hold a hotkey, speak, and your words appear wherever your cursor is.
@@ -195,7 +198,7 @@ VocaMac/
 │   ├── PRD.md                      # Product Requirements Document
 │   ├── ARCHITECTURE.md             # Technical Architecture
 │   └── DATA_MODEL.md               # Data Model & ERD
-├── LICENSE                         # MIT License
+├── LICENSE                         # AGPL-3.0 License
 └── .gitignore
 ```
 
@@ -251,7 +254,7 @@ Each platform uses native technologies for the best possible integration, while 
 
 ## 📄 License
 
-MIT License — see [LICENSE](LICENSE) for details.
+AGPL-3.0 License — see [LICENSE](LICENSE) for details.
 
 ---
 


### PR DESCRIPTION
## Summary

Enhances the README with status badges and updates license references for better open source presentation.

### Badges Added
- **Build & Test** — CI status from GitHub Actions
- **License: AGPL-3.0** — License indicator
- **Platform: macOS 13+** — Supported platform
- **Swift 5.9+** — Language version
- **Website** — Link to vocamac.com in brand blue
- **GitHub Stars** — Social proof

### License Reference
- Updated all MIT references in README to AGPL-3.0 (matching the license change in PR)