### PR TITLE
ui: move Skip Setup button to bottom navigation bar

### DIFF
--- a/Sources/VocaMac/Views/OnboardingView.swift
+++ b/Sources/VocaMac/Views/OnboardingView.swift
@@ -53,15 +53,6 @@ struct OnboardingView: View {
                         .font(.caption)
                         .foregroundStyle(.secondary)
                     Spacer()
-                    if currentStep != .complete {
-                        Button(action: skipOnboarding) {
-                            Text("Skip setup")
-                                .font(.caption)
-                                .foregroundStyle(.secondary)
-                        }
-                        .buttonStyle(.plain)
-                        .help("Skip setup and don't show again. You can re-run it from Settings or Menu Bar → Setup Wizard.")
-                    }
                     HStack(spacing: 4) {
                         ForEach(OnboardingStep.allCases, id: \.self) { step in
                             Circle()
@@ -97,6 +88,29 @@ struct OnboardingView: View {
 
                 // Navigation buttons
                 HStack(spacing: 12) {
+                    if currentStep == .welcome {
+                        Button(action: skipOnboarding) {
+                            Text("Skip Setup")
+                                .font(.body)
+                                .padding(.horizontal, 16)
+                                .padding(.vertical, 8)
+                                .background(Color.gray.opacity(0.2))
+                                .foregroundStyle(.primary)
+                                .cornerRadius(8)
+                        }
+                        .buttonStyle(.plain)
+                        .help("Skip setup and don't show again. You can re-run it from Menu Bar → Setup Wizard.")
+                    } else if currentStep != .complete {
+                        Button(action: skipOnboarding) {
+                            Text("Skip")
+                                .font(.body)
+                                .padding(.horizontal, 16)
+                                .padding(.vertical, 8)
+                        }
+                        .buttonStyle(.plain)
+                        .foregroundStyle(.secondary)
+                        .help("Skip setup and don't show again.")
+                    }
                     if currentStep != .welcome {
                         Button(action: goToPreviousStep) {
                             Text("Back")


### PR DESCRIPTION
## Summary

<img width="712" height="690" alt="image" src="https://github.com/user-attachments/assets/45b4c0d3-ac5e-4ac4-adc1-bf3278c0f900" />


Move the 'Skip setup' button from the barely visible top step indicator bar to the bottom navigation bar where it's easy to find.

### Before
- Tiny 'Skip setup' text crammed next to the step dots in the top bar — easy to miss

### After
- **Welcome step**: Prominent 'Skip Setup' button in bottom-left (gray rounded, same style as Back)
- **Other steps**: Subtle 'Skip' text link in bottom-left, next to Back button
- **Completion step**: Hidden (not needed — user is already done)

Clicking Skip marks onboarding as complete and won't show again on next launch. Users can always re-run it from Menu Bar → Setup Wizard or Settings → About.
