### PR TITLE
feat: add sound effects for recording start/stop

### DIFF
--- a/Sources/VocaMac/Models/AppState.swift
+++ b/Sources/VocaMac/Models/AppState.swift
@@ -101,6 +101,7 @@ final class AppState: ObservableObject {
     @AppStorage("vocamac.selectedLanguage") var selectedLanguage: String = "auto"
     @AppStorage("vocamac.launchAtLogin") var launchAtLogin: Bool = false
     @AppStorage("vocamac.preserveClipboard") var preserveClipboard: Bool = true
+    @AppStorage("vocamac.soundEffectsEnabled") var soundEffectsEnabled: Bool = true
 
     // MARK: - Services
 
@@ -109,6 +110,7 @@ final class AppState: ObservableObject {
     let textInjector = TextInjector()
     let hotKeyManager = HotKeyManager()
     let modelManager = ModelManager()
+    let soundManager = SoundManager()
 
     // MARK: - Private
 
@@ -225,6 +227,11 @@ final class AppState: ObservableObject {
         isRecording = true
         errorMessage = nil
 
+        // Play start sound
+        if soundEffectsEnabled {
+            soundManager.playStartSound()
+        }
+
         audioEngine.startRecording(
             silenceThreshold: Float(silenceThreshold),
             silenceDuration: silenceDuration,
@@ -238,6 +245,11 @@ final class AppState: ObservableObject {
         let audioData = audioEngine.stopRecording()
         isRecording = false
         audioLevel = 0.0
+
+        // Play stop sound
+        if soundEffectsEnabled {
+            soundManager.playStopSound()
+        }
 
         guard !audioData.isEmpty else {
             appStatus = .idle

--- a/Sources/VocaMac/Services/SoundManager.swift
+++ b/Sources/VocaMac/Services/SoundManager.swift
@@ -1,0 +1,49 @@
+// SoundManager.swift
+// VocaMac
+//
+// Plays audio feedback sounds for recording start/stop events.
+// Uses macOS system sounds for soft, pleasing audio cues.
+
+import Foundation
+import AppKit
+
+final class SoundManager {
+
+    // MARK: - Sound Names
+
+    /// Soft tap sound for recording start
+    private let startSoundName = "Tink"
+
+    /// Soft pop sound for recording stop
+    private let stopSoundName = "Pop"
+
+    // MARK: - Properties
+
+    /// Volume for sound effects (0.0 to 1.0)
+    var volume: Float = 0.5
+
+    // MARK: - Public API
+
+    /// Play the recording-started sound
+    func playStartSound() {
+        playSystemSound(startSoundName)
+    }
+
+    /// Play the recording-stopped sound
+    func playStopSound() {
+        playSystemSound(stopSoundName)
+    }
+
+    // MARK: - Private
+
+    /// Play a macOS system sound by name
+    private func playSystemSound(_ name: String) {
+        let soundPath = "/System/Library/Sounds/\(name).aiff"
+        guard let sound = NSSound(contentsOfFile: soundPath, byReference: true) else {
+            NSLog("[SoundManager] Could not load system sound: %@", name)
+            return
+        }
+        sound.volume = volume
+        sound.play()
+    }
+}

--- a/Sources/VocaMac/Views/SettingsView.swift
+++ b/Sources/VocaMac/Views/SettingsView.swift
@@ -544,6 +544,14 @@ struct AudioSettingsTab: View {
                     .foregroundStyle(.secondary)
             }
 
+            Section("Sound Effects") {
+                Toggle("Enable sound effects", isOn: $appState.soundEffectsEnabled)
+
+                Text("Play subtle audio cues when recording starts and stops.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+
             Section("Input Device") {
                 if audioDevices.isEmpty {
                     HStack {


### PR DESCRIPTION
## Sound Effects for Recording Feedback

Adds subtle audio cues when recording starts and stops, so users get clear feedback that VocaMac is listening.

### Sounds
- **Start recording:** `Tink.aiff` — a soft, subtle tap sound
- **Stop recording:** `Pop.aiff` — a soft pop sound

Both are built-in macOS system sounds, so no audio files need to be bundled.

### Mute Toggle
A new **Sound Effects** section in Settings → Audio lets users disable sound effects without muting their entire system.

Setting is persisted via `@AppStorage` and defaults to **enabled**.

### Implementation
- New `SoundManager` service (`Sources/VocaMac/Services/SoundManager.swift`)
- Integrated into `AppState.startRecording()` and `stopRecordingAndTranscribe()`
- Toggle in `AudioSettingsTab` in SettingsView

### Files Changed
- `Sources/VocaMac/Services/SoundManager.swift` (new)
- `Sources/VocaMac/Models/AppState.swift` (sound integration + setting)
- `Sources/VocaMac/Views/SettingsView.swift` (toggle in Audio tab)