### PR TITLE
chore: Add Makefile and restructure install.sh for /Applications install

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,7 +48,8 @@ VocaMac/
 │   └── Resources/        # Bundled resources (.gitkeep placeholder)
 ├── Tests/VocaMacTests/   # Unit tests
 ├── web/                  # Static website (HTML/CSS/JS, deployed to GitHub Pages)
-├── scripts/              # build.sh, install.sh
+├── Makefile              # make build, install, test, clean
+├── scripts/              # build.sh, install.sh, uninstall.sh
 ├── docs/                 # ARCHITECTURE.md, DATA_MODEL.md, PRD.md
 ├── Package.swift         # SPM manifest
 └── VocaMac.entitlements  # App sandbox entitlements
@@ -59,20 +60,28 @@ VocaMac/
 ## Build & Run
 
 ```bash
-# Build (debug)
-swift build
+# Build + install to /Applications (recommended)
+make install
 
-# Build (release)
-swift build -c release
+# Build .app bundle in repo root (fast dev iteration)
+make build
+
+# Install CLI commands to ~/.local/bin
+make install-cli
 
 # Run tests
-swift test
+make test
 
-# Build app bundle (creates VocaMac.app)
-./scripts/build.sh
+# Clean build artifacts
+make clean
+```
 
-# Install via script
-./scripts/install.sh
+Or use the scripts directly:
+
+```bash
+./scripts/build.sh              # Build .app bundle (dev)
+./scripts/install.sh            # Build + install to /Applications
+./scripts/install.sh --cli      # Install CLI commands
 ```
 
 The project builds on **macOS only** (requires AppKit, CoreML, AVFoundation). CI runs on `macos-15`.

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,46 @@
+# VocaMac — Makefile
+# Run `make help` for available commands.
+
+.PHONY: build install install-cli test clean run help
+
+## Build .app bundle in repo root (fast, for development)
+build:
+	@./scripts/build.sh
+
+## Build and install to /Applications (recommended for first-time setup)
+install:
+	@./scripts/install.sh
+
+## Install CLI commands (vocamac, vocamac-build) to ~/.local/bin
+install-cli:
+	@./scripts/install.sh --cli
+
+## Run tests
+test:
+	@swift test
+
+## Remove build artifacts
+clean:
+	@echo "🧹 Cleaning build artifacts..."
+	@swift package clean
+	@rm -rf VocaMac.app
+	@rm -rf .build
+	@echo "✅ Clean complete"
+
+## Launch the locally built .app (build first with `make build`)
+run:
+	@open VocaMac.app 2>/dev/null || (echo "❌ VocaMac.app not found. Run 'make build' first." && exit 1)
+
+## Show this help
+help:
+	@echo "VocaMac — Available Commands"
+	@echo ""
+	@echo "  make build        Build .app bundle (fast, for development)"
+	@echo "  make install      Build + install to /Applications (recommended)"
+	@echo "  make install-cli  Install CLI commands to ~/.local/bin"
+	@echo "  make test         Run tests"
+	@echo "  make run          Launch the locally built .app"
+	@echo "  make clean        Remove build artifacts"
+	@echo "  make help         Show this help"
+	@echo ""
+	@echo "Quick start:  make install"

--- a/README.md
+++ b/README.md
@@ -134,34 +134,29 @@ VocaMac requires three macOS permissions:
 4. **Open** VocaMac from Applications (right-click → Open on first launch)
 5. **Grant permissions** — Microphone, Accessibility, and Input Monitoring when prompted
 
-### Option 2: Build from Source
+### Option 2: Build from Source (Recommended)
 
 ```bash
-# Clone the repository
 git clone https://github.com/jatinkrmalik/vocamac.git
 cd vocamac
-
-# Build the app bundle
-./scripts/build.sh
-
-# Launch VocaMac
-open VocaMac.app
+make install
 ```
 
-**Or use the install script** for a CLI-based workflow:
+This builds VocaMac, installs it to `/Applications`, and launches it. Permissions are granted directly to VocaMac — just like the DMG method.
+
+### Option 3: CLI Commands (For Developers)
 
 ```bash
-# Build + install `vocamac` command to ~/.local/bin
-./scripts/install.sh
-
-# Launch in background
-vocamac &
-
-# Rebuild anytime after pulling updates
-vocamac-build
+git clone https://github.com/jatinkrmalik/vocamac.git
+cd vocamac
+make install-cli
 ```
 
-> **Permissions note:** When running from terminal, macOS assigns permissions to your **terminal app** (Terminal, iTerm2, etc.) rather than VocaMac itself. Grant Microphone, Accessibility, and Input Monitoring to your terminal app instead.
+This installs two commands to `~/.local/bin`:
+- `vocamac &` — Launch VocaMac in background
+- `vocamac-build` — Rebuild from source after pulling updates
+
+> **Permissions note:** In CLI mode, macOS assigns permissions to your **terminal app** (Terminal, iTerm2, etc.) rather than VocaMac itself. Grant Microphone, Accessibility, and Input Monitoring to your terminal app instead.
 
 ### First Launch
 
@@ -291,9 +286,10 @@ VocaMac/
 │       └── Resources/
 ├── Tests/
 │   └── VocaMacTests/
+├── Makefile                        # make build, install, test, clean
 ├── scripts/
-│   ├── build.sh                    # Build .app bundle
-│   ├── install.sh                  # Install to ~/.local/bin
+│   ├── build.sh                    # Build .app bundle (dev)
+│   ├── install.sh                  # Install to /Applications or CLI
 │   └── uninstall.sh                # Full uninstall & cleanup
 ├── web/                            # Marketing website (vocamac.com)
 ├── docs/
@@ -306,23 +302,13 @@ VocaMac/
 ### Build Commands
 
 ```bash
-# Debug build
-swift build
-
-# Release build (optimized)
-swift build -c release
-
-# Run
-swift run VocaMac
-
-# Run tests (requires Xcode)
-swift test
-
-# Build .app bundle
-./scripts/build.sh
-
-# Install launcher scripts to ~/.local/bin
-./scripts/install.sh
+make install        # Build + install to /Applications (recommended)
+make install-cli    # Install CLI commands to ~/.local/bin
+make build          # Build .app bundle in repo root (dev iteration)
+make test           # Run tests
+make run            # Launch the locally built .app
+make clean          # Remove build artifacts
+make help           # Show all commands
 ```
 
 ### Uninstall

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -448,17 +448,23 @@ Package.swift
 ### 7.2 Build Commands
 
 ```bash
-# Debug build
+# Build + install to /Applications (recommended)
+make install
+
+# Build .app bundle in repo root (fast dev iteration)
+make build
+
+# Install CLI commands to ~/.local/bin
+make install-cli
+
+# Run tests
+make test
+
+# Debug build (SPM only, no .app bundle)
 swift build
 
-# Release build (optimized)
+# Release build (SPM only, no .app bundle)
 swift build -c release
-
-# Run
-swift run VocaMac
-
-# Create app bundle (requires additional scripting)
-./scripts/build.sh
 ```
 
 ### 7.3 Distribution Strategy (MVP)

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,77 +1,150 @@
 #!/bin/bash
-# install.sh — Install VocaMac for easy daily use
+# install.sh — Build and install VocaMac
 #
-# Creates a 'vocamac' command in ~/.local/bin (no sudo required).
-# Run this script once after cloning. Rebuild anytime with: vocamac-build
+# Usage:
+#   ./scripts/install.sh          Build .app and install to /Applications (recommended)
+#   ./scripts/install.sh --cli    Install CLI commands (vocamac, vocamac-build) to ~/.local/bin
+#   ./scripts/install.sh --help   Show this help message
 
-set -euo pipefail
+set -e
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 PROJECT_DIR="$(dirname "$SCRIPT_DIR")"
-cd "$PROJECT_DIR"
 
-LOCAL_BIN="$HOME/.local/bin"
-BINARY="$(pwd)/.build/arm64-apple-macosx/release/VocaMac"
+# ─── Help ───────────────────────────────────────────────────────────────────────
 
-echo "🔨 Building VocaMac (release)..."
-swift build -c release 2>&1 | tail -3
+show_help() {
+    echo "VocaMac Installer"
+    echo ""
+    echo "Usage:"
+    echo "  ./scripts/install.sh          Build and install to /Applications (recommended)"
+    echo "  ./scripts/install.sh --cli    Install CLI commands to ~/.local/bin"
+    echo "  ./scripts/install.sh --help   Show this help"
+    echo ""
+    echo "Default mode builds VocaMac.app and copies it to /Applications."
+    echo "Permissions (Microphone, Accessibility, Input Monitoring) are granted"
+    echo "directly to VocaMac — no terminal permission workarounds needed."
+    echo ""
+    echo "CLI mode installs 'vocamac' and 'vocamac-build' shell commands."
+    echo "Note: In CLI mode, macOS permissions are granted to your terminal app"
+    echo "(Terminal, iTerm2, etc.) instead of VocaMac."
+}
 
-if [ ! -f "$BINARY" ]; then
-    echo "❌ Build failed"
-    exit 1
-fi
+# ─── App Install (default) ──────────────────────────────────────────────────────
 
-# Create ~/.local/bin if it doesn't exist
-mkdir -p "$LOCAL_BIN"
+install_app() {
+    echo "🔨 Building VocaMac.app..."
+    "$SCRIPT_DIR/build.sh"
+    echo ""
 
-# Create launcher script
-cat > "$LOCAL_BIN/vocamac" << EOF
+    # Kill any running instance
+    pkill -f VocaMac 2>/dev/null || true
+    sleep 1
+
+    # Copy to /Applications
+    echo "📦 Installing to /Applications..."
+    if [ -d "/Applications/VocaMac.app" ]; then
+        rm -rf "/Applications/VocaMac.app"
+    fi
+    cp -R "$PROJECT_DIR/VocaMac.app" "/Applications/VocaMac.app"
+
+    echo "🚀 Launching VocaMac..."
+    open "/Applications/VocaMac.app"
+
+    echo ""
+    echo "✅ VocaMac installed to /Applications and launched!"
+    echo ""
+    echo "┌─────────────────────────────────────────────────────────────┐"
+    echo "│  First-time setup:                                         │"
+    echo "│                                                            │"
+    echo "│  1. Grant Microphone permission when prompted              │"
+    echo "│  2. Grant Accessibility in System Settings                 │"
+    echo "│  3. Grant Input Monitoring in System Settings              │"
+    echo "│  4. Restart VocaMac after granting Input Monitoring        │"
+    echo "│                                                            │"
+    echo "│  Then hold Right Option (⌥) and start talking!             │"
+    echo "│                                                            │"
+    echo "│  ⚠️  Permissions reset on every rebuild (ad-hoc signing)    │"
+    echo "│  After rebuilding, re-grant Accessibility & Input          │"
+    echo "│  Monitoring in System Settings → Privacy & Security        │"
+    echo "└─────────────────────────────────────────────────────────────┘"
+    echo ""
+    echo "To rebuild after code changes:  ./scripts/install.sh"
+    echo "To uninstall:                   ./scripts/uninstall.sh"
+}
+
+# ─── CLI Install ────────────────────────────────────────────────────────────────
+
+install_cli() {
+    echo "🔨 Building VocaMac (release)..."
+    cd "$PROJECT_DIR"
+    swift build -c release
+
+    BINARY_PATH=".build/arm64-apple-macosx/release/VocaMac"
+
+    if [ ! -f "$BINARY_PATH" ]; then
+        echo "❌ Build failed — binary not found at $BINARY_PATH"
+        exit 1
+    fi
+
+    echo "📦 Installing CLI commands to ~/.local/bin..."
+    mkdir -p "$HOME/.local/bin"
+
+    # Create vocamac launcher
+    cat > "$HOME/.local/bin/vocamac" << LAUNCHER
 #!/bin/bash
-# VocaMac launcher — local voice-to-text for macOS
-# Kill any existing instance and launch fresh
-pkill -f "VocaMac" 2>/dev/null
+# VocaMac launcher — kills any running instance and starts fresh
+killall VocaMac 2>/dev/null
 sleep 0.5
-exec "$BINARY" "\$@"
-EOF
-chmod +x "$LOCAL_BIN/vocamac"
+"$PROJECT_DIR/$BINARY_PATH" &
+echo "VocaMac started (PID: \$!)"
+LAUNCHER
+    chmod +x "$HOME/.local/bin/vocamac"
 
-# Create a rebuild shortcut
-cat > "$LOCAL_BIN/vocamac-build" << EOF
+    # Create vocamac-build command
+    cat > "$HOME/.local/bin/vocamac-build" << BUILDER
 #!/bin/bash
-# Rebuild VocaMac from source
+# VocaMac rebuild — rebuilds from source
 cd "$PROJECT_DIR"
-pkill -f "VocaMac" 2>/dev/null
-swift build -c release 2>&1 | tail -3
-echo "✅ VocaMac rebuilt. Run 'vocamac &' to launch."
-EOF
-chmod +x "$LOCAL_BIN/vocamac-build"
+killall VocaMac 2>/dev/null
+swift build -c release
+echo "✅ VocaMac rebuilt successfully"
+BUILDER
+    chmod +x "$HOME/.local/bin/vocamac-build"
 
-echo ""
-echo "✅ VocaMac installed!"
-echo ""
+    # Check PATH
+    if [[ ":$PATH:" != *":$HOME/.local/bin:"* ]]; then
+        echo ""
+        echo "⚠️  ~/.local/bin is not in your PATH. Add it:"
+        echo ""
+        echo "    echo 'export PATH=\"\$HOME/.local/bin:\$PATH\"' >> ~/.zshrc"
+        echo "    source ~/.zshrc"
+        echo ""
+    fi
 
-# Check if ~/.local/bin is in PATH
-if [[ ":$PATH:" != *":$LOCAL_BIN:"* ]]; then
-    echo "⚠️  Add ~/.local/bin to your PATH. Add this to your ~/.zshrc:"
     echo ""
-    echo "   export PATH=\"\$HOME/.local/bin:\$PATH\""
+    echo "✅ CLI commands installed!"
     echo ""
-    echo "   Then run: source ~/.zshrc"
+    echo "  vocamac          Launch VocaMac in background"
+    echo "  vocamac-build    Rebuild from source"
     echo ""
-fi
+    echo "⚠️  In CLI mode, grant permissions to your terminal app"
+    echo "   (Terminal/iTerm2) in System Settings → Privacy & Security:"
+    echo "   • Microphone"
+    echo "   • Accessibility"
+    echo "   • Input Monitoring"
+}
 
-echo "📋 Commands:"
-echo "   vocamac &         — Launch VocaMac in background"
-echo "   vocamac-build     — Rebuild from source"
-echo "   killall VocaMac   — Stop VocaMac"
-echo ""
-echo "⚠️  First time? Grant these permissions to Terminal.app:"
-echo "   System Settings → Privacy & Security → Accessibility → Terminal → ON"
-echo "   System Settings → Privacy & Security → Input Monitoring → Terminal → ON"
-echo "   System Settings → Privacy & Security → Microphone → Terminal → ON"
-echo ""
-echo "🎤 Usage:"
-echo "   1. Run: vocamac &"
-echo "   2. Click into any text field"
-echo "   3. Hold Right Option → speak → release"
-echo "   4. Text appears at your cursor!"
+# ─── Main ───────────────────────────────────────────────────────────────────────
+
+case "${1:-}" in
+    --cli)
+        install_cli
+        ;;
+    --help|-h)
+        show_help
+        ;;
+    *)
+        install_app
+        ;;
+esac


### PR DESCRIPTION
## Problem

Building from source and running `open VocaMac.app` from the repo root causes permission issues — macOS assigns permissions to Terminal instead of VocaMac. Users had to figure out the workaround themselves.

## Solution

### New install.sh (two modes)

| Command | What it does |
|---|---|
| `./scripts/install.sh` | Build `.app`, copy to `/Applications`, launch. Permissions go to VocaMac directly. |
| `./scripts/install.sh --cli` | Install `vocamac` + `vocamac-build` CLI commands to `~/.local/bin` (old behavior). |

### Makefile

| Command | What it does |
|---|---|
| `make install` | Build + install to /Applications (recommended) |
| `make install-cli` | Install CLI commands to ~/.local/bin |
| `make build` | Build .app bundle in repo root (fast dev iteration) |
| `make test` | Run tests |
| `make run` | Launch the locally built .app |
| `make clean` | Remove build artifacts |
| `make help` | Show available commands |

### Quick start is now:
```bash
git clone https://github.com/jatinkrmalik/vocamac.git
cd vocamac
make install
```

### Docs updated
- README.md — Quick Start (3 options: DMG, make install, make install-cli), Build Commands, Project Structure
- AGENTS.md — Build & Run section, Repository Structure
- docs/ARCHITECTURE.md — Build Commands section

### What stays the same
- `build.sh` — unchanged, still the fast dev iteration tool
- `uninstall.sh` — unchanged
- CI workflows — unchanged (`swift build` + `swift test` + `build.sh release`)