### PR TITLE
feat: add system-wide logging framework with rotation and export

### DIFF
--- a/Sources/VocaMac/Models/AppState.swift
+++ b/Sources/VocaMac/Models/AppState.swift
@@ -107,6 +107,7 @@ final class AppState: ObservableObject {
     @AppStorage("vocamac.soundEffectsEnabled") var soundEffectsEnabled: Bool = true
     @AppStorage("vocamac.showCursorIndicator") var showCursorIndicator: Bool = true
     @AppStorage("vocamac.translationEnabled") var translationEnabled: Bool = false
+    @AppStorage("vocamac.logLevel") var logLevel: String = "info"
 
     // MARK: - Services
 
@@ -125,7 +126,7 @@ final class AppState: ObservableObject {
     // MARK: - Initialization
 
     init() {
-        NSLog("[AppState] Initializing...")
+        VocaLogger.info(.appState, "Initializing...")
         setupServices()
         // Trigger startup automatically
         Task {
@@ -480,46 +481,43 @@ final class AppState: ObservableObject {
     // MARK: - Startup
 
     func performStartup() async {
-        NSLog("[AppState] performStartup beginning...")
+        VocaLogger.info(.appState, "performStartup beginning...")
 
         // 1. Detect hardware
         systemCapabilities = SystemInfo.detect()
-        NSLog("[AppState] System: %@ | %d GB RAM | %d cores",
-              systemCapabilities?.processorName ?? "unknown",
-              systemCapabilities?.physicalMemoryGB ?? 0,
-              systemCapabilities?.coreCount ?? 0)
+        let sysInfo = systemCapabilities
+        VocaLogger.info(.appState, "System: \(sysInfo?.processorName ?? "unknown") | \(sysInfo?.physicalMemoryGB ?? 0) GB RAM | \(sysInfo?.coreCount ?? 0) cores")
 
         // 2. Check/request permissions
         checkPermissions()
-        NSLog("[AppState] Mic permission: %@ | Accessibility: %@ | Input Monitoring: %@",
-              micPermission.rawValue, accessibilityPermission.rawValue, inputMonitoringPermission.rawValue)
+        VocaLogger.info(.appState, "Mic permission: \(micPermission.rawValue) | Accessibility: \(accessibilityPermission.rawValue) | Input Monitoring: \(inputMonitoringPermission.rawValue)")
 
         // Auto-prompt for microphone permission on first launch
         if micPermission == .notDetermined {
-            NSLog("[AppState] Mic permission not determined — requesting...")
+            VocaLogger.info(.appState, "Mic permission not determined — requesting...")
             requestMicrophonePermission()
         }
 
         // 3. Load model — let WhisperKit auto-select and download the best model
-        NSLog("[AppState] Loading WhisperKit model (auto-select)...")
+        VocaLogger.info(.appState, "Loading WhisperKit model (auto-select)...")
         await loadModel()
         NSLog("[AppState] Model loaded: %@", whisperService.loadedModelName ?? "none")
 
         // 4. Always attempt to start hotkey listener
         // The event tap creation itself will fail if permissions aren't granted,
         // and we handle that gracefully in HotKeyManager.
-        NSLog("[AppState] Attempting to start hotkey listener...")
+        VocaLogger.info(.appState, "Attempting to start hotkey listener...")
         hotKeyManager.startListening(
             keyCode: hotKeyCode,
             mode: activationMode,
             doubleTapThreshold: doubleTapThreshold
         )
         if hotKeyManager.isListening {
-            NSLog("[AppState] Hotkey listener active (keyCode=%d, mode=%@)", hotKeyCode, activationMode.rawValue)
+            VocaLogger.info(.appState, "Hotkey listener active (keyCode=\(hotKeyCode), mode=\(activationMode.rawValue))")
         } else {
-            NSLog("[AppState] WARNING: Hotkey listener failed to start. Check Accessibility & Input Monitoring permissions.")
+            VocaLogger.warning(.appState, "Hotkey listener failed to start. Check Accessibility & Input Monitoring permissions.")
         }
 
-        NSLog("[AppState] Startup complete!")
+        VocaLogger.info(.appState, "Startup complete!")
     }
 }

--- a/Sources/VocaMac/Services/AudioEngine.swift
+++ b/Sources/VocaMac/Services/AudioEngine.swift
@@ -108,7 +108,7 @@ final class AudioEngine {
         do {
             try engine.start()
         } catch {
-            print("[AudioEngine] Failed to start audio engine: \(error)")
+            VocaLogger.error(.audioEngine, "Failed to start audio engine: \(error)")
             isCurrentlyRecording = false
         }
     }
@@ -200,7 +200,7 @@ final class AudioEngine {
 
         // Create a converter
         guard let converter = AVAudioConverter(from: inputFormat, to: whisperFormat) else {
-            print("[AudioEngine] Failed to create audio format converter")
+            VocaLogger.error(.audioEngine, "Failed to create audio format converter")
             return nil
         }
 
@@ -224,7 +224,7 @@ final class AudioEngine {
         converter.convert(to: outputBuffer, error: &error, withInputFrom: inputBlock)
 
         if let error = error {
-            print("[AudioEngine] Conversion error: \(error)")
+            VocaLogger.error(.audioEngine, "Conversion error: \(error)")
             return nil
         }
 

--- a/Sources/VocaMac/Services/CursorOverlayManager.swift
+++ b/Sources/VocaMac/Services/CursorOverlayManager.swift
@@ -73,14 +73,14 @@ final class CursorOverlayManager {
         }
 
         viewModel.isActive = true
-        NSLog("[CursorOverlay] Indicator shown (recording)")
+        VocaLogger.debug(.cursorOverlay, "Indicator shown (recording)")
     }
 
     /// Transition the indicator from recording (red) to processing (purple)
     /// Keeps the overlay visible so the user knows text is on its way.
     func transitionToProcessing() {
         viewModel.phase = .processing
-        NSLog("[CursorOverlay] Transitioned to processing")
+        VocaLogger.debug(.cursorOverlay, "Transitioned to processing")
     }
 
     /// Hide the recording indicator
@@ -92,7 +92,7 @@ final class CursorOverlayManager {
         overlayPanel?.orderOut(nil)
         overlayPanel = nil
         hostingView = nil
-        NSLog("[CursorOverlay] Indicator hidden")
+        VocaLogger.debug(.cursorOverlay, "Indicator hidden")
     }
 
     /// Update the audio level (kept for future use)

--- a/Sources/VocaMac/Services/HotKeyManager.swift
+++ b/Sources/VocaMac/Services/HotKeyManager.swift
@@ -72,7 +72,7 @@ final class HotKeyManager {
         doubleTapThreshold: Double = 0.4
     ) {
         guard !isListening else {
-            print("[HotKeyManager] Already listening")
+            VocaLogger.debug(.hotKeyManager, "Already listening")
             return
         }
 
@@ -101,7 +101,7 @@ final class HotKeyManager {
             callback: HotKeyManager.eventTapCallback,
             userInfo: userInfo
         ) else {
-            NSLog("[HotKeyManager] FAILED to create event tap! Check Accessibility & Input Monitoring permissions.")
+            VocaLogger.error(.hotKeyManager, "FAILED to create event tap! Check Accessibility & Input Monitoring permissions.")
             return
         }
 
@@ -114,7 +114,7 @@ final class HotKeyManager {
         CGEvent.tapEnable(tap: tap, enable: true)
 
         isListening = true
-        NSLog("[HotKeyManager] Event tap created successfully. Listening for keyCode %d in %@ mode", keyCode, mode.rawValue)
+        VocaLogger.info(.hotKeyManager, "Event tap created successfully. Listening for keyCode \(keyCode) in \(mode.rawValue) mode")
     }
 
     /// Stop listening for global hotkey events
@@ -135,7 +135,7 @@ final class HotKeyManager {
         isKeyHeld = false
         isToggled = false
 
-        print("[HotKeyManager] Stopped listening")
+        VocaLogger.info(.hotKeyManager, "Stopped listening")
     }
 
     /// Update the configuration while listening
@@ -180,7 +180,7 @@ final class HotKeyManager {
         // For regular keys, we use keyDown/keyUp events
         if type == .flagsChanged {
             if keyCode == targetKeyCode {
-                NSLog("[HotKeyManager] flagsChanged event for target keyCode %d", keyCode)
+                VocaLogger.debug(.hotKeyManager, "flagsChanged event for target keyCode \(keyCode)")
             }
             handleModifierKeyEvent(keyCode: keyCode, event: event)
         } else if type == .keyDown || type == .keyUp {
@@ -234,14 +234,14 @@ final class HotKeyManager {
     /// Process a key-down event for the target hotkey
     private func handleKeyDown() {
         let currentTime = CFAbsoluteTimeGetCurrent()
-        NSLog("[HotKeyManager] Key DOWN detected (mode=%@)", mode.rawValue)
+        VocaLogger.debug(.hotKeyManager, "Key DOWN detected (mode=\(mode.rawValue))")
 
         switch mode {
         case .pushToTalk:
             // Push-to-talk: start recording on key down (if not already held)
             if !isKeyHeld {
                 isKeyHeld = true
-                NSLog("[HotKeyManager] Push-to-talk: START recording")
+                VocaLogger.debug(.hotKeyManager, "Push-to-talk: START recording")
                 DispatchQueue.main.async { [weak self] in
                     self?.onRecordingStart?()
                 }
@@ -272,14 +272,14 @@ final class HotKeyManager {
 
     /// Process a key-up event for the target hotkey
     private func handleKeyUp() {
-        NSLog("[HotKeyManager] Key UP detected (mode=%@)", mode.rawValue)
+        VocaLogger.debug(.hotKeyManager, "Key UP detected (mode=\(mode.rawValue))")
 
         switch mode {
         case .pushToTalk:
             // Push-to-talk: stop recording on key release
             if isKeyHeld {
                 isKeyHeld = false
-                NSLog("[HotKeyManager] Push-to-talk: STOP recording")
+                VocaLogger.debug(.hotKeyManager, "Push-to-talk: STOP recording")
                 DispatchQueue.main.async { [weak self] in
                     self?.onRecordingStop?()
                 }

--- a/Sources/VocaMac/Services/Logger.swift
+++ b/Sources/VocaMac/Services/Logger.swift
@@ -1,0 +1,280 @@
+// Logger.swift
+// VocaMac
+//
+// System-wide logging framework with os.Logger integration,
+// persistent file logging, and automatic log rotation.
+
+import Foundation
+import os
+
+/// Log categories for different services and components
+enum LogCategory: String {
+    case appState = "AppState"
+    case audioEngine = "AudioEngine"
+    case whisperService = "WhisperService"
+    case hotKeyManager = "HotKeyManager"
+    case modelManager = "ModelManager"
+    case soundManager = "SoundManager"
+    case textInjector = "TextInjector"
+    case cursorOverlay = "CursorOverlay"
+    case onboarding = "Onboarding"
+    case general = "General"
+}
+
+/// Log levels for filtering and categorization
+enum LogLevel: String {
+    case debug = "DEBUG"
+    case info = "INFO"
+    case warning = "WARNING"
+    case error = "ERROR"
+}
+
+/// Unified logging framework for VocaMac
+/// Combines os.Logger (Console.app integration) with persistent file logging
+final class VocaLogger {
+    // MARK: - Singleton
+
+    static let shared = VocaLogger()
+
+    // MARK: - Properties
+
+    private let logDirectory: URL
+    private let logFileURL: URL
+    private let fileQueue = DispatchQueue(label: "com.vocamac.logger.file", attributes: .initiallyInactive)
+    private let osLogger: os.Logger
+    private var logFileHandle: FileHandle?
+    private let logMaxSize = 5_000_000  // 5 MB
+    private let maxRotatedFiles = 3
+    private var currentLogLevel: LogLevel = .info
+
+    // MARK: - Initialization
+
+    private init() {
+        // Setup log directory
+        let appSupportURL = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask)[0]
+        self.logDirectory = appSupportURL.appendingPathComponent("VocaMac/logs", isDirectory: true)
+
+        self.logFileURL = logDirectory.appendingPathComponent("vocamac.log")
+
+        // Ensure log directory exists
+        try? FileManager.default.createDirectory(at: logDirectory, withIntermediateDirectories: true, attributes: nil)
+
+        // Initialize os.Logger
+        self.osLogger = os.Logger(subsystem: "com.vocamac", category: "general")
+
+        // Activate file queue
+        fileQueue.activate()
+
+        // Open or create log file
+        fileQueue.async {
+            self.setupLogFile()
+        }
+    }
+
+    // MARK: - Public API
+
+    /// Set the global log level for file and console output
+    static func setLogLevel(_ level: LogLevel) {
+        VocaLogger.shared.currentLogLevel = level
+    }
+
+    /// Log a debug message
+    static func debug(_ category: LogCategory, _ message: String) {
+        VocaLogger.shared.log(message, level: .debug, category: category)
+    }
+
+    /// Log an info message
+    static func info(_ category: LogCategory, _ message: String) {
+        VocaLogger.shared.log(message, level: .info, category: category)
+    }
+
+    /// Log a warning message
+    static func warning(_ category: LogCategory, _ message: String) {
+        VocaLogger.shared.log(message, level: .warning, category: category)
+    }
+
+    /// Log an error message
+    static func error(_ category: LogCategory, _ message: String) {
+        VocaLogger.shared.log(message, level: .error, category: category)
+    }
+
+    /// Get the URL of the active log file
+    static func logFileURL() -> URL {
+        VocaLogger.shared.logFileURL
+    }
+
+    /// Get the log directory URL
+    static func logDirectory() -> URL {
+        VocaLogger.shared.logDirectory
+    }
+
+    /// Read the last N lines from the log file
+    static func readLastLines(_ count: Int = 500) -> [String] {
+        VocaLogger.shared.getLastLines(count)
+    }
+
+    /// Export logs as a formatted string with system info header
+    static func exportLogs(lastLines: Int = 500) -> String {
+        VocaLogger.shared.formatExportedLogs(lastLines: lastLines)
+    }
+
+    // MARK: - Private Methods
+
+    private func log(_ message: String, level: LogLevel, category: LogCategory) {
+        // Check log level filter
+        guard shouldLog(level: level) else { return }
+
+        // Format the log message
+        let timestamp = ISO8601DateFormatter().string(from: Date())
+        let formattedMessage = "[\(timestamp)] [\(level.rawValue)] [\(category.rawValue)] \(message)"
+
+        // Write to os.Logger
+        let osLogType: OSLogType = level == .error ? .error : (level == .warning ? .default : .info)
+        osLogger.log(level: osLogType, "\(formattedMessage)")
+
+        // Write to persistent file
+        fileQueue.async {
+            self.writeToFile(formattedMessage)
+        }
+    }
+
+    private func shouldLog(level: LogLevel) -> Bool {
+        switch (currentLogLevel, level) {
+        case (.debug, _):
+            return true
+        case (.info, .debug):
+            return false
+        case (.info, _):
+            return true
+        case (.warning, .debug), (.warning, .info):
+            return false
+        case (.warning, _):
+            return true
+        case (.error, .error):
+            return true
+        case (.error, _):
+            return false
+        }
+    }
+
+    private func setupLogFile() {
+        // Create file if it doesn't exist
+        if !FileManager.default.fileExists(atPath: logFileURL.path) {
+            FileManager.default.createFile(atPath: logFileURL.path, contents: nil, attributes: nil)
+        }
+
+        // Open file handle for appending
+        logFileHandle = FileHandle(forWritingAtPath: logFileURL.path)
+        if logFileHandle == nil {
+            logFileHandle = FileHandle(forWritingAtPath: logFileURL.path)
+        }
+        logFileHandle?.seekToEndOfFile()
+
+        // Check if rotation is needed
+        checkAndRotateIfNeeded()
+    }
+
+    private func writeToFile(_ message: String) {
+        guard let data = (message + "\n").data(using: .utf8) else { return }
+
+        if let handle = logFileHandle {
+            handle.write(data)
+            handle.synchronizeFile()
+        }
+
+        // Check if rotation is needed
+        checkAndRotateIfNeeded()
+    }
+
+    private func checkAndRotateIfNeeded() {
+        guard let attributes = try? FileManager.default.attributesOfItem(atPath: logFileURL.path),
+              let size = attributes[.size] as? Int else {
+            return
+        }
+
+        if size > logMaxSize {
+            performRotation()
+        }
+    }
+
+    private func performRotation() {
+        // Close current file handle
+        logFileHandle?.closeFile()
+        logFileHandle = nil
+
+        // Rotate existing log files
+        for i in stride(from: maxRotatedFiles - 1, through: 1, by: -1) {
+            let oldName = "vocamac.\(i).log"
+            let newName = "vocamac.\(i + 1).log"
+            let oldURL = logDirectory.appendingPathComponent(oldName)
+            let newURL = logDirectory.appendingPathComponent(newName)
+
+            if FileManager.default.fileExists(atPath: oldURL.path) {
+                try? FileManager.default.moveItem(at: oldURL, to: newURL)
+            }
+        }
+
+        // Move current log to vocamac.1.log
+        let rotatedURL = logDirectory.appendingPathComponent("vocamac.1.log")
+        try? FileManager.default.moveItem(at: logFileURL, to: rotatedURL)
+
+        // Remove oldest rotated file if it exceeds max count
+        let oldestURL = logDirectory.appendingPathComponent("vocamac.\(maxRotatedFiles + 1).log")
+        try? FileManager.default.removeItem(at: oldestURL)
+
+        // Setup new log file
+        setupLogFile()
+    }
+
+    private func getLastLines(_ count: Int) -> [String] {
+        var allLines: [String] = []
+
+        // Read current log file
+        if let currentContent = try? String(contentsOf: logFileURL, encoding: .utf8) {
+            allLines.append(contentsOf: currentContent.split(separator: "\n", omittingEmptySubsequences: false).map(String.init))
+        }
+
+        // Read rotated log files in reverse order (newest first)
+        for i in 1...maxRotatedFiles {
+            let rotatedURL = logDirectory.appendingPathComponent("vocamac.\(i).log")
+            if let content = try? String(contentsOf: rotatedURL, encoding: .utf8) {
+                allLines.insert(contentsOf: content.split(separator: "\n", omittingEmptySubsequences: false).map(String.init).reversed(), at: 0)
+            }
+        }
+
+        // Return last N lines
+        return Array(allLines.suffix(count))
+    }
+
+    private func formatExportedLogs(lastLines: Int = 500) -> String {
+        var result = ""
+
+        // Add system info header
+        result += "=== VocaMac Debug Log Export ===\n"
+        result += "Generated: \(ISO8601DateFormatter().string(from: Date()))\n"
+
+        // Add system information
+        let capabilities = SystemInfo.detect()
+        result += "Device: \(capabilities.processorName)\n"
+        result += "Architecture: \(capabilities.isAppleSilicon ? "Apple Silicon (ARM64)" : "Intel (x86_64)")\n"
+        result += "RAM: \(capabilities.physicalMemoryGB) GB\n"
+        result += "CPU Cores: \(capabilities.coreCount)\n"
+
+        // App version
+        if let appVersion = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String {
+            result += "App Version: \(appVersion)\n"
+        }
+
+        result += "================================\n\n"
+
+        // Add log lines
+        let lines = getLastLines(lastLines)
+        for line in lines {
+            if !line.isEmpty {
+                result += line + "\n"
+            }
+        }
+
+        return result
+    }
+}

--- a/Sources/VocaMac/Services/ModelManager.swift
+++ b/Sources/VocaMac/Services/ModelManager.swift
@@ -118,7 +118,7 @@ final class ModelManager {
         size: ModelSize,
         onProgress: @escaping (Double) -> Void
     ) async throws {
-        print("[ModelManager] Downloading model: \(whisperKitModelName(for: size))")
+        VocaLogger.info(.modelManager, "Downloading model: \(whisperKitModelName(for: size))")
 
         // Ensure download directory exists
         try FileManager.default.createDirectory(
@@ -165,7 +165,7 @@ final class ModelManager {
             // before we send the final progress update
             try? await Task.sleep(nanoseconds: 50_000_000)  // 50ms
             onProgress(1.0)
-            print("[ModelManager] Model '\(whisperKitModelName(for: size))' downloaded successfully")
+            VocaLogger.info(.modelManager, "Model '\(whisperKitModelName(for: size))' downloaded successfully")
         } catch {
             throw ModelManagerError.downloadFailed(reason: error.localizedDescription)
         }
@@ -175,7 +175,7 @@ final class ModelManager {
     func cancelDownload(for size: ModelSize) {
         // WhisperKit manages downloads internally via URLSession
         // For MVP, we rely on task cancellation at the caller level
-        print("[ModelManager] Download cancellation requested for \(size.displayName)")
+        VocaLogger.info(.modelManager, "Download cancellation requested for \(size.displayName)")
     }
 
     // MARK: - Model Deletion
@@ -187,7 +187,7 @@ final class ModelManager {
 
         if FileManager.default.fileExists(atPath: modelDir.path) {
             try FileManager.default.removeItem(at: modelDir)
-            print("[ModelManager] Deleted model: \(modelName)")
+            VocaLogger.info(.modelManager, "Deleted model: \(modelName)")
         }
     }
 

--- a/Sources/VocaMac/Services/SoundManager.swift
+++ b/Sources/VocaMac/Services/SoundManager.swift
@@ -60,7 +60,7 @@ final class SoundManager: NSObject, NSSoundDelegate, @unchecked Sendable {
     private func playSystemSound(_ name: String) {
         let soundPath = "/System/Library/Sounds/\(name).aiff"
         guard let sound = NSSound(contentsOfFile: soundPath, byReference: true) else {
-            NSLog("[SoundManager] Could not load system sound: %@", name)
+            VocaLogger.warning(.soundManager, "Could not load system sound: \(name)")
             return
         }
         sound.volume = volume

--- a/Sources/VocaMac/Services/TextInjector.swift
+++ b/Sources/VocaMac/Services/TextInjector.swift
@@ -41,10 +41,10 @@ final class TextInjector {
 
         // Check accessibility permission
         let trusted = AXIsProcessTrusted()
-        NSLog("[TextInjector] AXIsProcessTrusted = %@", trusted ? "YES" : "NO")
+        VocaLogger.debug(.textInjector, "AXIsProcessTrusted = \(trusted ? "YES" : "NO")")
 
         if !trusted {
-            NSLog("[TextInjector] No accessibility permission. Copying to clipboard only.")
+            VocaLogger.warning(.textInjector, "No accessibility permission. Copying to clipboard only.")
             let pasteboard = NSPasteboard.general
             pasteboard.clearContents()
             pasteboard.setString(text, forType: .string)
@@ -61,11 +61,11 @@ final class TextInjector {
         // Set transcribed text to clipboard
         pasteboard.clearContents()
         pasteboard.setString(text, forType: .string)
-        NSLog("[TextInjector] Set clipboard with %ld characters", text.count)
+        VocaLogger.debug(.textInjector, "Set clipboard: '\(String(text.prefix(80)))'")
 
         // Delay to let clipboard settle, then simulate Cmd+V
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) { [self] in
-            NSLog("[TextInjector] Simulating Cmd+V...")
+            VocaLogger.debug(.textInjector, "Simulating Cmd+V...")
             simulatePaste()
 
             // Restore clipboard after paste completes
@@ -77,7 +77,7 @@ final class TextInjector {
                         // Previous clipboard was empty; clear the transcribed text
                         pasteboard.clearContents()
                     }
-                    NSLog("[TextInjector] Clipboard restored")
+                    VocaLogger.debug(.textInjector, "Clipboard restored")
                 }
             }
         }
@@ -125,7 +125,7 @@ final class TextInjector {
         }
 
         pasteboard.writeObjects(newItems)
-        NSLog("[TextInjector] Restored clipboard with %ld items", newItems.count)
+        VocaLogger.debug(.textInjector, "Restored clipboard with \(newItems.count) items")
     }
 
     // MARK: - Paste Simulation
@@ -136,7 +136,7 @@ final class TextInjector {
 
         // Cmd+V key down
         guard let keyDown = CGEvent(keyboardEventSource: source, virtualKey: kVK_V, keyDown: true) else {
-            NSLog("[TextInjector] ERROR: Failed to create key down event")
+            VocaLogger.error(.textInjector, "ERROR: Failed to create key down event")
             return
         }
         keyDown.flags = [.maskCommand]
@@ -144,12 +144,12 @@ final class TextInjector {
 
         // Cmd+V key up
         guard let keyUp = CGEvent(keyboardEventSource: source, virtualKey: kVK_V, keyDown: false) else {
-            NSLog("[TextInjector] ERROR: Failed to create key up event")
+            VocaLogger.error(.textInjector, "ERROR: Failed to create key up event")
             return
         }
         keyUp.flags = [.maskCommand]
         keyUp.post(tap: .cgAnnotatedSessionEventTap)
 
-        NSLog("[TextInjector] Cmd+V posted")
+        VocaLogger.info(.textInjector, "Cmd+V posted")
     }
 }

--- a/Sources/VocaMac/Services/WhisperService.swift
+++ b/Sources/VocaMac/Services/WhisperService.swift
@@ -64,7 +64,7 @@ final class WhisperService: @unchecked Sendable {
         unloadModel()
 
         let displayName = modelName ?? "auto-detect"
-        print("[WhisperService] Loading model: \(displayName)...")
+        VocaLogger.info(.whisperService, "Loading model: \(displayName)...")
         let startTime = CFAbsoluteTimeGetCurrent()
 
         do {
@@ -95,9 +95,9 @@ final class WhisperService: @unchecked Sendable {
             self.loadedModelName = modelName ?? kit.modelVariant.description
 
             let elapsed = CFAbsoluteTimeGetCurrent() - startTime
-            print("[WhisperService] Model loaded in \(String(format: "%.2f", elapsed))s")
+            VocaLogger.info(.whisperService, "Model loaded in \(String(format: "%.2f", elapsed))s")
         } catch {
-            print("[WhisperService] ERROR loading model: \(error)")
+            VocaLogger.error(.whisperService, "ERROR loading model: \(error)")
             throw WhisperError.initializationFailed(reason: error.localizedDescription)
         }
     }
@@ -107,7 +107,7 @@ final class WhisperService: @unchecked Sendable {
         if whisperKit != nil {
             whisperKit = nil
             loadedModelName = nil
-            print("[WhisperService] Model unloaded")
+            VocaLogger.info(.whisperService, "Model unloaded")
         }
     }
 
@@ -133,7 +133,7 @@ final class WhisperService: @unchecked Sendable {
         }
 
         let audioLengthSeconds = Double(audioData.count) / 16000.0
-        print("[WhisperService] Transcribing \(String(format: "%.1f", audioLengthSeconds))s of audio...")
+        VocaLogger.info(.whisperService, "Transcribing \(String(format: "%.1f", audioLengthSeconds))s of audio...")
 
         let startTime = CFAbsoluteTimeGetCurrent()
 
@@ -165,8 +165,8 @@ final class WhisperService: @unchecked Sendable {
 
             let modelUsed = modelSizeFromName(loadedModelName ?? "tiny")
 
-            print("[WhisperService] Transcription completed in \(String(format: "%.2f", elapsed))s")
-            print("[WhisperService] Transcribed \(fullText.count) characters")
+            VocaLogger.info(.whisperService, "Transcription completed in \(String(format: "%.2f", elapsed))s")
+            VocaLogger.info(.whisperService, "Result: \(fullText.prefix(100))...")
 
             return VocaTranscription(
                 text: fullText,

--- a/Sources/VocaMac/Views/SettingsView.swift
+++ b/Sources/VocaMac/Views/SettingsView.swift
@@ -632,6 +632,7 @@ struct AudioSettingsTab: View {
 
 struct AboutTab: View {
     @EnvironmentObject var appState: AppState
+    @State private var showingExportSuccess = false
 
     var body: some View {
         VStack(spacing: 16) {
@@ -694,6 +695,31 @@ struct AboutTab: View {
             }
             .font(.caption)
 
+            Divider()
+                .frame(width: 200)
+
+            // Debug logs section
+            VStack(spacing: 8) {
+                Text("Debug Logs")
+                    .font(.caption)
+                    .fontWeight(.semibold)
+                    .foregroundStyle(.secondary)
+
+                HStack(spacing: 8) {
+                    Button(action: copyDebugLogs) {
+                        Label("Copy", systemImage: "doc.on.clipboard")
+                            .font(.caption)
+                    }
+                    .help("Copy last 500 lines of logs to clipboard")
+
+                    Button(action: exportDebugLogs) {
+                        Label("Export", systemImage: "arrow.down.doc")
+                            .font(.caption)
+                    }
+                    .help("Save debug logs to file and reveal in Finder")
+                }
+            }
+
             Spacer()
 
             HStack(spacing: 0) {
@@ -707,6 +733,36 @@ struct AboutTab: View {
         }
         .frame(maxWidth: .infinity)
         .padding()
+    }
+
+    // MARK: - Debug Log Actions
+
+    private func copyDebugLogs() {
+        let logs = VocaLogger.exportLogs(lastLines: 500)
+        let pasteboard = NSPasteboard.general
+        pasteboard.clearContents()
+        pasteboard.setString(logs, forType: .string)
+    }
+
+    private func exportDebugLogs() {
+        let logs = VocaLogger.exportLogs(lastLines: 1000)
+
+        // Create save panel
+        let savePanel = NSSavePanel()
+        savePanel.allowedContentTypes = [.plainText]
+        savePanel.nameFieldStringValue = "VocaMac-Debug-\(ISO8601DateFormatter().string(from: Date()).prefix(19)).log"
+        savePanel.directoryURL = FileManager.default.homeDirectoryForCurrentUser
+
+        savePanel.begin { response in
+            if response == .OK, let fileURL = savePanel.url {
+                do {
+                    try logs.write(to: fileURL, atomically: true, encoding: .utf8)
+                    NSWorkspace.shared.selectFile(fileURL.path, inFileViewerRootedAtPath: fileURL.deletingLastPathComponent().path)
+                } catch {
+                    VocaLogger.error(.general, "Failed to export logs: \(error)")
+                }
+            }
+        }
     }
 }
 


### PR DESCRIPTION
## Summary
Replaces ad-hoc print()/NSLog() logging with a unified VocaLogger framework.

## Changes
- New VocaLogger service with os.Logger integration + persistent file logging
- Automatic log rotation (5MB cap, 3 rotated files)
- Log categories per service (AudioEngine, WhisperService, etc.)
- Log levels: debug, info, warning, error
- Migrated ALL existing print()/NSLog() calls across all services
- Export/Copy Debug Logs buttons in Settings → About
- System info header in exported logs
- Configurable log level via AppStorage
- Persistent logs at ~/Library/Application Support/VocaMac/logs/vocamac.log

Closes #36