### PR TITLE
ui: Fix About tagline truncation and use Alpha label

### DIFF
--- a/Sources/VocaMac/Views/SettingsView.swift
+++ b/Sources/VocaMac/Views/SettingsView.swift
@@ -29,7 +29,7 @@ struct SettingsView: View {
                     Label("About", systemImage: "info.circle")
                 }
         }
-        .frame(width: 560, height: 480)
+        .frame(width: 560, height: 520)
     }
 }
 
@@ -630,8 +630,9 @@ struct AboutTab: View {
                 .font(.subheadline)
                 .foregroundStyle(.secondary)
                 .multilineTextAlignment(.center)
+                .fixedSize(horizontal: false, vertical: true)
 
-            Text("Version 0.1.0 (MVP)")
+            Text("Version 0.1.0 (Alpha)")
                 .font(.caption)
                 .foregroundStyle(.tertiary)
 


### PR DESCRIPTION
## Changes

- **Settings window height:** Increased from 480 → 520 to accommodate the two-line tagline
- **Tagline text wrapping:** Added `.fixedSize(horizontal: false, vertical: true)` to prevent truncation
- **Version label:** Changed from "Version 0.1.0 (MVP)" to "Version 0.1.0 (Alpha)"

## Screenshots

Before: Tagline was truncated showing only "Your voice, your Mac, your privacy...."
After: Both lines display fully:
> Your voice, your Mac, your privacy.
> Open-source dictation powered by AI.

## Context

These changes were tested locally but missed the push before PR #35 was merged. This is a quick follow-up to get them into main before tagging v0.1.0.