### PR TITLE
v0.2.0: Settings overhaul, Debug tab, onboarding improvements, and bug fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,10 @@ Package.resolved
 # Built app bundle
 VocaMac.app/
 
+# DMG build artifacts
+*.dmg
+dmg-staging*/
+
 # Legacy stubs
 Sources/CWhisper/
 VocaMac.iconset/

--- a/README.md
+++ b/README.md
@@ -368,9 +368,27 @@ Each platform uses native technologies for the best possible integration, while 
 
 ## ⚠️ Known Limitations
 
-- **Ad-hoc code signing** - Accessibility and Input Monitoring permissions reset on every rebuild. Re-grant them after each build.
-- **First launch requires internet** - WhisperKit downloads the speech recognition model on first run. All subsequent launches work fully offline.
-- **macOS only** - Requires macOS 13 (Ventura) or later.
+- **Permissions reset on rebuild** — Accessibility and Input Monitoring permissions reset on every rebuild (see below).
+- **First launch requires internet** — WhisperKit downloads the speech recognition model on first run. All subsequent launches work fully offline.
+- **macOS only** — Requires macOS 13 (Ventura) or later.
+
+### Why Do Permissions Reset on Every Rebuild?
+
+macOS tracks Accessibility and Input Monitoring permissions using the app's **CDHash** (a cryptographic hash of the code signature), not the bundle identifier. When you rebuild VocaMac with ad-hoc signing (`codesign --sign -`), the binary changes, producing a new CDHash — so macOS treats it as a completely new, untrusted app.
+
+This is **not a bug** — it's macOS security by design, preventing modified apps from inheriting sensitive permissions. All open-source macOS apps that use Accessibility (Rectangle, Maccy, AltTab, etc.) have the same limitation.
+
+**Why Microphone permission persists:** Microphone access uses AVFoundation's framework-level preference cache with relaxed verification, unlike the strict CDHash checks for Accessibility and Input Monitoring.
+
+**Workarounds:**
+
+| Approach | How | Permissions Persist |
+|---|---|---|
+| **Re-grant manually** | System Settings → Privacy & Security after each rebuild | Per rebuild |
+| **Run from Terminal** | Grant permissions to Terminal.app once, then run `make run` or `.build/arm64-apple-macosx/release/VocaMac` | ✅ Always |
+| **Developer ID signing** | Requires Apple Developer Program ($99/year) — planned for future releases | ✅ Always |
+
+> **💡 Developer tip:** Add your Terminal app (Terminal.app or iTerm2) to both Accessibility and Input Monitoring in System Settings. Then run VocaMac directly from Terminal — permissions are inherited and never reset.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -341,6 +341,14 @@ Then relaunch VocaMac. This only clears the onboarding state — all other prefe
 defaults delete com.vocamac.app
 ```
 
+**Reset permissions after updating:** When updating VocaMac to a newer version, it's recommended to reset permissions first so the new binary gets a clean grant. You can do this from **Settings → Debug → Reset All Permissions**, or manually via Terminal:
+
+```bash
+tccutil reset All com.vocamac.app
+```
+
+This clears all permission entries (Microphone, Accessibility, Input Monitoring) for VocaMac. On next launch, macOS will prompt you to re-grant them for the new version. This avoids stale permission entries that point to an old binary's CDHash.
+
 ---
 
 
@@ -384,6 +392,7 @@ This is **not a bug** — it's macOS security by design, preventing modified app
 
 | Approach | How | Permissions Persist |
 |---|---|---|
+| **Reset permissions on update** | Settings → Debug → Reset All Permissions (or `tccutil reset All com.vocamac.app`) | Recommended before each update |
 | **Re-grant manually** | System Settings → Privacy & Security after each rebuild | Per rebuild |
 | **Run from Terminal** | Grant permissions to Terminal.app once, then run `make run` or `.build/arm64-apple-macosx/release/VocaMac` | ✅ Always |
 | **Developer ID signing** | Requires Apple Developer Program ($99/year) — planned for future releases | ✅ Always |

--- a/README.md
+++ b/README.md
@@ -243,7 +243,7 @@ VocaMacApp (SwiftUI MenuBarExtra)
 ├── SoundManager      - Audio feedback (start/stop recording cues)
 ├── TextInjector      - Clipboard + Cmd+V text injection
 ├── MenuBarView       - Status popover UI
-└── SettingsView      - Configuration tabs (General, Models, Audio, About)
+└── SettingsView      - Configuration tabs (General, Models, Audio, Debug, About)
 ```
 
 For detailed documentation, see:
@@ -270,7 +270,7 @@ VocaMac/
 │       │   └── VocaMacApp.swift    # Entry point, MenuBarExtra
 │       ├── Views/
 │       │   ├── MenuBarView.swift   # Menu bar popover
-│       │   └── SettingsView.swift  # Settings window (4 tabs)
+│       │   └── SettingsView.swift  # Settings window (5 tabs)
 │       ├── Services/
 │       │   ├── AudioEngine.swift   # AVAudioEngine mic capture
 │       │   ├── HotKeyManager.swift # CGEventTap global hotkeys
@@ -323,6 +323,22 @@ Use `--keep-build` to preserve build artifacts:
 
 ```bash
 ./scripts/uninstall.sh --keep-build
+```
+
+### Troubleshooting
+
+**Reset onboarding:** To re-trigger the first-launch onboarding wizard (e.g., after an upgrade or for testing), reset the onboarding flag:
+
+```bash
+defaults delete com.vocamac.app vocamac.hasCompletedOnboarding
+```
+
+Then relaunch VocaMac. This only clears the onboarding state — all other preferences (hotkey, language, model) are preserved.
+
+**Reset all preferences:** To start completely fresh:
+
+```bash
+defaults delete com.vocamac.app
 ```
 
 ---

--- a/Sources/VocaMac/App/VocaMacApp.swift
+++ b/Sources/VocaMac/App/VocaMacApp.swift
@@ -167,6 +167,13 @@ struct VocaMacApp: App {
         ) { [self] _ in
             self.onboardingManager.open(appState: self.appState, force: true)
         }
+
+        // Show onboarding on first launch
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) { [self] in
+            if !self.appState.hasCompletedOnboarding {
+                self.onboardingManager.open(appState: self.appState)
+            }
+        }
     }
 
     /// Terminate any other running instances of VocaMac

--- a/Sources/VocaMac/App/VocaMacApp.swift
+++ b/Sources/VocaMac/App/VocaMacApp.swift
@@ -151,6 +151,15 @@ struct VocaMacApp: App {
         DispatchQueue.main.async {
             NSApp?.setActivationPolicy(.accessory)
         }
+
+        // Listen for "Show Setup Wizard" requests from Settings
+        NotificationCenter.default.addObserver(
+            forName: .showOnboarding,
+            object: nil,
+            queue: .main
+        ) { [self] _ in
+            self.onboardingManager.open(appState: self.appState)
+        }
     }
 
     /// Terminate any other running instances of VocaMac

--- a/Sources/VocaMac/App/VocaMacApp.swift
+++ b/Sources/VocaMac/App/VocaMacApp.swift
@@ -82,7 +82,7 @@ final class OnboardingWindowManager: ObservableObject {
 
         // Create a new window
         let window = NSWindow(
-            contentRect: NSRect(x: 0, y: 0, width: 600, height: 550),
+            contentRect: NSRect(x: 0, y: 0, width: 600, height: 620),
             styleMask: [.titled, .closable],
             backing: .buffered,
             defer: false

--- a/Sources/VocaMac/App/VocaMacApp.swift
+++ b/Sources/VocaMac/App/VocaMacApp.swift
@@ -57,16 +57,23 @@ final class SettingsWindowManager: ObservableObject {
 }
 
 /// Manages the onboarding window
+@MainActor
 final class OnboardingWindowManager: ObservableObject {
     private var onboardingWindow: NSWindow?
     var onCompletion: (() -> Void)?
 
-    func open(appState: AppState) {
+    func open(appState: AppState, force: Bool = false) {
         // If window already exists, just bring it to front
         if let window = onboardingWindow, window.isVisible {
             window.makeKeyAndOrderFront(nil)
             NSApp.activate(ignoringOtherApps: true)
             return
+        }
+
+        // When manually re-triggered, reset completion flag so the
+        // monitor doesn't immediately close the window
+        if force {
+            appState.hasCompletedOnboarding = false
         }
 
         // Create the onboarding view
@@ -152,13 +159,13 @@ struct VocaMacApp: App {
             NSApp?.setActivationPolicy(.accessory)
         }
 
-        // Listen for "Show Setup Wizard" requests from Settings
+        // Listen for "Show Setup Wizard" requests from Settings / Menu Bar
         NotificationCenter.default.addObserver(
             forName: .showOnboarding,
             object: nil,
             queue: .main
         ) { [self] _ in
-            self.onboardingManager.open(appState: self.appState)
+            self.onboardingManager.open(appState: self.appState, force: true)
         }
     }
 

--- a/Sources/VocaMac/App/VocaMacApp.swift
+++ b/Sources/VocaMac/App/VocaMacApp.swift
@@ -82,7 +82,7 @@ final class OnboardingWindowManager: ObservableObject {
 
         // Create a new window
         let window = NSWindow(
-            contentRect: NSRect(x: 0, y: 0, width: 600, height: 680),
+            contentRect: NSRect(x: 0, y: 0, width: 600, height: 580),
             styleMask: [.titled, .closable],
             backing: .buffered,
             defer: false

--- a/Sources/VocaMac/App/VocaMacApp.swift
+++ b/Sources/VocaMac/App/VocaMacApp.swift
@@ -82,7 +82,7 @@ final class OnboardingWindowManager: ObservableObject {
 
         // Create a new window
         let window = NSWindow(
-            contentRect: NSRect(x: 0, y: 0, width: 600, height: 620),
+            contentRect: NSRect(x: 0, y: 0, width: 600, height: 680),
             styleMask: [.titled, .closable],
             backing: .buffered,
             defer: false

--- a/Sources/VocaMac/Models/AppState.swift
+++ b/Sources/VocaMac/Models/AppState.swift
@@ -404,12 +404,26 @@ final class AppState: ObservableObject {
         // Mark the model as loading
         if let size = size, let idx = availableModels.firstIndex(where: { $0.size == size }) {
             availableModels[idx].isLoading = true
+            availableModels[idx].loadingStatus = "Preparing…"
         }
 
         do {
             // If model is downloaded locally, use the local folder
             let folder = size.flatMap { modelManager.modelFolder(for: $0) }
-            try await whisperService.loadModel(name: modelName, folder: folder)
+
+            // Update status: unpacking
+            if let size = size, let idx = availableModels.firstIndex(where: { $0.size == size }) {
+                availableModels[idx].loadingStatus = "Unpacking model…"
+            }
+
+            // Load model with status callback
+            try await whisperService.loadModel(name: modelName, folder: folder) { [weak self] phase in
+                Task { @MainActor in
+                    guard let self = self, let size = size,
+                          let idx = self.availableModels.firstIndex(where: { $0.size == size }) else { return }
+                    self.availableModels[idx].loadingStatus = phase
+                }
+            }
 
             if let size = size {
                 selectedModelSize = size.rawValue

--- a/Sources/VocaMac/Models/AppState.swift
+++ b/Sources/VocaMac/Models/AppState.swift
@@ -513,9 +513,15 @@ final class AppState: ObservableObject {
             requestMicrophonePermission()
         }
 
-        // 3. Load model — let WhisperKit auto-select and download the best model
-        VocaLogger.info(.appState, "Loading WhisperKit model (auto-select)...")
-        await loadModel()
+        // 3. Load the user's preferred model (or auto-select on first launch)
+        if let preferredSize = ModelSize(rawValue: selectedModelSize),
+           modelManager.isModelDownloaded(preferredSize) {
+            VocaLogger.info(.appState, "Loading preferred model: \(preferredSize.displayName)...")
+            await loadModel(preferredSize)
+        } else {
+            VocaLogger.info(.appState, "Loading WhisperKit model (auto-select)...")
+            await loadModel()
+        }
         NSLog("[AppState] Model loaded: %@", whisperService.loadedModelName ?? "none")
 
         // 4. Always attempt to start hotkey listener

--- a/Sources/VocaMac/Models/WhisperModel.swift
+++ b/Sources/VocaMac/Models/WhisperModel.swift
@@ -105,12 +105,15 @@ struct WhisperModelInfo: Identifiable {
     /// Whether this model is currently being loaded into memory
     var isLoading: Bool = false
 
+    /// Descriptive loading phase (e.g., "Preparing…", "Compiling…")
+    var loadingStatus: String = "Loading…"
+
     var id: String { size.id }
 
     /// Human-readable status description
     var statusDescription: String {
         if isActive { return "Active" }
-        if isLoading { return "Loading..." }
+        if isLoading { return loadingStatus }
         if let progress = downloadProgress {
             return "Downloading (\(Int(progress * 100))%)"
         }

--- a/Sources/VocaMac/Services/Logger.swift
+++ b/Sources/VocaMac/Services/Logger.swift
@@ -116,6 +116,12 @@ final class VocaLogger {
         return content.components(separatedBy: "\n").filter { !$0.isEmpty }.count
     }
 
+    /// Clear all log entries from the current log file
+    static func clearLogs() {
+        try? "".write(to: VocaLogger.shared.logFileURL, atomically: true, encoding: .utf8)
+        VocaLogger.info(.general, "Logs cleared")
+    }
+
     /// Read the last N lines from the log file
     static func readLastLines(_ count: Int = 500) -> [String] {
         VocaLogger.shared.getLastLines(count)

--- a/Sources/VocaMac/Services/Logger.swift
+++ b/Sources/VocaMac/Services/Logger.swift
@@ -108,6 +108,14 @@ final class VocaLogger {
         VocaLogger.shared.logDirectory
     }
 
+    /// Get the approximate number of log entries in the current log file
+    static var logEntryCount: Int {
+        guard let content = try? String(contentsOf: VocaLogger.shared.logFileURL, encoding: .utf8) else {
+            return 0
+        }
+        return content.components(separatedBy: "\n").filter { !$0.isEmpty }.count
+    }
+
     /// Read the last N lines from the log file
     static func readLastLines(_ count: Int = 500) -> [String] {
         VocaLogger.shared.getLastLines(count)

--- a/Sources/VocaMac/Services/WhisperService.swift
+++ b/Sources/VocaMac/Services/WhisperService.swift
@@ -75,6 +75,16 @@ final class WhisperService: @unchecked Sendable {
                 config.model = name
             }
 
+            // Store models in Application Support, not the default ~/Documents
+            // path, to avoid triggering a Documents folder permission prompt.
+            let appSupport = FileManager.default.urls(
+                for: .applicationSupportDirectory,
+                in: .userDomainMask
+            ).first!
+            config.downloadBase = appSupport
+                .appendingPathComponent("VocaMac")
+                .appendingPathComponent("models")
+
             // Verbose logging for debugging
             config.verbose = true
 

--- a/Sources/VocaMac/Services/WhisperService.swift
+++ b/Sources/VocaMac/Services/WhisperService.swift
@@ -59,7 +59,11 @@ final class WhisperService: @unchecked Sendable {
     /// - Parameters:
     ///   - modelName: The model variant to load (e.g., "openai_whisper-tiny"), or nil for auto-select
     ///   - modelFolder: Optional local folder containing pre-downloaded models
-    func loadModel(name modelName: String? = nil, folder modelFolder: URL? = nil) async throws {
+    func loadModel(
+        name modelName: String? = nil,
+        folder modelFolder: URL? = nil,
+        onPhaseChange: ((String) -> Void)? = nil
+    ) async throws {
         // Unload any existing model
         unloadModel()
 
@@ -68,6 +72,7 @@ final class WhisperService: @unchecked Sendable {
         let startTime = CFAbsoluteTimeGetCurrent()
 
         do {
+            onPhaseChange?("Configuring…")
             let config = WhisperKitConfig()
 
             // Set model if specified, otherwise WhisperKit auto-selects
@@ -100,7 +105,10 @@ final class WhisperService: @unchecked Sendable {
                 config.download = false
             }
 
+            onPhaseChange?("Loading model…")
             let kit = try await WhisperKit(config)
+
+            onPhaseChange?("Compiling neural engine…")
             self.whisperKit = kit
             self.loadedModelName = modelName ?? kit.modelVariant.description
 

--- a/Sources/VocaMac/Views/MenuBarView.swift
+++ b/Sources/VocaMac/Views/MenuBarView.swift
@@ -337,6 +337,26 @@ struct MenuBarView: View {
             .buttonStyle(MenuRowButtonStyle())
 
             Button {
+                NotificationCenter.default.post(name: .showOnboarding, object: nil)
+            } label: {
+                HStack {
+                    Image(systemName: "wand.and.stars")
+                    Text("Setup Wizard")
+                    Spacer()
+                }
+                .font(.body)
+                .padding(.vertical, 6)
+                .padding(.horizontal, 8)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .contentShape(Rectangle())
+                .background(
+                    RoundedRectangle(cornerRadius: 6)
+                        .fill(Color.primary.opacity(0.0001))
+                )
+            }
+            .buttonStyle(MenuRowButtonStyle())
+
+            Button {
                 NSApplication.shared.terminate(nil)
             } label: {
                 HStack {

--- a/Sources/VocaMac/Views/OnboardingView.swift
+++ b/Sources/VocaMac/Views/OnboardingView.swift
@@ -461,6 +461,14 @@ struct ModelSelectionCard: View {
                             .font(.caption2)
                             .foregroundStyle(.secondary)
                     }
+                } else if modelInfo.isLoading {
+                    HStack(spacing: 8) {
+                        ProgressView()
+                            .controlSize(.small)
+                        Text("Loading model…")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
                 } else if modelInfo.isDownloaded {
                     if modelInfo.isActive {
                         Label("Active", systemImage: "checkmark.circle.fill")

--- a/Sources/VocaMac/Views/OnboardingView.swift
+++ b/Sources/VocaMac/Views/OnboardingView.swift
@@ -465,7 +465,7 @@ struct ModelSelectionCard: View {
                     HStack(spacing: 8) {
                         ProgressView()
                             .controlSize(.small)
-                        Text("Loading model…")
+                        Text(modelInfo.loadingStatus)
                             .font(.caption)
                             .foregroundStyle(.secondary)
                     }

--- a/Sources/VocaMac/Views/OnboardingView.swift
+++ b/Sources/VocaMac/Views/OnboardingView.swift
@@ -295,6 +295,7 @@ struct OnboardingPermissionRow: View {
                             .foregroundStyle(.white)
                             .cornerRadius(6)
                     }
+                    .buttonStyle(.plain)
                 }
             }
         }
@@ -325,12 +326,13 @@ struct ModelSelectionStep: View {
                 .frame(maxWidth: .infinity, alignment: .leading)
                 .padding(.horizontal)
 
-            if let recommended = appState.systemCapabilities?.recommendedModel {
+            if let recommended = appState.deviceRecommendedModel,
+               let recommendedSize = ModelSize.allCases.first(where: { recommended.contains($0.rawValue) }) {
                 HStack(spacing: 12) {
                     Image(systemName: "lightbulb.fill")
                         .font(.caption)
                         .foregroundStyle(.orange)
-                    Text("We recommend: **\(recommended.displayName)**")
+                    Text("We recommend: **\(recommendedSize.displayName)**")
                         .font(.caption)
                         .foregroundStyle(.secondary)
                     Spacer()
@@ -343,7 +345,7 @@ struct ModelSelectionStep: View {
                     ForEach(appState.availableModels) { modelInfo in
                         ModelSelectionCard(
                             modelInfo: modelInfo,
-                            isRecommended: modelInfo.size == appState.systemCapabilities?.recommendedModel,
+                            isRecommended: appState.deviceRecommendedModel?.contains(modelInfo.size.rawValue) == true,
                             onSelect: {
                                 Task {
                                     await appState.loadModel(modelInfo.size)
@@ -452,6 +454,7 @@ struct ModelSelectionCard: View {
                                 .foregroundStyle(.white)
                                 .cornerRadius(6)
                         }
+                        .buttonStyle(.plain)
                     }
                 } else if !modelInfo.isSupported {
                     Text("Not supported on this device")
@@ -470,6 +473,7 @@ struct ModelSelectionCard: View {
                         .foregroundStyle(.primary)
                         .cornerRadius(6)
                     }
+                    .buttonStyle(.plain)
                 }
 
                 Spacer()

--- a/Sources/VocaMac/Views/OnboardingView.swift
+++ b/Sources/VocaMac/Views/OnboardingView.swift
@@ -12,10 +12,9 @@ import SwiftUI
 enum OnboardingStep: Int, CaseIterable, Identifiable {
     case welcome = 0
     case permissions = 1
-    case modelSelection = 2
-    case hotkeyConfig = 3
-    case quickTest = 4
-    case complete = 5
+    case hotkeyConfig = 2
+    case quickTest = 3
+    case complete = 4
 
     var id: Int { rawValue }
 
@@ -23,7 +22,6 @@ enum OnboardingStep: Int, CaseIterable, Identifiable {
         switch self {
         case .welcome: return "Welcome to VocaMac"
         case .permissions: return "Grant Permissions"
-        case .modelSelection: return "Choose Your Model"
         case .hotkeyConfig: return "Configure Hotkey"
         case .quickTest: return "Quick Test"
         case .complete: return "All Set!"
@@ -31,7 +29,7 @@ enum OnboardingStep: Int, CaseIterable, Identifiable {
     }
 
     var stepNumber: String {
-        "Step \(rawValue + 1) of 6"
+        "Step \(rawValue + 1) of \(OnboardingStep.allCases.count)"
     }
 }
 
@@ -74,8 +72,6 @@ struct OnboardingView: View {
                             WelcomeStep()
                         case .permissions:
                             PermissionsStep()
-                        case .modelSelection:
-                            ModelSelectionStep()
                         case .hotkeyConfig:
                             HotkeyConfigStep()
                         case .quickTest:
@@ -781,7 +777,6 @@ struct CompleteStep: View {
                 if appState.inputMonitoringPermission == .granted {
                     SummaryItem(icon: "keyboard.fill", text: "Input monitoring enabled")
                 }
-                SummaryItem(icon: "brain", text: "Model: \(appState.currentModel?.size.displayName ?? "Selected")")
                 SummaryItem(icon: "keyboard", text: "Hotkey: \(KeyCodeReference.displayName(for: appState.hotKeyCode))")
             }
             .frame(maxWidth: .infinity, alignment: .leading)

--- a/Sources/VocaMac/Views/OnboardingView.swift
+++ b/Sources/VocaMac/Views/OnboardingView.swift
@@ -66,22 +66,25 @@ struct OnboardingView: View {
                 .padding()
                 .borderBottom()
 
-                // Step content
-                Group {
-                    switch currentStep {
-                    case .welcome:
-                        WelcomeStep()
-                    case .permissions:
-                        PermissionsStep()
-                    case .modelSelection:
-                        ModelSelectionStep()
-                    case .hotkeyConfig:
-                        HotkeyConfigStep()
-                    case .quickTest:
-                        QuickTestStep()
-                    case .complete:
-                        CompleteStep()
+                // Step content (scrollable to handle varying content heights)
+                ScrollView {
+                    Group {
+                        switch currentStep {
+                        case .welcome:
+                            WelcomeStep()
+                        case .permissions:
+                            PermissionsStep()
+                        case .modelSelection:
+                            ModelSelectionStep()
+                        case .hotkeyConfig:
+                            HotkeyConfigStep()
+                        case .quickTest:
+                            QuickTestStep()
+                        case .complete:
+                            CompleteStep()
+                        }
                     }
+                    .frame(maxWidth: .infinity)
                 }
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
 

--- a/Sources/VocaMac/Views/OnboardingView.swift
+++ b/Sources/VocaMac/Views/OnboardingView.swift
@@ -195,6 +195,12 @@ struct WelcomeStep: View {
 struct PermissionsStep: View {
     @EnvironmentObject var appState: AppState
 
+    private var allPermissionsGranted: Bool {
+        appState.micPermission == .granted &&
+        appState.accessibilityPermission == .granted &&
+        appState.inputMonitoringPermission == .granted
+    }
+
     var body: some View {
         VStack(spacing: 16) {
             Text("VocaMac needs a few permissions to work properly.")
@@ -232,6 +238,22 @@ struct PermissionsStep: View {
 
             Spacer()
 
+            if !allPermissionsGranted {
+                HStack(spacing: 8) {
+                    Image(systemName: "exclamationmark.triangle.fill")
+                        .font(.caption)
+                        .foregroundStyle(.yellow)
+                    Text("Some permissions are missing. VocaMac may not work correctly until all permissions are granted. You can set them later in Settings → Debug.")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding()
+                .background(Color.yellow.opacity(0.05))
+                .cornerRadius(8)
+                .padding(.horizontal)
+            }
+
             HStack(spacing: 8) {
                 Image(systemName: "info.circle.fill")
                     .font(.caption)
@@ -244,7 +266,7 @@ struct PermissionsStep: View {
             .padding()
             .background(Color.blue.opacity(0.05))
             .cornerRadius(8)
-            .padding()
+            .padding(.horizontal)
 
             Spacer()
         }

--- a/Sources/VocaMac/Views/OnboardingView.swift
+++ b/Sources/VocaMac/Views/OnboardingView.swift
@@ -92,7 +92,14 @@ struct OnboardingView: View {
                     if currentStep != .welcome {
                         Button(action: goToPreviousStep) {
                             Text("Back")
+                                .font(.body)
+                                .padding(.horizontal, 16)
+                                .padding(.vertical, 8)
+                                .background(Color.gray.opacity(0.2))
+                                .foregroundStyle(.primary)
+                                .cornerRadius(8)
                         }
+                        .buttonStyle(.plain)
                         .keyboardShortcut(.cancelAction)
                     }
 
@@ -101,12 +108,28 @@ struct OnboardingView: View {
                     if currentStep != .complete {
                         Button(action: goToNextStep) {
                             Text(currentStep == .quickTest ? "Finish" : "Continue")
+                                .font(.body)
+                                .fontWeight(.medium)
+                                .padding(.horizontal, 20)
+                                .padding(.vertical, 8)
+                                .background(Color.blue)
+                                .foregroundStyle(.white)
+                                .cornerRadius(8)
                         }
+                        .buttonStyle(.plain)
                         .keyboardShortcut(.defaultAction)
                     } else {
                         Button(action: completeOnboarding) {
                             Text("Start Using VocaMac")
+                                .font(.body)
+                                .fontWeight(.medium)
+                                .padding(.horizontal, 20)
+                                .padding(.vertical, 8)
+                                .background(Color.blue)
+                                .foregroundStyle(.white)
+                                .cornerRadius(8)
                         }
+                        .buttonStyle(.plain)
                         .keyboardShortcut(.defaultAction)
                     }
                 }

--- a/Sources/VocaMac/Views/SettingsView.swift
+++ b/Sources/VocaMac/Views/SettingsView.swift
@@ -731,10 +731,21 @@ struct DebugTab: View {
                         .foregroundStyle(.secondary)
                 }
 
-                Button("Re-check Permissions") {
-                    appState.checkPermissions()
+                HStack {
+                    Button("Re-check Permissions") {
+                        appState.checkPermissions()
+                    }
+                    .controlSize(.small)
+
+                    Spacer()
+
+                    Button(action: resetPermissions) {
+                        Label("Reset All Permissions", systemImage: "arrow.counterclockwise")
+                            .foregroundStyle(.red)
+                    }
+                    .controlSize(.small)
+                    .help("Reset all TCC permissions for VocaMac. The app will quit and you'll need to re-grant permissions on next launch.")
                 }
-                .controlSize(.small)
 
                 HStack(alignment: .top, spacing: 8) {
                     Image(systemName: "exclamationmark.triangle.fill")
@@ -816,6 +827,32 @@ struct DebugTab: View {
     }
 
     // MARK: - Actions
+
+    private func resetPermissions() {
+        let alert = NSAlert()
+        alert.messageText = "Reset All Permissions?"
+        alert.informativeText = "This will clear all permission grants (Microphone, Accessibility, Input Monitoring) for VocaMac. The app will quit and you'll need to re-grant permissions on next launch.\n\nThis is useful when permissions appear stuck or aren't being recognized after an update."
+        alert.alertStyle = .warning
+        alert.addButton(withTitle: "Reset & Quit")
+        alert.addButton(withTitle: "Cancel")
+
+        let response = alert.runModal()
+        if response == .alertFirstButtonReturn {
+            // Run tccutil to reset all TCC permissions for this app
+            let task = Process()
+            task.executableURL = URL(fileURLWithPath: "/usr/bin/tccutil")
+            task.arguments = ["reset", "All", "com.vocamac.app"]
+            try? task.run()
+            task.waitUntilExit()
+
+            VocaLogger.info(.general, "TCC permissions reset via tccutil")
+
+            // Quit the app so permissions take effect on next launch
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
+                NSApplication.shared.terminate(nil)
+            }
+        }
+    }
 
     private func restartApp() {
         let bundlePath = Bundle.main.bundlePath

--- a/Sources/VocaMac/Views/SettingsView.swift
+++ b/Sources/VocaMac/Views/SettingsView.swift
@@ -734,6 +734,15 @@ struct DebugTab: View {
                     appState.checkPermissions()
                 }
                 .controlSize(.small)
+
+                HStack(alignment: .top, spacing: 8) {
+                    Image(systemName: "exclamationmark.triangle.fill")
+                        .foregroundStyle(.yellow)
+                        .font(.caption)
+                    Text("**Upgrading?** After updating VocaMac, you must remove the old entry (using \"−\") from Accessibility and Input Monitoring in System Settings → Privacy & Security, then re-add the new version. Permissions don't carry over because the app is not signed with a Developer ID.")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
             }
 
             // Debug Logs

--- a/Sources/VocaMac/Views/SettingsView.swift
+++ b/Sources/VocaMac/Views/SettingsView.swift
@@ -767,8 +767,46 @@ struct DebugTab: View {
                     .font(.caption)
                     .foregroundStyle(.secondary)
             }
+
+            // Application
+            Section("Application") {
+                HStack {
+                    Button(action: restartApp) {
+                        Label("Restart VocaMac", systemImage: "arrow.trianglehead.clockwise")
+                    }
+                    .help("Quit and relaunch VocaMac")
+
+                    Spacer()
+
+                    Button(role: .destructive, action: {
+                        NSApplication.shared.terminate(nil)
+                    }) {
+                        Label("Quit VocaMac", systemImage: "power")
+                    }
+                    .help("Quit VocaMac")
+                }
+
+                Text("Restart can help resolve issues with permissions or audio devices.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
         }
         .formStyle(.grouped)
+    }
+
+    // MARK: - Actions
+
+    private func restartApp() {
+        let bundlePath = Bundle.main.bundlePath
+        let task = Process()
+        task.executableURL = URL(fileURLWithPath: "/usr/bin/open")
+        task.arguments = ["-n", bundlePath, "--args", "--restarted"]
+        try? task.run()
+
+        // Give the new instance a moment to start
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
+            NSApplication.shared.terminate(nil)
+        }
     }
 
     // MARK: - Debug Log Actions

--- a/Sources/VocaMac/Views/SettingsView.swift
+++ b/Sources/VocaMac/Views/SettingsView.swift
@@ -231,25 +231,6 @@ struct ModelSettingsTab: View {
                             }
                             .frame(maxWidth: .infinity, alignment: .leading)
 
-                            if let recommended = appState.deviceRecommendedModel {
-                                HStack {
-                                    Image(systemName: "sparkles")
-                                        .foregroundStyle(.blue)
-                                    Text("WhisperKit recommends: **\(recommended)**")
-                                        .font(.callout)
-                                }
-                                .padding(.top, 4)
-                            }
-
-                            // Disk usage
-                            HStack {
-                                Image(systemName: "internaldrive")
-                                    .foregroundStyle(.secondary)
-                                Text("Model storage: \(appState.modelManager.diskUsageDescription())")
-                                    .font(.caption)
-                                    .foregroundStyle(.secondary)
-                            }
-                            .padding(.top, 2)
                         }
                         .padding(4)
                     }
@@ -339,6 +320,23 @@ struct ModelSettingsTab: View {
                     Image(systemName: "info.circle")
                         .foregroundStyle(.secondary)
                     Text("Models are downloaded from HuggingFace and cached locally. Larger models produce better results but are slower and use more memory.")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+
+                if let recommended = appState.deviceRecommendedModel {
+                    HStack {
+                        Image(systemName: "sparkles")
+                            .foregroundStyle(.blue)
+                        Text("WhisperKit recommends: **\(recommended)**")
+                            .font(.callout)
+                    }
+                }
+
+                HStack {
+                    Image(systemName: "internaldrive")
+                        .foregroundStyle(.secondary)
+                    Text("Model storage: \(appState.modelManager.diskUsageDescription())")
                         .font(.caption)
                         .foregroundStyle(.secondary)
                 }
@@ -723,14 +721,27 @@ struct DebugTab: View {
 
             // Debug Logs
             Section("Debug Logs") {
-                HStack(spacing: 8) {
+                LabeledContent("Log File") {
+                    Text(VocaLogger.logFileURL().lastPathComponent)
+                        .foregroundStyle(.secondary)
+                }
+
+                LabeledContent("Log Entries") {
+                    Text("\(VocaLogger.logEntryCount)")
+                        .monospacedDigit()
+                        .foregroundStyle(.secondary)
+                }
+
+                HStack {
                     Button(action: copyDebugLogs) {
-                        Label("Copy", systemImage: "doc.on.clipboard")
+                        Label("Copy to Clipboard", systemImage: "doc.on.clipboard")
                     }
                     .help("Copy last 500 lines of logs to clipboard")
 
+                    Spacer()
+
                     Button(action: exportDebugLogs) {
-                        Label("Export", systemImage: "arrow.down.doc")
+                        Label("Export to File…", systemImage: "square.and.arrow.up")
                     }
                     .help("Save debug logs to file and reveal in Finder")
                 }

--- a/Sources/VocaMac/Views/SettingsView.swift
+++ b/Sources/VocaMac/Views/SettingsView.swift
@@ -6,6 +6,10 @@
 
 import SwiftUI
 
+extension Notification.Name {
+    static let showOnboarding = Notification.Name("com.vocamac.showOnboarding")
+}
+
 struct SettingsView: View {
     var body: some View {
         TabView {
@@ -660,6 +664,19 @@ struct AboutTab: View {
                 }
             }
             .font(.caption)
+
+            Divider()
+                .frame(width: 200)
+
+            Button(action: {
+                NotificationCenter.default.post(name: .showOnboarding, object: nil)
+            }) {
+                Label("Show Setup Wizard…", systemImage: "wand.and.stars")
+                    .font(.caption)
+            }
+            .buttonStyle(.plain)
+            .foregroundStyle(.blue)
+            .help("Re-run the first-launch setup wizard")
 
             Spacer()
 

--- a/Sources/VocaMac/Views/SettingsView.swift
+++ b/Sources/VocaMac/Views/SettingsView.swift
@@ -770,6 +770,15 @@ struct DebugTab: View {
                         Label("Export to File…", systemImage: "square.and.arrow.up")
                     }
                     .help("Save debug logs to file and reveal in Finder")
+
+                    Spacer()
+
+                    Button(role: .destructive, action: {
+                        VocaLogger.clearLogs()
+                    }) {
+                        Label("Clear", systemImage: "trash")
+                    }
+                    .help("Clear all log entries")
                 }
 
                 Text("Copy or export recent application logs for troubleshooting.")

--- a/Sources/VocaMac/Views/SettingsView.swift
+++ b/Sources/VocaMac/Views/SettingsView.swift
@@ -443,7 +443,7 @@ struct ModelRow: View {
                     ProgressView()
                         .frame(width: 60)
                         .controlSize(.small)
-                    Text("Loading...")
+                    Text(model.loadingStatus)
                         .font(.caption2)
                         .foregroundStyle(.secondary)
                 }

--- a/Sources/VocaMac/Views/SettingsView.swift
+++ b/Sources/VocaMac/Views/SettingsView.swift
@@ -2,7 +2,7 @@
 // VocaMac
 //
 // Settings window for VocaMac configuration.
-// Organized into tabs: General, Models, Audio, About.
+// Organized into tabs: General, Models, Audio, Debug, About.
 
 import SwiftUI
 
@@ -22,6 +22,11 @@ struct SettingsView: View {
             AudioSettingsTab()
                 .tabItem {
                     Label("Audio", systemImage: "waveform")
+                }
+
+            DebugTab()
+                .tabItem {
+                    Label("Debug", systemImage: "ladybug")
                 }
 
             AboutTab()
@@ -147,43 +152,8 @@ struct GeneralSettingsTab: View {
                     .foregroundStyle(.secondary)
             }
 
-            // Permissions
-            Section("Permissions") {
-                PermissionRow(
-                    name: "Microphone",
-                    icon: "mic.fill",
-                    status: appState.micPermission,
-                    action: { appState.requestMicrophonePermission() }
-                )
-
-                PermissionRow(
-                    name: "Accessibility",
-                    icon: "accessibility",
-                    status: appState.accessibilityPermission,
-                    action: { appState.requestAccessibilityPermission() }
-                )
-
-                PermissionRow(
-                    name: "Input Monitoring",
-                    icon: "keyboard",
-                    status: appState.inputMonitoringPermission,
-                    action: { appState.requestInputMonitoringPermission() }
-                )
-
-                if appState.micPermission == .denied || appState.accessibilityPermission == .denied || appState.inputMonitoringPermission == .denied {
-                    Text("Denied permissions must be enabled manually in System Settings → Privacy & Security.")
-                        .font(.caption)
-                        .foregroundStyle(.secondary)
-                }
-
-                Button("Re-check Permissions") {
-                    appState.checkPermissions()
-                }
-                .controlSize(.small)
-            }
         }
         .formStyle(.grouped)
-        .padding(.horizontal)
     }
 }
 
@@ -615,7 +585,6 @@ struct AudioSettingsTab: View {
             }
         }
         .formStyle(.grouped)
-        .padding(.horizontal)
         .onAppear {
             audioDevices = AudioEngine.availableInputDevices()
         }
@@ -632,7 +601,6 @@ struct AudioSettingsTab: View {
 
 struct AboutTab: View {
     @EnvironmentObject var appState: AppState
-    @State private var showingExportSuccess = false
 
     var body: some View {
         VStack(spacing: 16) {
@@ -695,31 +663,6 @@ struct AboutTab: View {
             }
             .font(.caption)
 
-            Divider()
-                .frame(width: 200)
-
-            // Debug logs section
-            VStack(spacing: 8) {
-                Text("Debug Logs")
-                    .font(.caption)
-                    .fontWeight(.semibold)
-                    .foregroundStyle(.secondary)
-
-                HStack(spacing: 8) {
-                    Button(action: copyDebugLogs) {
-                        Label("Copy", systemImage: "doc.on.clipboard")
-                            .font(.caption)
-                    }
-                    .help("Copy last 500 lines of logs to clipboard")
-
-                    Button(action: exportDebugLogs) {
-                        Label("Export", systemImage: "arrow.down.doc")
-                            .font(.caption)
-                    }
-                    .help("Save debug logs to file and reveal in Finder")
-                }
-            }
-
             Spacer()
 
             HStack(spacing: 0) {
@@ -734,6 +677,71 @@ struct AboutTab: View {
         .frame(maxWidth: .infinity)
         .padding()
     }
+}
+
+// MARK: - Debug Tab
+
+struct DebugTab: View {
+    @EnvironmentObject var appState: AppState
+
+    var body: some View {
+        Form {
+            // Permissions
+            Section("Permissions") {
+                PermissionRow(
+                    name: "Microphone",
+                    icon: "mic.fill",
+                    status: appState.micPermission,
+                    action: { appState.requestMicrophonePermission() }
+                )
+
+                PermissionRow(
+                    name: "Accessibility",
+                    icon: "accessibility",
+                    status: appState.accessibilityPermission,
+                    action: { appState.requestAccessibilityPermission() }
+                )
+
+                PermissionRow(
+                    name: "Input Monitoring",
+                    icon: "keyboard",
+                    status: appState.inputMonitoringPermission,
+                    action: { appState.requestInputMonitoringPermission() }
+                )
+
+                if appState.micPermission == .denied || appState.accessibilityPermission == .denied || appState.inputMonitoringPermission == .denied {
+                    Text("Denied permissions must be enabled manually in System Settings → Privacy & Security.")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+
+                Button("Re-check Permissions") {
+                    appState.checkPermissions()
+                }
+                .controlSize(.small)
+            }
+
+            // Debug Logs
+            Section("Debug Logs") {
+                HStack(spacing: 8) {
+                    Button(action: copyDebugLogs) {
+                        Label("Copy", systemImage: "doc.on.clipboard")
+                    }
+                    .help("Copy last 500 lines of logs to clipboard")
+
+                    Button(action: exportDebugLogs) {
+                        Label("Export", systemImage: "arrow.down.doc")
+                    }
+                    .help("Save debug logs to file and reveal in Finder")
+                }
+
+                Text("Copy or export recent application logs for troubleshooting.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+        }
+        .formStyle(.grouped)
+    }
 
     // MARK: - Debug Log Actions
 
@@ -747,7 +755,6 @@ struct AboutTab: View {
     private func exportDebugLogs() {
         let logs = VocaLogger.exportLogs(lastLines: 1000)
 
-        // Create save panel
         let savePanel = NSSavePanel()
         savePanel.allowedContentTypes = [.plainText]
         savePanel.nameFieldStringValue = "VocaMac-Debug-\(ISO8601DateFormatter().string(from: Date()).prefix(19)).log"

--- a/Sources/VocaMac/Views/SettingsView.swift
+++ b/Sources/VocaMac/Views/SettingsView.swift
@@ -698,6 +698,7 @@ struct AboutTab: View {
 
 struct DebugTab: View {
     @EnvironmentObject var appState: AppState
+    @State private var logEntryCount: Int = VocaLogger.logEntryCount
 
     var body: some View {
         Form {
@@ -753,7 +754,7 @@ struct DebugTab: View {
                 }
 
                 LabeledContent("Log Entries") {
-                    Text("\(VocaLogger.logEntryCount)")
+                    Text("\(logEntryCount)")
                         .monospacedDigit()
                         .foregroundStyle(.secondary)
                 }
@@ -773,10 +774,12 @@ struct DebugTab: View {
 
                     Spacer()
 
-                    Button(role: .destructive, action: {
+                    Button(action: {
                         VocaLogger.clearLogs()
+                        logEntryCount = VocaLogger.logEntryCount
                     }) {
                         Label("Clear", systemImage: "trash")
+                            .foregroundStyle(.red)
                     }
                     .help("Clear all log entries")
                 }

--- a/Tests/VocaMacTests/VocaMacTests.swift
+++ b/Tests/VocaMacTests/VocaMacTests.swift
@@ -417,13 +417,12 @@ final class OnboardingStepTests: XCTestCase {
 
     func testOnboardingStepOrdering() {
         let steps = OnboardingStep.allCases
-        XCTAssertEqual(steps.count, 6)
+        XCTAssertEqual(steps.count, 5)
         XCTAssertEqual(steps[0], .welcome)
         XCTAssertEqual(steps[1], .permissions)
-        XCTAssertEqual(steps[2], .modelSelection)
-        XCTAssertEqual(steps[3], .hotkeyConfig)
-        XCTAssertEqual(steps[4], .quickTest)
-        XCTAssertEqual(steps[5], .complete)
+        XCTAssertEqual(steps[2], .hotkeyConfig)
+        XCTAssertEqual(steps[3], .quickTest)
+        XCTAssertEqual(steps[4], .complete)
     }
 
     func testOnboardingStepTitles() {
@@ -434,7 +433,7 @@ final class OnboardingStepTests: XCTestCase {
 
     func testOnboardingStepNumbers() {
         for (index, step) in OnboardingStep.allCases.enumerated() {
-            XCTAssertEqual(step.stepNumber, "Step \(index + 1) of 6")
+            XCTAssertEqual(step.stepNumber, "Step \(index + 1) of \(OnboardingStep.allCases.count)")
         }
     }
 

--- a/Tests/VocaMacTests/VocaMacTests.swift
+++ b/Tests/VocaMacTests/VocaMacTests.swift
@@ -168,7 +168,7 @@ final class WhisperModelInfoTests: XCTestCase {
             isActive: false, isSupported: true
         )
         model.isLoading = true
-        XCTAssertEqual(model.statusDescription, "Loading...")
+        XCTAssertEqual(model.statusDescription, "Loading…")
         XCTAssertEqual(model.statusIconName, "arrow.trianglehead.2.clockwise")
     }
 


### PR DESCRIPTION
## Summary

Comprehensive UI overhaul of Settings, onboarding wizard, and model loading pipeline ahead of the v0.2.0 release.

---

### 🆕 New: Debug Tab

Adds a dedicated **Debug** tab (🐞) to Settings, consolidating diagnostic tools:

- **Permissions** — Microphone, Accessibility, Input Monitoring status with Re-check and **Reset All Permissions** buttons. Reset runs `tccutil reset All com.vocamac.app` with a confirmation dialog, then quits the app for a clean re-grant on next launch
- **Debug Logs** — Log file name, entry count, Copy to Clipboard, Export to File…, and **Clear** (red) button with live count update
- **Application** — Restart VocaMac and Quit buttons
- ⚠️ Upgrade note explaining that permissions don't carry over after updates (CDHash limitation) and users must remove old entries before re-adding

Previously, Permissions lived in General and Debug Logs lived in About — both are now consolidated here.

---

### 🆕 New: Setup Wizard Access

Users can re-trigger the onboarding wizard from two places:
- **Menu bar popover** → Setup Wizard (✨ wand icon, between Settings and Quit)
- **Settings → About** → Show Setup Wizard… (blue link)

Both use `NotificationCenter` to communicate with the app-level `OnboardingWindowManager`.

---

### 🐛 Bug Fixes

| Bug | Root Cause | Fix |
|-----|-----------|-----|
| **Setup Wizard flashes and closes** | `monitorOnboardingCompletion` saw `hasCompletedOnboarding = true` and closed the window within 100ms | Added `force` parameter that resets the flag when manually triggered |
| **Onboarding never auto-launches** | No startup logic checked `hasCompletedOnboarding` to show the wizard | Added delayed check in `init()` that opens onboarding if not completed |
| **Model selection not persisted** | `performStartup()` always called `loadModel()` with no argument, auto-selecting Tiny regardless of saved preference | Now loads user's preferred model from `selectedModelSize` if downloaded |
| **Documents folder permission prompt** | `WhisperService` created `WhisperKitConfig()` without `downloadBase`, defaulting to `~/Documents/huggingface` | Set `downloadBase` to `~/Library/Application Support/VocaMac/models` |
| **Onboarding button rendering glitch** | macOS default button chrome overlapped custom styling on Open Settings, Use This Model, Download | Added `.buttonStyle(.plain)` to all custom-styled buttons |
| **Model recommendation mismatch** | Onboarding used `SystemInfo.recommendModel()` (RAM heuristic → Medium) while Models tab used WhisperKit (→ Large v3) | Onboarding now uses `appState.deviceRecommendedModel` |
| **Completion step cut off** | Fixed window height couldn't accommodate all step content | Wrapped step content in `ScrollView`, reduced window to 580px |
| **Clear button not red** | `role: .destructive` doesn't render red in grouped Form | Used explicit `.foregroundStyle(.red)` |
| **Log count not updating after clear** | Static computed property had no state binding | Tracked as `@State` for immediate view refresh |

---

### 🎨 UI Improvements

- **Scrollbar consistency** — Removed `.padding(.horizontal)` from General and Audio tabs so scrollbar sits flush at window edge, matching Models tab
- **Models tab** — Moved WhisperKit recommendation and Model storage info below the info text
- **Model loading phases** — Added `loadingStatus` to `WhisperModelInfo` with descriptive phases (Preparing… → Unpacking model… → Configuring… → Loading model… → Compiling neural engine…) shown in both onboarding and Settings
- **Onboarding permissions** — Yellow ⚠️ warning when permissions are missing; Continue always enabled
- **Onboarding navigation buttons** — Custom-styled Back (gray) and Continue/Start (blue) buttons replacing default macOS button chrome
- **Onboarding scroll** — All step content wrapped in `ScrollView` so navigation buttons are never clipped
- **About tab** — Cleaned up: removed Debug Logs (→ Debug tab), added Setup Wizard link
- **Debug Logs** — `LabeledContent` rows for Log File and Log Entries, full button labels, macOS-native share icon

---

### 📝 Documentation

- **README: Troubleshooting** — Reset onboarding (`defaults delete`), reset preferences, reset permissions (`tccutil`) on update
- **README: Permission reset** — Why Accessibility/Input Monitoring reset on rebuild (CDHash-based TCC tracking), why Microphone doesn't, workaround table
- **README** — Updated tab count (4 → 5) in architecture diagram and project structure
- **RELEASE.md** — Version checklist now includes `SettingsView.swift` and `web/index.html`
- **.gitignore** — Added `*.dmg` and `dmg-staging*/`

---

### Files Changed (22 commits)

| File | Changes |
|------|---------|
| `Sources/VocaMac/Views/SettingsView.swift` | Debug tab, About cleanup, scrollbar fix, clear logs, reset permissions, upgrade note |
| `Sources/VocaMac/Views/OnboardingView.swift` | Button fixes, recommendation fix, permission warning, loading indicator, ScrollView, nav button styling |
| `Sources/VocaMac/Views/MenuBarView.swift` | Setup Wizard button |
| `Sources/VocaMac/App/VocaMacApp.swift` | Force-reopen onboarding, notification listener, auto-launch, @MainActor, window height |
| `Sources/VocaMac/Models/WhisperModel.swift` | `loadingStatus` property |
| `Sources/VocaMac/Models/AppState.swift` | Loading phase callbacks, preferred model on startup |
| `Sources/VocaMac/Services/WhisperService.swift` | `onPhaseChange` callback, `downloadBase` fix |
| `Sources/VocaMac/Services/Logger.swift` | `logEntryCount`, `clearLogs()` |
| `README.md` | Troubleshooting, permission docs, tab count |
| `.gitignore` | DMG artifacts |
