### PR TITLE
fix: hyperlink author name to Twitter profile in About tab

### DIFF
--- a/Sources/VocaMac/Views/SettingsView.swift
+++ b/Sources/VocaMac/Views/SettingsView.swift
@@ -612,10 +612,14 @@ struct AboutTab: View {
 
             Spacer()
 
-            Text("Made with ❤️ by Jatin Kumar Malik")
-                .font(.caption2)
-                .foregroundStyle(.tertiary)
-                .padding(.bottom, 8)
+            HStack(spacing: 0) {
+                Text("Made with ❤️ by ")
+                    .font(.caption2)
+                    .foregroundStyle(.tertiary)
+                Link("Jatin Kumar Malik", destination: URL(string: "https://x.com/intent/user?screen_name=jatinkrmalik")!)
+                    .font(.caption2)
+            }
+            .padding(.bottom, 8)
         }
         .frame(maxWidth: .infinity)
         .padding()


### PR DESCRIPTION
## Change
Made 'Jatin Kumar Malik' in the About tab footer a clickable link to the Twitter/X profile.

**URL:** https://x.com/intent/user?screen_name=jatinkrmalik

The footer now reads: "Made with ❤️ by [Jatin Kumar Malik](https://x.com/intent/user?screen_name=jatinkrmalik)"