### PR TITLE
fix: preserve clipboard contents after text injection

### DIFF
--- a/Sources/VocaMac/Services/TextInjector.swift
+++ b/Sources/VocaMac/Services/TextInjector.swift
@@ -17,6 +17,19 @@ final class TextInjector {
     /// Virtual key code for the V key
     private let kVK_V: CGKeyCode = 9
 
+    // MARK: - Types
+
+    /// Deep copy of a single pasteboard item's data across all its types
+    private struct PasteboardItemSnapshot {
+        /// Map from pasteboard type to raw data
+        let dataByType: [(NSPasteboard.PasteboardType, Data)]
+    }
+
+    /// Deep copy of the entire pasteboard state
+    private struct PasteboardSnapshot {
+        let items: [PasteboardItemSnapshot]
+    }
+
     // MARK: - Public API
 
     /// Inject text at the current cursor position in any application
@@ -40,8 +53,10 @@ final class TextInjector {
 
         let pasteboard = NSPasteboard.general
 
-        // Save current clipboard text
-        let previousText = preserveClipboard ? pasteboard.string(forType: .string) : nil
+        // Deep-copy current clipboard state before we overwrite it.
+        // NSPasteboardItem objects are invalidated when the pasteboard is cleared,
+        // so we must extract the raw data eagerly.
+        let snapshot = preserveClipboard ? captureSnapshot(pasteboard) : nil
 
         // Set transcribed text to clipboard
         pasteboard.clearContents()
@@ -54,13 +69,63 @@ final class TextInjector {
             simulatePaste()
 
             // Restore clipboard after paste completes
-            if preserveClipboard, let previous = previousText {
+            if preserveClipboard {
                 DispatchQueue.main.asyncAfter(deadline: .now() + clipboardRestoreDelay) {
-                    pasteboard.clearContents()
-                    pasteboard.setString(previous, forType: .string)
+                    if let snapshot = snapshot {
+                        self.restoreSnapshot(snapshot, to: pasteboard)
+                    } else {
+                        // Previous clipboard was empty; clear the transcribed text
+                        pasteboard.clearContents()
+                    }
+                    NSLog("[TextInjector] Clipboard restored")
                 }
             }
         }
+    }
+
+    // MARK: - Clipboard Snapshot Management
+
+    /// Deep-copy every item and type from the pasteboard into plain `Data` values.
+    /// This must be called *before* `clearContents()` because NSPasteboardItem
+    /// objects are invalidated when the pasteboard changes.
+    private func captureSnapshot(_ pasteboard: NSPasteboard) -> PasteboardSnapshot? {
+        guard let pasteboardItems = pasteboard.pasteboardItems, !pasteboardItems.isEmpty else {
+            return nil
+        }
+
+        var itemSnapshots: [PasteboardItemSnapshot] = []
+
+        for item in pasteboardItems {
+            var dataByType: [(NSPasteboard.PasteboardType, Data)] = []
+            for type in item.types {
+                if let data = item.data(forType: type) {
+                    dataByType.append((type, data))
+                }
+            }
+            if !dataByType.isEmpty {
+                itemSnapshots.append(PasteboardItemSnapshot(dataByType: dataByType))
+            }
+        }
+
+        guard !itemSnapshots.isEmpty else { return nil }
+        return PasteboardSnapshot(items: itemSnapshots)
+    }
+
+    /// Write a previously captured snapshot back to the pasteboard.
+    private func restoreSnapshot(_ snapshot: PasteboardSnapshot, to pasteboard: NSPasteboard) {
+        pasteboard.clearContents()
+
+        var newItems: [NSPasteboardItem] = []
+        for itemSnapshot in snapshot.items {
+            let newItem = NSPasteboardItem()
+            for (type, data) in itemSnapshot.dataByType {
+                newItem.setData(data, forType: type)
+            }
+            newItems.append(newItem)
+        }
+
+        pasteboard.writeObjects(newItems)
+        NSLog("[TextInjector] Restored clipboard with %ld items", newItems.count)
     }
 
     // MARK: - Paste Simulation


### PR DESCRIPTION
## Problem
When transcribing text, the TextInjector uses the clipboard to paste via Cmd+V simulation. The previous clipboard contents were supposed to be saved and restored, but:

1. **Only string content was saved** — images, files, rich text were lost permanently
2. **Empty clipboard was never restored** — the `if let previous = previousText` guard would fail, leaving transcribed text on the clipboard
3. **NSPasteboardItem invalidation** — the original items become invalid after `clearContents()` is called

## Fix
- **Deep-copy all pasteboard item data** (every type, as raw `Data`) before overwriting the clipboard
- **Always restore** the clipboard when `preserveClipboard` is enabled — even if it was previously empty (just clear it)
- **Handle all content types** — images, files, rich text, etc. are now preserved correctly

## Testing
- Copy an image to clipboard → transcribe → clipboard should still have the image
- Copy text to clipboard → transcribe → clipboard should still have the original text
- Have empty clipboard → transcribe → clipboard should be empty again (not contain transcribed text)