### PR TITLE
chore: bump version to v0.2.0

### DIFF
--- a/Sources/VocaMac/Views/SettingsView.swift
+++ b/Sources/VocaMac/Views/SettingsView.swift
@@ -654,7 +654,7 @@ struct AboutTab: View {
                 .multilineTextAlignment(.center)
                 .fixedSize(horizontal: false, vertical: true)
 
-            Text("Version 0.1.0 (Alpha)")
+            Text("Version 0.2.0 (Alpha)")
                 .font(.caption)
                 .foregroundStyle(.tertiary)
 

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -24,7 +24,10 @@ Pre-release versions use suffixes: `v0.1.0-alpha`, `v0.1.0-beta.1`
 
 1. **Ensure all PRs are merged** into `main`
 2. **Verify CI passes** on the latest `main` commit
-3. **Update version number** in `scripts/build.sh` (both `CFBundleVersion` and `CFBundleShortVersionString`)
+3. **Update version number** in all locations:
+   - `scripts/build.sh` — both `CFBundleVersion` and `CFBundleShortVersionString` in the Info.plist template
+   - `Sources/VocaMac/Views/SettingsView.swift` — version label in the About tab
+   - `web/index.html` — `softwareVersion` in JSON-LD schema and hero version badge
 4. **Test locally**:
    ```bash
    ./scripts/build.sh release
@@ -44,15 +47,15 @@ Pre-release versions use suffixes: `v0.1.0-alpha`, `v0.1.0-beta.1`
 
 1. **Tag the release**:
    ```bash
-   git tag -a v0.1.0 -m "VocaMac v0.1.0 - Alpha Release"
-   git push origin v0.1.0
+   git tag -a v0.2.0 -m "VocaMac v0.2.0"
+   git push origin v0.2.0
    ```
 
 2. **GitHub Actions automatically**:
    - Builds the release binary
    - Creates `VocaMac.app` bundle with ad-hoc signing
-   - Packages as DMG (`VocaMac-0.1.0-arm64.dmg`)
-   - Packages as ZIP (`VocaMac-0.1.0-arm64.zip`)
+   - Packages as DMG (`VocaMac-0.2.0-arm64.dmg`)
+   - Packages as ZIP (`VocaMac-0.2.0-arm64.zip`)
    - Generates SHA-256 checksums
    - Creates a **draft** GitHub Release with all artifacts
 
@@ -132,10 +135,10 @@ If you need to create a release locally:
 mkdir -p dmg-staging
 cp -R VocaMac.app dmg-staging/
 ln -s /Applications dmg-staging/Applications
-hdiutil create -volname "VocaMac" -srcfolder dmg-staging -ov -format UDZO "VocaMac-0.1.0-arm64.dmg"
+hdiutil create -volname "VocaMac" -srcfolder dmg-staging -ov -format UDZO "VocaMac-0.2.0-arm64.dmg"
 
 # Create ZIP
-ditto -c -k --sequesterRsrc --keepParent VocaMac.app "VocaMac-0.1.0-arm64.zip"
+ditto -c -k --sequesterRsrc --keepParent VocaMac.app "VocaMac-0.2.0-arm64.zip"
 
 # Generate checksums
 shasum -a 256 VocaMac-*.dmg VocaMac-*.zip > checksums.txt
@@ -147,7 +150,7 @@ Then upload the artifacts manually to the GitHub Release page.
 
 For critical bugs in a released version:
 
-1. Create a branch from the release tag: `git checkout -b fix/critical-bug v0.1.0`
+1. Create a branch from the release tag: `git checkout -b fix/critical-bug v0.2.0`
 2. Fix the bug, commit, push
 3. Create a PR to `main`
 4. After merge, tag a patch release: `v0.1.1`

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -122,9 +122,9 @@ cat > "${APP_DIR}/Contents/Info.plist" << EOF
     <key>CFBundleDisplayName</key>
     <string>${APP_NAME}</string>
     <key>CFBundleVersion</key>
-    <string>0.1.0</string>
+    <string>0.2.0</string>
     <key>CFBundleShortVersionString</key>
-    <string>0.1.0</string>
+    <string>0.2.0</string>
     <key>CFBundlePackageType</key>
     <string>APPL</string>
     <key>LSMinimumSystemVersion</key>

--- a/web/index.html
+++ b/web/index.html
@@ -72,7 +72,7 @@
             "Open source (MIT license)"
         ],
         "screenshot": "https://vocamac.com/og-image.png",
-        "softwareVersion": "0.1.0",
+        "softwareVersion": "0.2.0",
         "softwareRequirements": "macOS 13 (Ventura) or later, Xcode 15+ or Swift 5.9+ toolchain, 8 GB RAM minimum"
     }
     </script>
@@ -120,7 +120,7 @@
             <div class="hero__content">
                 <div class="hero__badges">
                     <span class="badge badge--alpha">ALPHA RELEASE</span>
-                    <span class="badge badge--outline" id="version-badge">v0.1.1</span>
+                    <span class="badge badge--outline" id="version-badge">v0.2.0</span>
                 </div>
                 <h1 class="hero__headline">
                     Your Voice,<br>


### PR DESCRIPTION
## Release v0.2.0

Bumps version from v0.1.1 → v0.2.0 across all version references.

### Files Changed
- `scripts/build.sh` — CFBundleVersion & CFBundleShortVersionString → 0.2.0
- `web/index.html` — softwareVersion & version badge → v0.2.0
- `docs/RELEASE.md` — example commands & artifact names updated

### What's New in v0.2.0 (since v0.1.1)

#### ✨ New Features
- **First-launch onboarding flow** — guided setup for new users (#55, closes #22)
- **System-wide logging framework** — with log rotation and export support (#54, closes #36)
- **Translation toggle** — switch between Whisper translate vs transcribe modes (#53, closes #50)

#### 🐛 Bug Fixes
- **Prevent sound effects from bleeding into transcription** (#52, closes #49)
- **Remove sensitive data from logs** (#51)

#### 🌐 Website & SEO
- **Tabbed DMG/Source install section** with mobile fixes (#47)
- **Improved meta tags** — OG image, Twitter cards, and JSON-LD (#46)

#### 🔧 CI/CD
- **Add `xcodebuild -runFirstLaunch`** for actool support in CI (#45)

### Release Process
After this PR is merged:
1. Tag the release: `git tag -a v0.2.0 -m "VocaMac v0.2.0" && git push origin v0.2.0`
2. GitHub Actions will build the release artifacts (DMG, ZIP, checksums)
3. Review and publish the draft release on GitHub
