### PR TITLE
ci: Add xcodebuild -runFirstLaunch for actool support in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,9 +37,13 @@ jobs:
       - name: Build (Release)
         run: swift build -c release
 
+      - name: Initialize Xcode tools
+        run: sudo xcodebuild -runFirstLaunch
+
       - name: Verify app bundle
         run: |
           ./scripts/build.sh release
           test -d VocaMac.app || exit 1
           codesign -v VocaMac.app
+          test -f VocaMac.app/Contents/Resources/Assets.car || echo "⚠️ Assets.car missing"
           echo "App bundle verified"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,6 +27,9 @@ jobs:
           sed -i '' "s/CFBundleVersion.*/<key>CFBundleVersion<\/key>/" scripts/build.sh || true
           echo "Building version: ${{ steps.version.outputs.VERSION }}"
 
+      - name: Initialize Xcode tools
+        run: sudo xcodebuild -runFirstLaunch
+
       - name: Build release app bundle
         run: ./scripts/build.sh release
 


### PR DESCRIPTION
## Problem

The app icon doesn't display in Finder when VocaMac is built on CI. The DMG from releases shows a generic white icon.

## Root Cause

`actool` (the Asset Catalog compiler) requires Xcode's first-launch initialization to load its plugins. Without running `xcodebuild -runFirstLaunch`, `actool` fails silently and `build.sh` falls back to `.icns`-only — missing the `Assets.car` that modern macOS requires for icon rendering.

## Fix

Added `sudo xcodebuild -runFirstLaunch` step to both:
- **release.yml** — before building the release app bundle
- **ci.yml** — before verifying the app bundle

Also added an `Assets.car` presence check in the CI verification step.

## Impact

Future releases will have the correct app icon in Finder and DMG without needing manual asset uploads.