### PR TITLE
chore: v0.1.0 alpha release preparation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,17 +6,40 @@ on:
   pull_request:
     branches: [main]
 
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build-and-test:
     name: Build & Test
     runs-on: macos-15
+    timeout-minutes: 30
 
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Build
+      - name: Cache SPM dependencies
+        uses: actions/cache@v4
+        with:
+          path: .build
+          key: spm-${{ runner.os }}-${{ hashFiles('Package.resolved') }}
+          restore-keys: |
+            spm-${{ runner.os }}-
+
+      - name: Build (Debug)
         run: swift build
 
       - name: Test
         run: swift test
+
+      - name: Build (Release)
+        run: swift build -c release
+
+      - name: Verify app bundle
+        run: |
+          ./scripts/build.sh release
+          test -d VocaMac.app || exit 1
+          codesign -v VocaMac.app
+          echo "App bundle verified"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,90 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: write
+
+jobs:
+  build-and-release:
+    name: Build & Release
+    runs-on: macos-15
+    timeout-minutes: 30
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Extract version from tag
+        id: version
+        run: echo "VERSION=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
+
+      - name: Update version in build script
+        run: |
+          sed -i '' "s/CFBundleVersion.*/<key>CFBundleVersion<\/key>/" scripts/build.sh || true
+          echo "Building version: ${{ steps.version.outputs.VERSION }}"
+
+      - name: Build release app bundle
+        run: ./scripts/build.sh release
+
+      - name: Verify code signature
+        run: codesign -v --deep --strict VocaMac.app
+
+      - name: Run tests
+        run: swift test
+
+      - name: Create DMG
+        run: |
+          mkdir -p dmg-staging
+          cp -R VocaMac.app dmg-staging/
+          ln -s /Applications dmg-staging/Applications
+
+          hdiutil create -volname "VocaMac" \
+            -srcfolder dmg-staging \
+            -ov -format UDZO \
+            "VocaMac-${{ steps.version.outputs.VERSION }}-arm64.dmg"
+
+          echo "DMG created:"
+          ls -lh VocaMac-*.dmg
+
+      - name: Create ZIP archive
+        run: |
+          ditto -c -k --sequesterRsrc --keepParent VocaMac.app \
+            "VocaMac-${{ steps.version.outputs.VERSION }}-arm64.zip"
+
+          echo "ZIP created:"
+          ls -lh VocaMac-*.zip
+
+      - name: Generate checksums
+        run: |
+          shasum -a 256 VocaMac-*.dmg VocaMac-*.zip > checksums.txt
+          cat checksums.txt
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          generate_release_notes: true
+          draft: true
+          files: |
+            VocaMac-*.dmg
+            VocaMac-*.zip
+            checksums.txt
+          body: |
+            ## VocaMac ${{ steps.version.outputs.VERSION }}
+
+            ### Installation
+
+            1. Download `VocaMac-${{ steps.version.outputs.VERSION }}-arm64.dmg`
+            2. Open the DMG and drag VocaMac to Applications
+            3. Open VocaMac from Applications
+            4. Grant Microphone, Accessibility, and Input Monitoring permissions when prompted
+
+            ### Checksums (SHA-256)
+            See `checksums.txt` for verification.
+
+            ### Requirements
+            - macOS 13 (Ventura) or later
+            - Apple Silicon (arm64)

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 <h1 align="center">VocaMac</h1>
 
-[![Build & Test](https://github.com/jatinkrmalik/vocamac/actions/workflows/ci.yml/badge.svg)](https://github.com/jatinkrmalik/vocamac/actions/workflows/ci.yml) [![License: AGPL-3.0](https://img.shields.io/badge/License-AGPL--3.0-blue.svg)](https://www.gnu.org/licenses/agpl-3.0) [![Platform: macOS](https://img.shields.io/badge/Platform-macOS%2013%2B-lightgrey.svg)](https://github.com/jatinkrmalik/vocamac) [![Swift 5.9+](https://img.shields.io/badge/Swift-5.9%2B-orange.svg)](https://swift.org) [![Website](https://img.shields.io/badge/Web-vocamac.com-007AFF.svg)](https://vocamac.com) [![GitHub stars](https://img.shields.io/github/stars/jatinkrmalik/vocamac?style=social)](https://github.com/jatinkrmalik/vocamac/stargazers)
+[![Build & Test](https://github.com/jatinkrmalik/vocamac/actions/workflows/ci.yml/badge.svg)](https://github.com/jatinkrmalik/vocamac/actions/workflows/ci.yml) [![License: AGPL-3.0](https://img.shields.io/badge/License-AGPL--3.0-blue.svg)](https://www.gnu.org/licenses/agpl-3.0) [![Platform: macOS](https://img.shields.io/badge/Platform-macOS%2013%2B-lightgrey.svg)](https://github.com/jatinkrmalik/vocamac) [![Swift 5.9+](https://img.shields.io/badge/Swift-5.9%2B-orange.svg)](https://swift.org) [![Website](https://img.shields.io/badge/Web-vocamac.com-blue.svg)](https://vocamac.com)Website](https://img.shields.io/badge/Web-vocamac.com-007AFF.svg)](https://vocamac.com) [![GitHub stars](https://img.shields.io/github/stars/jatinkrmalik/vocamac?style=social)](https://github.com/jatinkrmalik/vocamac/stargazers)
 
 
 **Local voice-to-text for macOS — powered by [WhisperKit](https://github.com/argmaxinc/WhisperKit)**
@@ -159,7 +159,6 @@ VocaMacApp (SwiftUI MenuBarExtra)
 ```
 
 For detailed documentation, see:
-- [`docs/PRD.md`](docs/PRD.md) — Product Requirements Document
 - [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md) — Technical Architecture
 - [`docs/DATA_MODEL.md`](docs/DATA_MODEL.md) — Data Model & Entity Relationships
 
@@ -189,6 +188,7 @@ VocaMac/
 │       │   ├── HotKeyManager.swift # CGEventTap global hotkeys
 │       │   ├── WhisperService.swift# WhisperKit transcription wrapper
 │       │   ├── ModelManager.swift  # Model download & management
+│       │   ├── SoundManager.swift  # Audio feedback for recording
 │       │   ├── TextInjector.swift  # Clipboard-based text injection
 │       │   └── SystemInfo.swift    # Hardware detection
 │       ├── Models/
@@ -198,8 +198,12 @@ VocaMac/
 │       └── Resources/
 ├── Tests/
 │   └── VocaMacTests/
+├── scripts/
+│   ├── build.sh                    # Build .app bundle
+│   ├── install.sh                  # Install to ~/.local/bin
+│   └── uninstall.sh                # Full uninstall & cleanup
+├── web/                            # Marketing website (vocamac.com)
 ├── docs/
-│   ├── PRD.md                      # Product Requirements Document
 │   ├── ARCHITECTURE.md             # Technical Architecture
 │   └── DATA_MODEL.md               # Data Model & ERD
 ├── LICENSE                         # AGPL-3.0 License
@@ -220,6 +224,26 @@ swift run VocaMac
 
 # Run tests (requires Xcode)
 swift test
+
+# Build .app bundle
+./scripts/build.sh
+
+# Install launcher scripts
+./scripts/install.sh
+```
+
+### Uninstall
+
+To completely remove VocaMac and all its data (downloaded models, preferences, caches):
+
+```bash
+./scripts/uninstall.sh
+```
+
+Use `--keep-build` to preserve build artifacts:
+
+```bash
+./scripts/uninstall.sh --keep-build
 ```
 
 ---
@@ -227,7 +251,7 @@ swift test
 ## 🗺️ Roadmap
 
 - [x] **v0.1.0** — MVP: Menu bar app, push-to-talk, double-tap toggle, WhisperKit integration, text injection, settings
-- [ ] **v0.2.0** — Onboarding flow, transcription history, audio feedback sounds
+- [ ] **v0.2.0** — Onboarding flow, transcription history, ~~audio feedback sounds~~ ✅
 - [ ] **v0.3.0** — Custom prompts, real-time streaming transcription, word-level timestamps
 - [ ] **v0.4.0** — Auto-updates via Sparkle, code signing, DMG distribution
 - [ ] **v1.0.0** — Homebrew Cask, polished UI, performance tuning
@@ -256,6 +280,14 @@ Each platform uses native technologies for the best possible integration, while 
 
 ---
 
+## ⚠️ Known Limitations
+
+- **Ad-hoc code signing** — VocaMac uses ad-hoc signing for development builds. Accessibility and Input Monitoring permissions in System Settings → Privacy & Security will reset on every rebuild. You'll need to re-grant them after each build.
+- **First launch requires internet** — WhisperKit downloads the speech recognition model on first run. All subsequent launches work fully offline.
+- **macOS only** — VocaMac requires macOS 13 (Ventura) or later.
+
+---
+
 ## 📄 License
 
 AGPL-3.0 License — see [LICENSE](LICENSE) for details.
@@ -264,4 +296,4 @@ AGPL-3.0 License — see [LICENSE](LICENSE) for details.
 
 ## 👨‍💻 Author
 
-**Jatin Kumar Malik** · [GitHub](https://github.com/jatinkrmalik) · [vocamac.com](https://vocamac.com)
+**Jatin Kumar Malik** · [GitHub](https://github.com/jatinkrmalik) · [𝕏](https://x.com/intent/user?screen_name=jatinkrmalik) · [vocamac.com](https://vocamac.com)

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![Build & Test](https://github.com/jatinkrmalik/vocamac/actions/workflows/ci.yml/badge.svg)](https://github.com/jatinkrmalik/vocamac/actions/workflows/ci.yml) [![License: AGPL-3.0](https://img.shields.io/badge/License-AGPL--3.0-blue.svg)](https://www.gnu.org/licenses/agpl-3.0) [![Platform: macOS](https://img.shields.io/badge/Platform-macOS%2013%2B-lightgrey.svg)](https://github.com/jatinkrmalik/vocamac) [![Swift 5.9+](https://img.shields.io/badge/Swift-5.9%2B-orange.svg)](https://swift.org) [![Website](https://img.shields.io/badge/Web-vocamac.com-blue.svg)](https://vocamac.com)Website](https://img.shields.io/badge/Web-vocamac.com-007AFF.svg)](https://vocamac.com) [![GitHub stars](https://img.shields.io/github/stars/jatinkrmalik/vocamac?style=social)](https://github.com/jatinkrmalik/vocamac/stargazers)
 
 
-**Local voice-to-text for macOS — powered by [WhisperKit](https://github.com/argmaxinc/WhisperKit)**
+**Local voice-to-text for macOS  -  powered by [WhisperKit](https://github.com/argmaxinc/WhisperKit)**
 
 VocaMac is a native macOS menu bar application that transcribes your voice to text locally on your machine. No cloud, no subscriptions, no data leaves your device. Just hold a hotkey, speak, and your words appear wherever your cursor is.
 
@@ -17,14 +17,14 @@ VocaMac is a native macOS menu bar application that transcribes your voice to te
 
 ## ✨ Features
 
-- **🔒 100% Local** — All audio processing happens on your machine. No internet required (except for one-time model downloads).
-- **⌨️ System-Wide Text Injection** — Transcribed text is typed wherever your cursor is: browsers, Slack, VS Code, spreadsheets, terminals — everywhere.
-- **🎯 Push-to-Talk** — Hold a hotkey (default: Right Option) to record. Release to transcribe.
-- **👆 Double-Tap Toggle** — Double-tap the hotkey to start/stop recording.
-- **🧠 Smart Model Selection** — Auto-detects your hardware (Apple Silicon/Intel, RAM) and recommends the best whisper model via WhisperKit.
-- **⚡ Native Apple Acceleration** — CoreML + Metal + Neural Engine acceleration on Apple Silicon. No manual setup.
-- **📊 Visual Feedback** — Menu bar icon changes color during recording and processing. Audio level indicator shows input.
-- **⚙️ Configurable** — Choose hotkeys, models, languages, silence detection thresholds, and more.
+- **🔒 100% Local**  -  All audio processing happens on your machine. No internet required (except for one-time model downloads).
+- **⌨️ System-Wide Text Injection**  -  Transcribed text is typed wherever your cursor is: browsers, Slack, VS Code, spreadsheets, terminals  -  everywhere.
+- **🎯 Push-to-Talk**  -  Hold a hotkey (default: Right Option) to record. Release to transcribe.
+- **👆 Double-Tap Toggle**  -  Double-tap the hotkey to start/stop recording.
+- **🧠 Smart Model Selection**  -  Auto-detects your hardware (Apple Silicon/Intel, RAM) and recommends the best whisper model via WhisperKit.
+- **⚡ Native Apple Acceleration**  -  CoreML + Metal + Neural Engine acceleration on Apple Silicon. No manual setup.
+- **📊 Visual Feedback**  -  Menu bar icon changes color during recording and processing. Audio level indicator shows input.
+- **⚙️ Configurable**  -  Choose hotkeys, models, languages, silence detection thresholds, and more.
 
 ---
 
@@ -50,8 +50,8 @@ Same accuracy, dramatically better Apple platform integration.
 
 - **macOS 13 (Ventura)** or later
 - **Xcode 15+** or Swift 5.9+ (for building)
-- **Microphone permission** — For audio capture
-- **Accessibility permission** — For global hotkeys and text injection
+- **Microphone permission**  -  For audio capture
+- **Accessibility permission**  -  For global hotkeys and text injection
 
 ---
 
@@ -64,7 +64,7 @@ Same accuracy, dramatically better Apple platform integration.
 git clone https://github.com/jatinkrmalik/vocamac.git
 cd vocamac
 
-# Build (first build downloads WhisperKit dependency — ~1 min)
+# Build (first build downloads WhisperKit dependency  -  ~1 min)
 swift build -c release
 
 # Run VocaMac
@@ -75,9 +75,9 @@ swift run -c release VocaMac
 
 1. **VocaMac appears in your menu bar** (microphone icon, no Dock icon)
 2. **Grant Microphone permission** when prompted
-3. **Grant Accessibility permission** — VocaMac will guide you to System Settings → Privacy & Security → Accessibility
-4. **First model download** — WhisperKit automatically downloads the recommended model for your device (~40-500MB depending on hardware)
-5. **Start dictating** — Hold the **Right Option** key, speak, and release. Your words appear at the cursor!
+3. **Grant Accessibility permission**  -  VocaMac will guide you to System Settings → Privacy & Security → Accessibility
+4. **First model download**  -  WhisperKit automatically downloads the recommended model for your device (~40-500MB depending on hardware)
+5. **Start dictating**  -  Hold the **Right Option** key, speak, and release. Your words appear at the cursor!
 
 ---
 
@@ -124,15 +124,15 @@ Models are downloaded automatically from [HuggingFace](https://huggingface.co/ar
 Open Settings from the menu bar popover or with **⌘,**
 
 ### General
-- **Activation mode** — Push-to-Talk or Double-Tap Toggle
-- **Hotkey** — Choose from Right Option, Right Command, Fn, function keys, etc.
-- **Language** — Auto-detect or specify (English, Spanish, French, German, Chinese, Japanese, and more)
+- **Activation mode**  -  Push-to-Talk or Double-Tap Toggle
+- **Hotkey**  -  Choose from Right Option, Right Command, Fn, function keys, etc.
+- **Language**  -  Auto-detect or specify (English, Spanish, French, German, Chinese, Japanese, and more)
 - **Launch at login**
 
 ### Audio
-- **Max recording duration** — 30s, 60s, 120s, or 300s
-- **Silence detection** — Auto-stop recording after configurable silence
-- **Input device** — Select which microphone to use
+- **Max recording duration**  -  30s, 60s, 120s, or 300s
+- **Silence detection**  -  Auto-stop recording after configurable silence
+- **Input device**  -  Select which microphone to use
 
 ### Models
 - View system info and WhisperKit's hardware recommendation
@@ -147,20 +147,20 @@ VocaMac is built with a clean, modular architecture using native Swift and Swift
 
 ```
 VocaMacApp (SwiftUI MenuBarExtra)
-├── AppState          — Central observable state
-├── HotKeyManager     — CGEventTap global hotkey listener
-├── AudioEngine       — AVAudioEngine mic capture (16kHz, mono, Float32)
-├── WhisperService    — WhisperKit async transcription wrapper
-│   └── ModelManager  — Model download, storage, device recommendations
-│       └── SystemInfo — Hardware detection & model recommendation
-├── TextInjector      — Clipboard + Cmd+V text injection
-├── MenuBarView       — Status popover UI
-└── SettingsView      — Configuration tabs (General, Models, Audio, About)
+├── AppState           -  Central observable state
+├── HotKeyManager      -  CGEventTap global hotkey listener
+├── AudioEngine        -  AVAudioEngine mic capture (16kHz, mono, Float32)
+├── WhisperService     -  WhisperKit async transcription wrapper
+│   └── ModelManager   -  Model download, storage, device recommendations
+│       └── SystemInfo  -  Hardware detection & model recommendation
+├── TextInjector       -  Clipboard + Cmd+V text injection
+├── MenuBarView        -  Status popover UI
+└── SettingsView       -  Configuration tabs (General, Models, Audio, About)
 ```
 
 For detailed documentation, see:
-- [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md) — Technical Architecture
-- [`docs/DATA_MODEL.md`](docs/DATA_MODEL.md) — Data Model & Entity Relationships
+- [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md)  -  Technical Architecture
+- [`docs/DATA_MODEL.md`](docs/DATA_MODEL.md)  -  Data Model & Entity Relationships
 
 ---
 
@@ -216,7 +216,7 @@ VocaMac/
 # Debug build
 swift build
 
-# Release build (optimized — recommended for actual use)
+# Release build (optimized  -  recommended for actual use)
 swift build -c release
 
 # Run
@@ -250,11 +250,11 @@ Use `--keep-build` to preserve build artifacts:
 
 ## 🗺️ Roadmap
 
-- [x] **v0.1.0** — MVP: Menu bar app, push-to-talk, double-tap toggle, WhisperKit integration, text injection, settings
-- [ ] **v0.2.0** — Onboarding flow, transcription history, ~~audio feedback sounds~~ ✅
-- [ ] **v0.3.0** — Custom prompts, real-time streaming transcription, word-level timestamps
-- [ ] **v0.4.0** — Auto-updates via Sparkle, code signing, DMG distribution
-- [ ] **v1.0.0** — Homebrew Cask, polished UI, performance tuning
+- [x] **v0.1.0**  -  MVP: Menu bar app, push-to-talk, double-tap toggle, WhisperKit integration, text injection, settings
+- [ ] **v0.2.0**  -  Onboarding flow, transcription history, ~~audio feedback sounds~~ ✅
+- [ ] **v0.3.0**  -  Custom prompts, real-time streaming transcription, word-level timestamps
+- [ ] **v0.4.0**  -  Auto-updates via Sparkle, code signing, DMG distribution
+- [ ] **v1.0.0**  -  Homebrew Cask, polished UI, performance tuning
 
 ---
 
@@ -274,23 +274,23 @@ Each platform uses native technologies for the best possible integration, while 
 
 ## 🤝 Related Projects
 
-- [WhisperKit](https://github.com/argmaxinc/WhisperKit) — Swift native on-device speech recognition
-- [VocaLinux](https://github.com/jatinkrmalik/vocalinux) — Voice-to-text for Linux
-- [OpenAI Whisper](https://github.com/openai/whisper) — Original Whisper model
+- [WhisperKit](https://github.com/argmaxinc/WhisperKit)  -  Swift native on-device speech recognition
+- [VocaLinux](https://github.com/jatinkrmalik/vocalinux)  -  Voice-to-text for Linux
+- [OpenAI Whisper](https://github.com/openai/whisper)  -  Original Whisper model
 
 ---
 
 ## ⚠️ Known Limitations
 
-- **Ad-hoc code signing** — VocaMac uses ad-hoc signing for development builds. Accessibility and Input Monitoring permissions in System Settings → Privacy & Security will reset on every rebuild. You'll need to re-grant them after each build.
-- **First launch requires internet** — WhisperKit downloads the speech recognition model on first run. All subsequent launches work fully offline.
-- **macOS only** — VocaMac requires macOS 13 (Ventura) or later.
+- **Ad-hoc code signing**  -  VocaMac uses ad-hoc signing for development builds. Accessibility and Input Monitoring permissions in System Settings → Privacy & Security will reset on every rebuild. You'll need to re-grant them after each build.
+- **First launch requires internet**  -  WhisperKit downloads the speech recognition model on first run. All subsequent launches work fully offline.
+- **macOS only**  -  VocaMac requires macOS 13 (Ventura) or later.
 
 ---
 
 ## 📄 License
 
-AGPL-3.0 License — see [LICENSE](LICENSE) for details.
+AGPL-3.0 License  -  see [LICENSE](LICENSE) for details.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -4,27 +4,27 @@
 
 <h1 align="center">VocaMac</h1>
 
-[![Build & Test](https://github.com/jatinkrmalik/vocamac/actions/workflows/ci.yml/badge.svg)](https://github.com/jatinkrmalik/vocamac/actions/workflows/ci.yml) [![License: AGPL-3.0](https://img.shields.io/badge/License-AGPL--3.0-blue.svg)](https://www.gnu.org/licenses/agpl-3.0) [![Platform: macOS](https://img.shields.io/badge/Platform-macOS%2013%2B-lightgrey.svg)](https://github.com/jatinkrmalik/vocamac) [![Swift 5.9+](https://img.shields.io/badge/Swift-5.9%2B-orange.svg)](https://swift.org) [![Website](https://img.shields.io/badge/Web-vocamac.com-blue.svg)](https://vocamac.com)Website](https://img.shields.io/badge/Web-vocamac.com-007AFF.svg)](https://vocamac.com) [![GitHub stars](https://img.shields.io/github/stars/jatinkrmalik/vocamac?style=social)](https://github.com/jatinkrmalik/vocamac/stargazers)
+[![Build & Test](https://github.com/jatinkrmalik/vocamac/actions/workflows/ci.yml/badge.svg)](https://github.com/jatinkrmalik/vocamac/actions/workflows/ci.yml) [![License: AGPL-3.0](https://img.shields.io/badge/License-AGPL--3.0-blue.svg)](https://www.gnu.org/licenses/agpl-3.0) [![Platform: macOS](https://img.shields.io/badge/Platform-macOS%2013%2B-lightgrey.svg)](https://github.com/jatinkrmalik/vocamac) [![Swift 5.9+](https://img.shields.io/badge/Swift-5.9%2B-orange.svg)](https://swift.org)
 
 
-**Local voice-to-text for macOS  -  powered by [WhisperKit](https://github.com/argmaxinc/WhisperKit)**
+**Local voice-to-text for macOS - powered by [WhisperKit](https://github.com/argmaxinc/WhisperKit)**
 
 VocaMac is a native macOS menu bar application that transcribes your voice to text locally on your machine. No cloud, no subscriptions, no data leaves your device. Just hold a hotkey, speak, and your words appear wherever your cursor is.
 
-🌐 [vocamac.com](https://vocamac.com) · 🐧 [VocaLinux](https://github.com/jatinkrmalik/vocalinux) · 🪟 VocaWin *(coming soon)*
+ [VocaLinux](https://github.com/jatinkrmalik/vocalinux) ·  **VocaMac** · 🪟 VocaWin *(coming soon)* · 🌐 [vocamac.com](https://vocamac.com)
 
 ---
 
 ## ✨ Features
 
-- **🔒 100% Local**  -  All audio processing happens on your machine. No internet required (except for one-time model downloads).
-- **⌨️ System-Wide Text Injection**  -  Transcribed text is typed wherever your cursor is: browsers, Slack, VS Code, spreadsheets, terminals  -  everywhere.
-- **🎯 Push-to-Talk**  -  Hold a hotkey (default: Right Option) to record. Release to transcribe.
-- **👆 Double-Tap Toggle**  -  Double-tap the hotkey to start/stop recording.
-- **🧠 Smart Model Selection**  -  Auto-detects your hardware (Apple Silicon/Intel, RAM) and recommends the best whisper model via WhisperKit.
-- **⚡ Native Apple Acceleration**  -  CoreML + Metal + Neural Engine acceleration on Apple Silicon. No manual setup.
-- **📊 Visual Feedback**  -  Menu bar icon changes color during recording and processing. Audio level indicator shows input.
-- **⚙️ Configurable**  -  Choose hotkeys, models, languages, silence detection thresholds, and more.
+- **🔒 100% Local** - All audio processing happens on your machine. No internet required (except for one-time model downloads).
+- **⌨️ System-Wide Text Injection** - Transcribed text is typed wherever your cursor is: browsers, Slack, VS Code, spreadsheets, terminals - everywhere.
+- **🎯 Push-to-Talk** - Hold a hotkey (default: Right Option) to record. Release to transcribe.
+- **👆 Double-Tap Toggle** - Double-tap the hotkey to start/stop recording.
+- **🧠 Smart Model Selection** - Auto-detects your hardware (Apple Silicon/Intel, RAM) and recommends the best whisper model via WhisperKit.
+- **⚡ Native Apple Acceleration** - CoreML + Metal + Neural Engine acceleration on Apple Silicon. No manual setup.
+- **📊 Visual Feedback** - Menu bar icon changes color during recording and processing. Audio level indicator shows input.
+- **⚙️ Configurable** - Choose hotkeys, models, languages, silence detection thresholds, and more.
 
 ---
 
@@ -50,8 +50,8 @@ Same accuracy, dramatically better Apple platform integration.
 
 - **macOS 13 (Ventura)** or later
 - **Xcode 15+** or Swift 5.9+ (for building)
-- **Microphone permission**  -  For audio capture
-- **Accessibility permission**  -  For global hotkeys and text injection
+- **Microphone permission** - For audio capture
+- **Accessibility permission** - For global hotkeys and text injection
 
 ---
 
@@ -64,7 +64,7 @@ Same accuracy, dramatically better Apple platform integration.
 git clone https://github.com/jatinkrmalik/vocamac.git
 cd vocamac
 
-# Build (first build downloads WhisperKit dependency  -  ~1 min)
+# Build (first build downloads WhisperKit dependency - ~1 min)
 swift build -c release
 
 # Run VocaMac
@@ -75,9 +75,9 @@ swift run -c release VocaMac
 
 1. **VocaMac appears in your menu bar** (microphone icon, no Dock icon)
 2. **Grant Microphone permission** when prompted
-3. **Grant Accessibility permission**  -  VocaMac will guide you to System Settings → Privacy & Security → Accessibility
-4. **First model download**  -  WhisperKit automatically downloads the recommended model for your device (~40-500MB depending on hardware)
-5. **Start dictating**  -  Hold the **Right Option** key, speak, and release. Your words appear at the cursor!
+3. **Grant Accessibility permission** - VocaMac will guide you to System Settings → Privacy & Security → Accessibility
+4. **First model download** - WhisperKit automatically downloads the recommended model for your device (~40-500MB depending on hardware)
+5. **Start dictating** - Hold the **Right Option** key, speak, and release. Your words appear at the cursor!
 
 ---
 
@@ -124,15 +124,16 @@ Models are downloaded automatically from [HuggingFace](https://huggingface.co/ar
 Open Settings from the menu bar popover or with **⌘,**
 
 ### General
-- **Activation mode**  -  Push-to-Talk or Double-Tap Toggle
-- **Hotkey**  -  Choose from Right Option, Right Command, Fn, function keys, etc.
-- **Language**  -  Auto-detect or specify (English, Spanish, French, German, Chinese, Japanese, and more)
+- **Activation mode** - Push-to-Talk or Double-Tap Toggle
+- **Hotkey** - Choose from Right Option, Right Command, Fn, function keys, etc.
+- **Language** - Auto-detect or specify (English, Spanish, French, German, Chinese, Japanese, and more)
 - **Launch at login**
 
 ### Audio
-- **Max recording duration**  -  30s, 60s, 120s, or 300s
-- **Silence detection**  -  Auto-stop recording after configurable silence
-- **Input device**  -  Select which microphone to use
+- **Max recording duration** - 30s, 60s, 120s, or 300s
+- **Silence detection** - Auto-stop recording after configurable silence
+- **Sound effects** - Toggle audio feedback for recording start/stop
+- **Input device** - Select which microphone to use
 
 ### Models
 - View system info and WhisperKit's hardware recommendation
@@ -147,20 +148,21 @@ VocaMac is built with a clean, modular architecture using native Swift and Swift
 
 ```
 VocaMacApp (SwiftUI MenuBarExtra)
-├── AppState           -  Central observable state
-├── HotKeyManager      -  CGEventTap global hotkey listener
-├── AudioEngine        -  AVAudioEngine mic capture (16kHz, mono, Float32)
-├── WhisperService     -  WhisperKit async transcription wrapper
-│   └── ModelManager   -  Model download, storage, device recommendations
-│       └── SystemInfo  -  Hardware detection & model recommendation
-├── TextInjector       -  Clipboard + Cmd+V text injection
-├── MenuBarView        -  Status popover UI
-└── SettingsView       -  Configuration tabs (General, Models, Audio, About)
+├── AppState          - Central observable state
+├── HotKeyManager     - CGEventTap global hotkey listener
+├── AudioEngine       - AVAudioEngine mic capture (16kHz, mono, Float32)
+├── WhisperService    - WhisperKit async transcription wrapper
+│   └── ModelManager  - Model download, storage, device recommendations
+│       └── SystemInfo - Hardware detection & model recommendation
+├── SoundManager      - Audio feedback (start/stop recording cues)
+├── TextInjector      - Clipboard + Cmd+V text injection
+├── MenuBarView       - Status popover UI
+└── SettingsView      - Configuration tabs (General, Models, Audio, About)
 ```
 
 For detailed documentation, see:
-- [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md)  -  Technical Architecture
-- [`docs/DATA_MODEL.md`](docs/DATA_MODEL.md)  -  Data Model & Entity Relationships
+- [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md) - Technical Architecture
+- [`docs/DATA_MODEL.md`](docs/DATA_MODEL.md) - Data Model & Entity Relationships
 
 ---
 
@@ -205,7 +207,7 @@ VocaMac/
 ├── web/                            # Marketing website (vocamac.com)
 ├── docs/
 │   ├── ARCHITECTURE.md             # Technical Architecture
-│   └── DATA_MODEL.md               # Data Model & ERD
+│   └── DATA_MODEL.md               # Data Model & Entity Relationships
 ├── LICENSE                         # AGPL-3.0 License
 └── .gitignore
 ```
@@ -216,7 +218,7 @@ VocaMac/
 # Debug build
 swift build
 
-# Release build (optimized  -  recommended for actual use)
+# Release build (optimized)
 swift build -c release
 
 # Run
@@ -228,7 +230,7 @@ swift test
 # Build .app bundle
 ./scripts/build.sh
 
-# Install launcher scripts
+# Install launcher scripts to ~/.local/bin
 ./scripts/install.sh
 ```
 
@@ -248,15 +250,6 @@ Use `--keep-build` to preserve build artifacts:
 
 ---
 
-## 🗺️ Roadmap
-
-- [x] **v0.1.0**  -  MVP: Menu bar app, push-to-talk, double-tap toggle, WhisperKit integration, text injection, settings
-- [ ] **v0.2.0**  -  Onboarding flow, transcription history, ~~audio feedback sounds~~ ✅
-- [ ] **v0.3.0**  -  Custom prompts, real-time streaming transcription, word-level timestamps
-- [ ] **v0.4.0**  -  Auto-updates via Sparkle, code signing, DMG distribution
-- [ ] **v1.0.0**  -  Homebrew Cask, polished UI, performance tuning
-
----
 
 ## 🌐 Cross-Platform
 
@@ -264,9 +257,9 @@ VocaMac is the macOS member of the Voca family:
 
 | Platform | Project | Status |
 |----------|---------|--------|
-| 🐧 Linux | [VocaLinux](https://github.com/jatinkrmalik/vocalinux) | ✅ Available |
-| 🍎 macOS | **VocaMac** (this project) | 🚧 MVP |
-| 🪟 Windows | VocaWin ([vocawin.com](https://vocawin.com)) | 📋 Planned |
+|  Linux | [VocaLinux](https://github.com/jatinkrmalik/vocalinux) | ✅ Available |
+|  macOS | [VocaMac](https://github.com/jatinkrmalik/vocamac) | 🚧 Alpha |
+| 🪟 Windows | [VocaWin](https://vocawin.com) | 📋 Planned |
 
 Each platform uses native technologies for the best possible integration, while sharing the same UX patterns and Whisper model family.
 
@@ -274,26 +267,24 @@ Each platform uses native technologies for the best possible integration, while 
 
 ## 🤝 Related Projects
 
-- [WhisperKit](https://github.com/argmaxinc/WhisperKit)  -  Swift native on-device speech recognition
-- [VocaLinux](https://github.com/jatinkrmalik/vocalinux)  -  Voice-to-text for Linux
-- [OpenAI Whisper](https://github.com/openai/whisper)  -  Original Whisper model
+- [WhisperKit](https://github.com/argmaxinc/WhisperKit) - Swift native on-device speech recognition
+- [VocaLinux](https://github.com/jatinkrmalik/vocalinux) - Voice-to-text for Linux
+- [OpenAI Whisper](https://github.com/openai/whisper) - Original Whisper model
 
 ---
 
 ## ⚠️ Known Limitations
 
-- **Ad-hoc code signing**  -  VocaMac uses ad-hoc signing for development builds. Accessibility and Input Monitoring permissions in System Settings → Privacy & Security will reset on every rebuild. You'll need to re-grant them after each build.
-- **First launch requires internet**  -  WhisperKit downloads the speech recognition model on first run. All subsequent launches work fully offline.
-- **macOS only**  -  VocaMac requires macOS 13 (Ventura) or later.
+- **Ad-hoc code signing** - Accessibility and Input Monitoring permissions reset on every rebuild. Re-grant them after each build.
+- **First launch requires internet** - WhisperKit downloads the speech recognition model on first run. All subsequent launches work fully offline.
+- **macOS only** - Requires macOS 13 (Ventura) or later.
 
 ---
 
 ## 📄 License
 
-AGPL-3.0 License  -  see [LICENSE](LICENSE) for details.
+AGPL-3.0 License - see [LICENSE](LICENSE) for details.
 
 ---
 
-## 👨‍💻 Author
-
-**Jatin Kumar Malik** · [GitHub](https://github.com/jatinkrmalik) · [𝕏](https://x.com/intent/user?screen_name=jatinkrmalik) · [vocamac.com](https://vocamac.com)
+Made with ❤️ for the macOS community!

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,4 +1,4 @@
-# VocaMac — Technical Architecture Document
+# VocaMac - Technical Architecture Document
 
 **Version:** 1.0
 **Date:** 2026-03-04
@@ -48,7 +48,7 @@ VocaMac is a native macOS menu bar application built with Swift and SwiftUI. It 
 │  ┌──────────────────────────────────────────────────────┐    │
 │  │                   SwiftUI Layer                       │    │
 │  │  ┌──────────────┐  ┌────────────┐  ┌──────────────┐ │    │
-│  │  │ MenuBarView  │  │SettingsView│  │SettingsView│ │    │
+│  │  │ MenuBarView  │  │SettingsView│                  │    │
 │  │  └──────────────┘  └────────────┘  └──────────────┘ │    │
 │  └──────────────────────────────────────────────────────┘    │
 └──────────────────────────────────────────────────────────────┘
@@ -68,7 +68,7 @@ VocaMac is a native macOS menu bar application built with Swift and SwiftUI. It 
 | STT Engine | WhisperKit | 0.9.4+ | CoreML-based on-device speech-to-text |
 | Acceleration | Metal | macOS 13+ | GPU-accelerated inference on Apple Silicon |
 | Build | Swift Package Manager | 5.9+ | Dependency management and build |
-| Min OS | macOS 13 Ventura | — | Minimum supported macOS version |
+| Min OS | macOS 13 Ventura | - | Minimum supported macOS version |
 
 ---
 
@@ -85,6 +85,7 @@ VocaMacApp (entry point)
     │     │     └── ModelManager
     │     │           └── SystemInfo
     │     └── TextInjector
+    │     └── SoundManager
     ├── MenuBarView
     ├── SettingsView
     └── SettingsView
@@ -92,7 +93,7 @@ VocaMacApp (entry point)
 
 ### 3.2 Module Specifications
 
-#### 3.2.1 `VocaMacApp` — Application Entry Point
+#### 3.2.1 `VocaMacApp` - Application Entry Point
 
 **Responsibility:** Bootstrap the app, configure as menu bar-only (no Dock icon), initialize all services.
 
@@ -112,7 +113,7 @@ App Launch
   → App is ready
 ```
 
-#### 3.2.2 `AppState` — Central State Management
+#### 3.2.2 `AppState` - Central State Management
 
 **Responsibility:** Single source of truth for all app state. Observable object that drives reactive UI updates.
 
@@ -143,7 +144,7 @@ HotKey Triggered (stop)
   → Set appStatus = .idle
 ```
 
-#### 3.2.3 `HotKeyManager` — Global Hotkey Listener
+#### 3.2.3 `HotKeyManager` - Global Hotkey Listener
 
 **Responsibility:** Listen for system-wide key events to trigger recording start/stop.
 
@@ -177,7 +178,7 @@ On keyUp:
 
 **Required Permission:** Accessibility (System Settings → Privacy & Security → Accessibility)
 
-#### 3.2.4 `AudioEngine` — Microphone Capture
+#### 3.2.4 `AudioEngine` - Microphone Capture
 
 **Responsibility:** Capture audio from the microphone in the format required by WhisperKit.
 
@@ -205,7 +206,7 @@ Microphone → AVAudioInputNode → Format Converter → Buffer Accumulator
 - Report to AppState on each buffer for UI visualization
 - Throttle updates to ~15 Hz to avoid excessive UI refreshes
 
-#### 3.2.5 `WhisperService` — Speech-to-Text Engine
+#### 3.2.5 `WhisperService` - Speech-to-Text Engine
 
 **Responsibility:** Load WhisperKit models and perform transcription.
 
@@ -244,7 +245,7 @@ audioData: [Float]
 - Compile flag: `WHISPER_METAL=1` or `CoreML_METAL=1`
 - Falls back to CPU on Intel Macs
 
-#### 3.2.6 `ModelManager` — Model Lifecycle Management
+#### 3.2.6 `ModelManager` - Model Lifecycle Management
 
 **Responsibility:** Discover, download, verify, and manage whisper model files.
 
@@ -277,7 +278,7 @@ audioData: [Float]
 4. Verify SHA256 checksum after download
 5. Move to models directory on success
 
-#### 3.2.7 `SystemInfo` — Hardware Detection
+#### 3.2.7 `SystemInfo` - Hardware Detection
 
 **Responsibility:** Detect system hardware capabilities and recommend optimal model size.
 
@@ -300,7 +301,7 @@ Intel:
   RAM ≥ 32 GB → small
 ```
 
-#### 3.2.8 `TextInjector` — System-Wide Text Insertion
+#### 3.2.8 `TextInjector` - System-Wide Text Insertion
 
 **Responsibility:** Insert transcribed text at the cursor position in any application.
 
@@ -406,8 +407,8 @@ Main Thread (Text Injection)
 ```
 
 **Key Threading Rules:**
-1. Audio capture callbacks run on AVAudioEngine's internal thread — keep work minimal
-2. Transcription runs via `Task { }` on a background executor — never block the main thread
+1. Audio capture callbacks run on AVAudioEngine's internal thread - keep work minimal
+2. Transcription runs via `Task { }` on a background executor - never block the main thread
 3. UI updates via `@MainActor` or `DispatchQueue.main`
 4. CGEvent posting should happen from the main thread
 5. Model loading/downloading uses async/await on background threads
@@ -427,7 +428,7 @@ let options = [kAXTrustedCheckOptionPrompt.takeRetainedValue(): true] as CFDicti
 let isTrusted = AXIsProcessTrustedWithOptions(options)
 ```
 
-Note: Unlike microphone access, Accessibility permission cannot be granted via a system dialog — the user must manually add the app in System Settings. The app should provide clear instructions.
+Note: Unlike microphone access, Accessibility permission cannot be granted via a system dialog - the user must manually add the app in System Settings. The app should provide clear instructions.
 
 ---
 
@@ -441,7 +442,7 @@ Package.swift
   ├── Products: VocaMac executable
   ├── Dependencies: WhisperKit (vendored or submodule)
   ├── Swift settings: -O (optimized for release)
-  └── C settings: -DCoreML_METAL=1 (Metal acceleration)
+  └── Platforms: .macOS(.v13)
 ```
 
 ### 7.2 Build Commands
@@ -457,14 +458,14 @@ swift build -c release
 swift run VocaMac
 
 # Create app bundle (requires additional scripting)
-./scripts/bundle.sh
+./scripts/build.sh
 ```
 
 ### 7.3 Distribution Strategy (MVP)
 
-1. **GitHub Releases** — DMG or ZIP containing the .app bundle
-2. **Homebrew Cask** — `brew install --cask vocamac` (post-MVP)
-3. **Mac App Store** — Future consideration (requires sandbox compliance)
+1. **GitHub Releases** - DMG or ZIP containing the .app bundle
+2. **Homebrew Cask** - `brew install --cask vocamac` (post-MVP)
+3. **Mac App Store** - Future consideration (requires sandbox compliance)
 
 ---
 
@@ -475,9 +476,9 @@ swift run VocaMac
 While VocaMac is a native macOS app, the architecture is designed to facilitate a future Windows port (VocaWin):
 
 ```
-Shared (C/C++):
-  └── WhisperKit           ← Already cross-platform
-  └── Model format (CoreML)   ← Already cross-platform
+Shared Concepts:
+  └── Whisper models        ← Same model family across platforms
+  └── UX patterns           ← Same user interaction design
 
 Platform-Specific:
   ┌──────────────────────┬──────────────────────┐
@@ -494,10 +495,10 @@ Platform-Specific:
 
 ### 8.2 What Can Be Shared
 
-- **WhisperKit** — The core engine is already cross-platform
-- **Model files** — CoreML model format works on all platforms
-- **Model catalog** — Same download URLs, checksums, metadata
-- **UX patterns** — Same user flows and interaction design
+- **Whisper models** - Same OpenAI Whisper model family on all platforms
+- **Model files** - Each platform uses its optimal format (CoreML on macOS, GGML on Linux/Windows)
+- **Model catalog** - Same model variants and metadata
+- **UX patterns** - Same user flows and interaction design
 
 ### 8.3 What Must Be Platform-Specific
 
@@ -519,7 +520,7 @@ Platform-Specific:
 | Model file corrupted/missing | Re-download model, fall back to bundled tiny |
 | Audio device disconnected | Detect and notify user, pause recording |
 | Transcription fails | Show error in menu bar popover, log details |
-| Clipboard restore fails | Log warning, don't crash — clipboard is transient |
+| Clipboard restore fails | Log warning, don't crash - clipboard is transient |
 | Out of memory during transcription | Suggest a smaller model, show clear error |
 | Network error during model download | Retry with exponential backoff, allow manual retry |
 
@@ -528,9 +529,9 @@ Platform-Specific:
 ## 10. Security Considerations
 
 1. **No network communication** except model downloads from Hugging Face
-2. **No telemetry or analytics** — fully offline operation
-3. **Audio data never leaves the device** — processed entirely in-memory
-4. **No persistent audio storage** — audio buffers are discarded after transcription
-5. **Model files verified by checksum** — prevent tampering
-6. **Code signing** — App should be signed with a Developer ID certificate
-7. **Hardened runtime** — Enable for Gatekeeper compatibility
+2. **No telemetry or analytics** - fully offline operation
+3. **Audio data never leaves the device** - processed entirely in-memory
+4. **No persistent audio storage** - audio buffers are discarded after transcription
+5. **Model files verified by checksum** - prevent tampering
+6. **Code signing** - App should be signed with a Developer ID certificate
+7. **Hardened runtime** - Enable for Gatekeeper compatibility

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -1,0 +1,154 @@
+# VocaMac Release Process
+
+## Overview
+
+VocaMac uses GitHub Actions for CI/CD. Releases are triggered by pushing a version tag (e.g., `v0.1.0`). The release workflow builds the app, creates a DMG and ZIP archive, generates checksums, and publishes a draft GitHub Release.
+
+## Versioning
+
+We follow [Semantic Versioning](https://semver.org/):
+
+```
+vMAJOR.MINOR.PATCH
+```
+
+- **MAJOR** - Breaking changes or significant redesigns
+- **MINOR** - New features, backward compatible
+- **PATCH** - Bug fixes, minor improvements
+
+Pre-release versions use suffixes: `v0.1.0-alpha`, `v0.1.0-beta.1`
+
+## Release Checklist
+
+### Before Tagging
+
+1. **Ensure all PRs are merged** into `main`
+2. **Verify CI passes** on the latest `main` commit
+3. **Update version number** in `scripts/build.sh` (both `CFBundleVersion` and `CFBundleShortVersionString`)
+4. **Test locally**:
+   ```bash
+   ./scripts/build.sh release
+   open VocaMac.app
+   ```
+5. **Verify core functionality**:
+   - App appears in menu bar
+   - Push-to-talk recording works
+   - Transcription produces correct text
+   - Text injection works at cursor
+   - Settings dialog opens and all tabs function
+   - Model download and switching works
+   - Sound effects play on start/stop
+6. **Review README** for accuracy
+
+### Creating a Release
+
+1. **Tag the release**:
+   ```bash
+   git tag -a v0.1.0 -m "VocaMac v0.1.0 - Alpha Release"
+   git push origin v0.1.0
+   ```
+
+2. **GitHub Actions automatically**:
+   - Builds the release binary
+   - Creates `VocaMac.app` bundle with ad-hoc signing
+   - Packages as DMG (`VocaMac-0.1.0-arm64.dmg`)
+   - Packages as ZIP (`VocaMac-0.1.0-arm64.zip`)
+   - Generates SHA-256 checksums
+   - Creates a **draft** GitHub Release with all artifacts
+
+3. **Review the draft release** at https://github.com/jatinkrmalik/vocamac/releases
+   - Edit release notes if needed
+   - Verify artifacts are attached
+   - **Publish** the release when ready
+
+4. **Website auto-deploys** when the release is published (via `deploy-website.yml`)
+
+## Release Artifacts
+
+Each release produces:
+
+| Artifact | Description |
+|----------|-------------|
+| `VocaMac-X.Y.Z-arm64.dmg` | DMG disk image with drag-to-Applications installer |
+| `VocaMac-X.Y.Z-arm64.zip` | ZIP archive of VocaMac.app |
+| `checksums.txt` | SHA-256 checksums for verification |
+
+## Architecture Support
+
+Currently **Apple Silicon (arm64) only**. The build runs on `macos-15` runners which are arm64.
+
+For universal binary support (arm64 + x86_64) in the future:
+```bash
+swift build -c release --arch arm64 --arch x86_64
+```
+
+## Code Signing
+
+### Current (Alpha)
+
+- **Ad-hoc signing** (no Apple Developer certificate)
+- Users must manually grant permissions after each install
+- Gatekeeper will show "unidentified developer" warning
+- Users bypass with: Right-click > Open > Open
+
+### Future (GA Release)
+
+- Sign with Apple Developer ID certificate
+- Notarize with Apple for Gatekeeper clearance
+- No security warnings for end users
+- Permissions persist across updates
+
+See [Issue #27](https://github.com/jatinkrmalik/vocamac/issues/27) for tracking.
+
+## CI Workflows
+
+### `ci.yml` - Build & Test
+
+- **Triggers**: Push to `main`, pull requests to `main`
+- **Steps**: Debug build, test suite, release build, app bundle verification
+- **Caching**: SPM dependencies cached for faster builds
+- **Concurrency**: Cancels in-progress runs for the same branch
+
+### `release.yml` - Release
+
+- **Triggers**: Push of version tags (`v*`)
+- **Steps**: Build, test, create DMG + ZIP, generate checksums, create draft release
+- **Output**: Draft GitHub Release with downloadable artifacts
+
+### `deploy-website.yml` - Website
+
+- **Triggers**: Release published, manual dispatch
+- **Steps**: Deploy `web/` directory to GitHub Pages
+
+## Manual Release (Without CI)
+
+If you need to create a release locally:
+
+```bash
+# Build the app
+./scripts/build.sh release
+
+# Create DMG
+mkdir -p dmg-staging
+cp -R VocaMac.app dmg-staging/
+ln -s /Applications dmg-staging/Applications
+hdiutil create -volname "VocaMac" -srcfolder dmg-staging -ov -format UDZO "VocaMac-0.1.0-arm64.dmg"
+
+# Create ZIP
+ditto -c -k --sequesterRsrc --keepParent VocaMac.app "VocaMac-0.1.0-arm64.zip"
+
+# Generate checksums
+shasum -a 256 VocaMac-*.dmg VocaMac-*.zip > checksums.txt
+```
+
+Then upload the artifacts manually to the GitHub Release page.
+
+## Hotfix Process
+
+For critical bugs in a released version:
+
+1. Create a branch from the release tag: `git checkout -b fix/critical-bug v0.1.0`
+2. Fix the bug, commit, push
+3. Create a PR to `main`
+4. After merge, tag a patch release: `v0.1.1`
+5. Push the tag to trigger the release workflow


### PR DESCRIPTION
## v0.1.0 Alpha Release Preparation

All documentation, CI/CD, and release infrastructure needed for the first public alpha.

### README Overhaul
- Fixed truncated badge line
- Consistent platform naming (VocaLinux / VocaMac / VocaWin) with platform icons
- Fixed cross-platform table with proper links
- Removed broken `docs/PRD.md` link
- Added SoundManager, `scripts/`, `web/` to project structure
- Added Sound Effects to Configuration section
- Added build/install/uninstall script documentation
- Added Known Limitations section
- Removed Roadmap section (now tracked via GitHub Issues #22-#29)
- Replaced Author section with 'Made with ❤️ for the macOS community!'
- Removed all em-dashes

### Architecture Doc Fixes
- Fixed duplicate SettingsView in UI layer diagram
- Fixed `bundle.sh` -> `build.sh` reference
- Fixed incorrect cross-platform claims (WhisperKit and CoreML are Apple-only)
- Added SoundManager to module dependency graph

### CI Improvements (`ci.yml`)
- SPM dependency caching for faster builds
- Concurrency control (cancels stale runs on same branch)
- 30-minute timeout to prevent hung builds
- Release build verification step
- App bundle creation + codesign check

### New Release Workflow (`release.yml`)
Tag-triggered automated releases:
1. Builds release binary and `.app` bundle
2. Runs full test suite
3. Creates DMG with drag-to-Applications installer
4. Creates ZIP archive
5. Generates SHA-256 checksums
6. Publishes a **draft** GitHub Release with all artifacts

### New Release Documentation (`docs/RELEASE.md`)
- Complete release checklist with testing steps
- Versioning conventions (semver)
- Manual release instructions (without CI)
- Hotfix process
- Code signing roadmap

### After Merging
```bash
git tag -a v0.1.0 -m "VocaMac v0.1.0 - Alpha Release"
git push origin v0.1.0
```
Then review and publish the draft release on GitHub.