### PR TITLE
feat: floating mic indicator near text cursor during recording

### DIFF
--- a/Sources/VocaMac/Models/AppState.swift
+++ b/Sources/VocaMac/Models/AppState.swift
@@ -259,10 +259,12 @@ final class AppState: ObservableObject {
             soundManager.playStopSound()
         }
 
-        // Hide cursor indicator
-        cursorOverlay.hide()
+        // Transition cursor indicator to processing state (red -> purple)
+        // Keeps the overlay visible so the user knows text is on its way
+        cursorOverlay.transitionToProcessing()
 
         guard !audioData.isEmpty else {
+            cursorOverlay.hide()
             appStatus = .idle
             return
         }
@@ -286,8 +288,10 @@ final class AppState: ObservableObject {
                 )
             }
 
+            cursorOverlay.hide()
             appStatus = .idle
         } catch {
+            cursorOverlay.hide()
             errorMessage = "Transcription failed: \(error.localizedDescription)"
             appStatus = .error
 

--- a/Sources/VocaMac/Models/AppState.swift
+++ b/Sources/VocaMac/Models/AppState.swift
@@ -102,6 +102,7 @@ final class AppState: ObservableObject {
     @AppStorage("vocamac.launchAtLogin") var launchAtLogin: Bool = false
     @AppStorage("vocamac.preserveClipboard") var preserveClipboard: Bool = true
     @AppStorage("vocamac.soundEffectsEnabled") var soundEffectsEnabled: Bool = true
+    @AppStorage("vocamac.showCursorIndicator") var showCursorIndicator: Bool = true
 
     // MARK: - Services
 
@@ -111,6 +112,7 @@ final class AppState: ObservableObject {
     let hotKeyManager = HotKeyManager()
     let modelManager = ModelManager()
     let soundManager = SoundManager()
+    let cursorOverlay = CursorOverlayManager()
 
     // MARK: - Private
 
@@ -152,6 +154,7 @@ final class AppState: ObservableObject {
         audioEngine.onAudioLevel = { [weak self] level in
             Task { @MainActor in
                 self?.audioLevel = level
+                self?.cursorOverlay.updateAudioLevel(level)
             }
         }
 
@@ -232,6 +235,11 @@ final class AppState: ObservableObject {
             soundManager.playStartSound()
         }
 
+        // Show cursor indicator
+        if showCursorIndicator {
+            cursorOverlay.show()
+        }
+
         audioEngine.startRecording(
             silenceThreshold: Float(silenceThreshold),
             silenceDuration: silenceDuration,
@@ -250,6 +258,9 @@ final class AppState: ObservableObject {
         if soundEffectsEnabled {
             soundManager.playStopSound()
         }
+
+        // Hide cursor indicator
+        cursorOverlay.hide()
 
         guard !audioData.isEmpty else {
             appStatus = .idle

--- a/Sources/VocaMac/Services/CursorOverlayManager.swift
+++ b/Sources/VocaMac/Services/CursorOverlayManager.swift
@@ -3,7 +3,7 @@
 //
 // Shows a floating mic indicator near the text cursor during recording.
 // Uses the Accessibility API to locate the caret position in the focused app,
-// then renders a small, non-interactive overlay that pulses with audio level.
+// then renders a small, non-interactive overlay that shows recording/processing state.
 
 import AppKit
 import SwiftUI
@@ -21,7 +21,7 @@ final class CursorOverlayManager {
     /// Hosting view for the SwiftUI indicator content
     private var hostingView: NSHostingView<MicIndicatorView>?
 
-    /// The SwiftUI view model driving the indicator animation
+    /// The SwiftUI view model driving the indicator
     private let viewModel = MicIndicatorViewModel()
 
     /// Timer to periodically reposition the overlay to follow the cursor
@@ -31,7 +31,13 @@ final class CursorOverlayManager {
 
     /// Show the recording indicator near the text cursor
     func show() {
-        guard overlayPanel == nil else { return }
+        guard overlayPanel == nil else {
+            // Already showing - just ensure it's in recording state
+            viewModel.phase = .recording
+            return
+        }
+
+        viewModel.phase = .recording
 
         let indicatorView = MicIndicatorView(viewModel: viewModel)
         let hosting = NSHostingView(rootView: indicatorView)
@@ -67,7 +73,14 @@ final class CursorOverlayManager {
         }
 
         viewModel.isActive = true
-        NSLog("[CursorOverlay] Indicator shown")
+        NSLog("[CursorOverlay] Indicator shown (recording)")
+    }
+
+    /// Transition the indicator from recording (red) to processing (purple)
+    /// Keeps the overlay visible so the user knows text is on its way.
+    func transitionToProcessing() {
+        viewModel.phase = .processing
+        NSLog("[CursorOverlay] Transitioned to processing")
     }
 
     /// Hide the recording indicator
@@ -75,13 +88,14 @@ final class CursorOverlayManager {
         repositionTimer?.invalidate()
         repositionTimer = nil
         viewModel.isActive = false
+        viewModel.phase = .idle
         overlayPanel?.orderOut(nil)
         overlayPanel = nil
         hostingView = nil
         NSLog("[CursorOverlay] Indicator hidden")
     }
 
-    /// Update the audio level for the pulsing animation
+    /// Update the audio level (kept for future use)
     func updateAudioLevel(_ level: Float) {
         viewModel.audioLevel = level
     }
@@ -159,12 +173,21 @@ final class CursorOverlayManager {
     }
 }
 
+// MARK: - IndicatorPhase
+
+enum IndicatorPhase {
+    case idle
+    case recording
+    case processing
+}
+
 // MARK: - MicIndicatorViewModel
 
 @MainActor
 final class MicIndicatorViewModel: ObservableObject {
     @Published var isActive: Bool = false
     @Published var audioLevel: Float = 0.0
+    @Published var phase: IndicatorPhase = .idle
 }
 
 // MARK: - MicIndicatorView
@@ -172,34 +195,47 @@ final class MicIndicatorViewModel: ObservableObject {
 struct MicIndicatorView: View {
     @ObservedObject var viewModel: MicIndicatorViewModel
 
+    /// Recording state - red, matching menu bar icon (.systemRed)
+    private let recordingColor = Color(nsColor: .systemRed)
+
+    /// Processing state - purple (#BF5AF2), matching menu bar icon
+    private let processingColor = Color(
+        red: 0.749, green: 0.353, blue: 0.949
+    )
+
     var body: some View {
         ZStack {
-            // Pulsing background circle
+            // Background circle with color transition
             Circle()
-                .fill(Color.red.opacity(0.2))
-                .frame(width: pulseSize, height: pulseSize)
-                .animation(.easeInOut(duration: 0.3), value: viewModel.audioLevel)
-
-            // Background circle
-            Circle()
-                .fill(Color.red.opacity(0.85))
+                .fill(phaseColor)
                 .frame(width: 28, height: 28)
-                .shadow(color: .red.opacity(0.4), radius: 4, x: 0, y: 0)
+                .shadow(color: phaseColor.opacity(0.4), radius: 4, x: 0, y: 0)
 
-            // Mic icon
-            Image(systemName: "mic.fill")
+            // Icon changes based on phase
+            Image(systemName: phaseIcon)
                 .font(.system(size: 14, weight: .semibold))
                 .foregroundColor(.white)
         }
         .opacity(viewModel.isActive ? 1 : 0)
-        .animation(.easeInOut(duration: 0.2), value: viewModel.isActive)
+        .animation(.easeInOut(duration: 0.3), value: viewModel.isActive)
+        .animation(.easeInOut(duration: 0.4), value: viewModel.phase)
     }
 
-    /// Size of the pulse circle, driven by audio level
-    private var pulseSize: CGFloat {
-        let base: CGFloat = 28
-        let maxPulse: CGFloat = 36
-        let level = CGFloat(min(max(viewModel.audioLevel, 0), 1))
-        return base + (maxPulse - base) * level
+    /// Color based on current phase
+    private var phaseColor: Color {
+        switch viewModel.phase {
+        case .idle:       return recordingColor
+        case .recording:  return recordingColor
+        case .processing: return processingColor
+        }
+    }
+
+    /// Icon based on current phase
+    private var phaseIcon: String {
+        switch viewModel.phase {
+        case .idle:       return "mic.fill"
+        case .recording:  return "mic.fill"
+        case .processing: return "ellipsis.circle"
+        }
     }
 }

--- a/Sources/VocaMac/Services/CursorOverlayManager.swift
+++ b/Sources/VocaMac/Services/CursorOverlayManager.swift
@@ -1,0 +1,205 @@
+// CursorOverlayManager.swift
+// VocaMac
+//
+// Shows a floating mic indicator near the text cursor during recording.
+// Uses the Accessibility API to locate the caret position in the focused app,
+// then renders a small, non-interactive overlay that pulses with audio level.
+
+import AppKit
+import SwiftUI
+
+// MARK: - CursorOverlayManager
+
+@MainActor
+final class CursorOverlayManager {
+
+    // MARK: - Properties
+
+    /// The floating panel that hosts the mic indicator
+    private var overlayPanel: NSPanel?
+
+    /// Hosting view for the SwiftUI indicator content
+    private var hostingView: NSHostingView<MicIndicatorView>?
+
+    /// The SwiftUI view model driving the indicator animation
+    private let viewModel = MicIndicatorViewModel()
+
+    /// Timer to periodically reposition the overlay to follow the cursor
+    private var repositionTimer: Timer?
+
+    // MARK: - Public API
+
+    /// Show the recording indicator near the text cursor
+    func show() {
+        guard overlayPanel == nil else { return }
+
+        let indicatorView = MicIndicatorView(viewModel: viewModel)
+        let hosting = NSHostingView(rootView: indicatorView)
+        hosting.frame = NSRect(x: 0, y: 0, width: 36, height: 36)
+
+        let panel = NSPanel(
+            contentRect: NSRect(x: 0, y: 0, width: 36, height: 36),
+            styleMask: [.borderless, .nonactivatingPanel],
+            backing: .buffered,
+            defer: false
+        )
+        panel.isOpaque = false
+        panel.backgroundColor = .clear
+        panel.hasShadow = false
+        panel.level = .floating
+        panel.collectionBehavior = [.canJoinAllSpaces, .fullScreenAuxiliary]
+        panel.ignoresMouseEvents = true
+        panel.contentView = hosting
+
+        // Position near the text cursor
+        positionNearCaret(panel)
+
+        panel.orderFront(nil)
+        overlayPanel = panel
+        hostingView = hosting
+
+        // Reposition periodically in case the user scrolls or the cursor moves
+        repositionTimer = Timer.scheduledTimer(withTimeInterval: 0.5, repeats: true) { [weak self] _ in
+            Task { @MainActor in
+                guard let self = self, let panel = self.overlayPanel else { return }
+                self.positionNearCaret(panel)
+            }
+        }
+
+        viewModel.isActive = true
+        NSLog("[CursorOverlay] Indicator shown")
+    }
+
+    /// Hide the recording indicator
+    func hide() {
+        repositionTimer?.invalidate()
+        repositionTimer = nil
+        viewModel.isActive = false
+        overlayPanel?.orderOut(nil)
+        overlayPanel = nil
+        hostingView = nil
+        NSLog("[CursorOverlay] Indicator hidden")
+    }
+
+    /// Update the audio level for the pulsing animation
+    func updateAudioLevel(_ level: Float) {
+        viewModel.audioLevel = level
+    }
+
+    // MARK: - Caret Position Detection
+
+    /// Position the panel near the text caret using the Accessibility API.
+    /// Falls back to positioning near the mouse cursor if the caret can't be found.
+    private func positionNearCaret(_ panel: NSPanel) {
+        if let caretRect = getCaretRect() {
+            // Place the indicator just above and to the right of the caret
+            let screenPoint = NSPoint(
+                x: caretRect.origin.x + caretRect.width + 4,
+                y: caretRect.origin.y + caretRect.height + 4
+            )
+            panel.setFrameOrigin(screenPoint)
+        } else {
+            // Fallback: position near the mouse cursor
+            let mouseLocation = NSEvent.mouseLocation
+            panel.setFrameOrigin(NSPoint(
+                x: mouseLocation.x + 16,
+                y: mouseLocation.y - 40
+            ))
+        }
+    }
+
+    /// Use the Accessibility API to get the bounding rect of the text caret
+    /// in the currently focused application.
+    private func getCaretRect() -> CGRect? {
+        // Get the focused application
+        let systemWide = AXUIElementCreateSystemWide()
+
+        var focusedApp: AnyObject?
+        guard AXUIElementCopyAttributeValue(systemWide, kAXFocusedApplicationAttribute as CFString, &focusedApp) == .success else {
+            return nil
+        }
+
+        // Get the focused UI element (usually a text field)
+        var focusedElement: AnyObject?
+        guard AXUIElementCopyAttributeValue(focusedApp as! AXUIElement, kAXFocusedUIElementAttribute as CFString, &focusedElement) == .success else {
+            return nil
+        }
+
+        let element = focusedElement as! AXUIElement
+
+        // Get the selected text range (caret position)
+        var selectedRange: AnyObject?
+        guard AXUIElementCopyAttributeValue(element, kAXSelectedTextRangeAttribute as CFString, &selectedRange) == .success else {
+            return nil
+        }
+
+        // Get the bounds of the selected range (caret position on screen)
+        var bounds: AnyObject?
+        guard AXUIElementCopyParameterizedAttributeValue(
+            element,
+            kAXBoundsForRangeParameterizedAttribute as CFString,
+            selectedRange!,
+            &bounds
+        ) == .success else {
+            return nil
+        }
+
+        // Convert AXValue to CGRect
+        var rect = CGRect.zero
+        guard AXValueGetValue(bounds as! AXValue, .cgRect, &rect) else {
+            return nil
+        }
+
+        // AX coordinates are top-left origin; convert to NSScreen bottom-left origin
+        if let screen = NSScreen.main {
+            rect.origin.y = screen.frame.height - rect.origin.y - rect.height
+        }
+
+        return rect
+    }
+}
+
+// MARK: - MicIndicatorViewModel
+
+@MainActor
+final class MicIndicatorViewModel: ObservableObject {
+    @Published var isActive: Bool = false
+    @Published var audioLevel: Float = 0.0
+}
+
+// MARK: - MicIndicatorView
+
+struct MicIndicatorView: View {
+    @ObservedObject var viewModel: MicIndicatorViewModel
+
+    var body: some View {
+        ZStack {
+            // Pulsing background circle
+            Circle()
+                .fill(Color.red.opacity(0.2))
+                .frame(width: pulseSize, height: pulseSize)
+                .animation(.easeInOut(duration: 0.3), value: viewModel.audioLevel)
+
+            // Background circle
+            Circle()
+                .fill(Color.red.opacity(0.85))
+                .frame(width: 28, height: 28)
+                .shadow(color: .red.opacity(0.4), radius: 4, x: 0, y: 0)
+
+            // Mic icon
+            Image(systemName: "mic.fill")
+                .font(.system(size: 14, weight: .semibold))
+                .foregroundColor(.white)
+        }
+        .opacity(viewModel.isActive ? 1 : 0)
+        .animation(.easeInOut(duration: 0.2), value: viewModel.isActive)
+    }
+
+    /// Size of the pulse circle, driven by audio level
+    private var pulseSize: CGFloat {
+        let base: CGFloat = 28
+        let maxPulse: CGFloat = 36
+        let level = CGFloat(min(max(viewModel.audioLevel, 0), 1))
+        return base + (maxPulse - base) * level
+    }
+}

--- a/Sources/VocaMac/Views/SettingsView.swift
+++ b/Sources/VocaMac/Views/SettingsView.swift
@@ -131,6 +131,8 @@ struct GeneralSettingsTab: View {
             Section("Behavior") {
                 Toggle("Preserve clipboard after text injection", isOn: $appState.preserveClipboard)
 
+            Toggle("Show mic indicator near cursor while recording", isOn: $appState.showCursorIndicator)
+
                 Text("When enabled, your clipboard contents are restored after injecting text.")
                     .font(.caption)
                     .foregroundStyle(.secondary)


### PR DESCRIPTION
## What

A small floating mic icon appears near the text cursor while recording, giving users a clear visual indicator of where their transcribed text will be pasted.


![Screen Recording 2026-03-04 at 21 38 21](https://github.com/user-attachments/assets/f755c90c-9e07-4126-9c63-87b1a4ff0da1)

### Demo
When you press the hotkey to start recording:
1. A red mic icon appears next to your text cursor
2. It pulses with your voice level
3. It follows the cursor if you move it
4. It disappears when recording stops

### How It Works
- Uses the **Accessibility API** (`AXUIElement`) to locate the caret position in the focused app
- Gets `kAXSelectedTextRangeAttribute` and `kAXBoundsForRangeParameterizedAttribute` to find the exact screen coordinates
- Falls back to **mouse cursor position** if the caret can't be detected (e.g., non-text apps)
- Renders as a non-interactive `NSPanel` at `.floating` window level
- Repositions every 0.5s to follow cursor movement

### Settings
Toggle in **Settings > General**: "Show mic indicator near cursor while recording"
- Enabled by default
- Persisted via `@AppStorage`

### Files Changed
- `Sources/VocaMac/Services/CursorOverlayManager.swift` (new) - Overlay panel, caret detection, SwiftUI indicator view
- `Sources/VocaMac/Models/AppState.swift` - Integration: show/hide/updateAudioLevel
- `Sources/VocaMac/Views/SettingsView.swift` - Toggle in General tab