### PR TITLE
fix: use correct SF Symbol for accessibility permission icon

### DIFF
--- a/Sources/VocaMac/Views/SettingsView.swift
+++ b/Sources/VocaMac/Views/SettingsView.swift
@@ -148,7 +148,7 @@ struct GeneralSettingsTab: View {
 
                 PermissionRow(
                     name: "Accessibility",
-                    icon: "universal.access",
+                    icon: "accessibility",
                     status: appState.accessibilityPermission,
                     action: { appState.requestAccessibilityPermission() },
                     actionLabel: "Open Settings"


### PR DESCRIPTION
## Problem
In Settings → General → Permissions, the Accessibility row used `"universal.access"` as the SF Symbol name, which doesn't exist in SF Symbols. The microphone (mic.fill) and input monitoring (keyboard) icons rendered correctly, but accessibility showed a blank space.

## Fix
Changed `"universal.access"` to `"accessibility"` — the correct SF Symbol name showing a person in a circle.