### PR TITLE
chore: add dist.sh script and make dmg target

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,9 +31,8 @@ Package.resolved
 # Built app bundle
 VocaMac.app/
 
-# DMG build artifacts
-*.dmg
-dmg-staging*/
+# Distribution artifacts
+dist/
 
 # Legacy stubs
 Sources/CWhisper/

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # VocaMac — Makefile
 # Run `make help` for available commands.
 
-.PHONY: build install install-cli test clean run help
+.PHONY: build install install-cli dmg test clean run help
 
 ## Build .app bundle in repo root (fast, for development)
 build:
@@ -15,6 +15,10 @@ install:
 install-cli:
 	@./scripts/install.sh --cli
 
+## Build DMG for distribution
+dmg:
+	@./scripts/dist.sh
+
 ## Run tests
 test:
 	@swift test
@@ -25,6 +29,7 @@ clean:
 	@swift package clean
 	@rm -rf VocaMac.app
 	@rm -rf .build
+	@rm -rf dist
 	@echo "✅ Clean complete"
 
 ## Launch the locally built .app (build first with `make build`)
@@ -38,6 +43,7 @@ help:
 	@echo "  make build        Build .app bundle (fast, for development)"
 	@echo "  make install      Build + install to /Applications (recommended)"
 	@echo "  make install-cli  Install CLI commands to ~/.local/bin"
+	@echo "  make dmg          Build DMG for distribution (output in dist/)"
 	@echo "  make test         Run tests"
 	@echo "  make run          Launch the locally built .app"
 	@echo "  make clean        Remove build artifacts"

--- a/scripts/dist.sh
+++ b/scripts/dist.sh
@@ -1,0 +1,63 @@
+#!/bin/bash
+# dist.sh — Build VocaMac and package as a DMG
+# Usage: ./scripts/dist.sh
+#
+# This script:
+# 1. Builds VocaMac.app via build.sh
+# 2. Creates a DMG with the app and an Applications symlink
+# 3. Outputs the DMG to dist/
+#
+# All artifacts are placed in dist/ — a single, clean output directory.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_DIR="$(dirname "$SCRIPT_DIR")"
+cd "$PROJECT_DIR"
+
+# Get version from build.sh's Info.plist template
+VERSION=$(grep -A1 'CFBundleShortVersionString' scripts/build.sh | grep '<string>' | sed 's/.*<string>\(.*\)<\/string>/\1/' | head -1)
+ARCH=$(uname -m)
+DMG_NAME="VocaMac-${VERSION}-${ARCH}.dmg"
+DIST_DIR="dist"
+STAGING_DIR="${DIST_DIR}/.staging"
+
+# Build the app first
+echo "🔨 Building VocaMac..."
+"$SCRIPT_DIR/build.sh" release
+
+if [ ! -d "VocaMac.app" ]; then
+    echo "❌ VocaMac.app not found. Build failed."
+    exit 1
+fi
+
+# Clean and prepare dist directory
+echo "📦 Preparing distribution..."
+rm -rf "$STAGING_DIR"
+mkdir -p "$STAGING_DIR"
+mkdir -p "$DIST_DIR"
+
+# Stage the app and Applications symlink
+cp -R VocaMac.app "$STAGING_DIR/"
+ln -sf /Applications "$STAGING_DIR/Applications"
+
+# Create the DMG
+echo "💿 Creating DMG..."
+hdiutil create -volname "VocaMac" \
+    -srcfolder "$STAGING_DIR" \
+    -ov -format UDZO \
+    "${DIST_DIR}/${DMG_NAME}"
+
+# Clean up staging
+rm -rf "$STAGING_DIR"
+
+echo ""
+echo "✅ DMG created!"
+echo ""
+echo "   File: ${DIST_DIR}/${DMG_NAME}"
+echo "   Size: $(du -h "${DIST_DIR}/${DMG_NAME}" | cut -f1)"
+echo ""
+echo "   SHA-256:"
+echo "   $(shasum -a 256 "${DIST_DIR}/${DMG_NAME}")"
+echo ""
+echo "🚀 To test:  open ${DIST_DIR}/${DMG_NAME}"


### PR DESCRIPTION
## Summary

Replaces the ad-hoc DMG staging directory mess with a clean, repeatable process.

### Before
Every DMG build created a new `dmg-staging-vN/` directory that couldn't be easily cleaned up, resulting in 22+ leftover directories cluttering the repo root.

### After
- **`make dmg`** — single command to build and package a DMG
- **`scripts/dist.sh`** — builds the app, stages in `dist/.staging/`, creates the DMG in `dist/`, cleans up staging automatically
- **`dist/`** — single output directory, gitignored, cleaned by `make clean`

### Usage
```bash
make dmg
# Output: dist/VocaMac-0.2.0-arm64.dmg
```

### Changes
- `scripts/dist.sh` — new DMG build script
- `Makefile` — added `dmg` target, added `dist/` to `clean`
- `.gitignore` — replaced `*.dmg` + `dmg-staging*/` with `dist/`

### Cleanup
After merging, run `rm -rf dmg-staging*` to remove the old directories.
