### PR TITLE
feat: add Launch at Login toggle using SMAppService

### DIFF
--- a/Sources/VocaMac/Models/AppState.swift
+++ b/Sources/VocaMac/Models/AppState.swift
@@ -7,6 +7,7 @@
 import Foundation
 import SwiftUI
 import Combine
+import ServiceManagement
 
 // MARK: - Enums
 
@@ -128,10 +129,48 @@ final class AppState: ObservableObject {
 
     init() {
         VocaLogger.info(.appState, "Initializing...")
+        syncLaunchAtLogin()
         setupServices()
         // Trigger startup automatically
         Task {
             await performStartup()
+        }
+    }
+
+    // MARK: - Launch at Login
+
+    /// Sync the persisted launchAtLogin preference with SMAppService.
+    /// Called once on init to reconcile state (e.g. if the user toggled it
+    /// in System Settings directly, or if the app was re-installed).
+    private func syncLaunchAtLogin() {
+        let currentStatus = SMAppService.mainApp.status
+        let isRegistered = currentStatus == .enabled
+
+        if launchAtLogin && !isRegistered {
+            // User wants launch-at-login but it's not registered — register now
+            setLaunchAtLogin(true)
+        } else if !launchAtLogin && isRegistered {
+            // Persisted preference says disabled but system says enabled — unregister
+            setLaunchAtLogin(false)
+        }
+    }
+
+    /// Register or unregister the app as a login item via SMAppService.
+    /// Updates the persisted `launchAtLogin` preference to match.
+    func setLaunchAtLogin(_ enabled: Bool) {
+        do {
+            if enabled {
+                try SMAppService.mainApp.register()
+                VocaLogger.info(.appState, "Registered as login item")
+            } else {
+                try SMAppService.mainApp.unregister()
+                VocaLogger.info(.appState, "Unregistered as login item")
+            }
+            launchAtLogin = enabled
+        } catch {
+            VocaLogger.error(.appState, "Failed to \(enabled ? "register" : "unregister") login item: \(error.localizedDescription)")
+            // Revert the preference to match the actual system state
+            launchAtLogin = SMAppService.mainApp.status == .enabled
         }
     }
 

--- a/Sources/VocaMac/Views/MenuBarView.swift
+++ b/Sources/VocaMac/Views/MenuBarView.swift
@@ -314,25 +314,6 @@ struct MenuBarView: View {
 
     private var actionsSection: some View {
         VStack(spacing: 2) {
-            // Launch at Login toggle
-            Toggle(isOn: Binding(
-                get: { appState.launchAtLogin },
-                set: { appState.setLaunchAtLogin($0) }
-            )) {
-                HStack {
-                    Image(systemName: "sunrise")
-                    Text("Launch at Login")
-                }
-                .font(.body)
-            }
-            .toggleStyle(.switch)
-            .controlSize(.small)
-            .padding(.vertical, 6)
-            .padding(.horizontal, 8)
-
-            Divider()
-                .padding(.vertical, 4)
-
             Button {
                 settingsManager.open(appState: appState)
             } label: {

--- a/Sources/VocaMac/Views/MenuBarView.swift
+++ b/Sources/VocaMac/Views/MenuBarView.swift
@@ -314,6 +314,25 @@ struct MenuBarView: View {
 
     private var actionsSection: some View {
         VStack(spacing: 2) {
+            // Launch at Login toggle
+            Toggle(isOn: Binding(
+                get: { appState.launchAtLogin },
+                set: { appState.setLaunchAtLogin($0) }
+            )) {
+                HStack {
+                    Image(systemName: "sunrise")
+                    Text("Launch at Login")
+                }
+                .font(.body)
+            }
+            .toggleStyle(.switch)
+            .controlSize(.small)
+            .padding(.vertical, 6)
+            .padding(.horizontal, 8)
+
+            Divider()
+                .padding(.vertical, 4)
+
             Button {
                 settingsManager.open(appState: appState)
             } label: {

--- a/Sources/VocaMac/Views/OnboardingView.swift
+++ b/Sources/VocaMac/Views/OnboardingView.swift
@@ -811,6 +811,30 @@ struct CompleteStep: View {
             .background(Color.green.opacity(0.05))
             .cornerRadius(8)
 
+            // Launch at Login option
+            Toggle(isOn: Binding(
+                get: { appState.launchAtLogin },
+                set: { appState.setLaunchAtLogin($0) }
+            )) {
+                HStack(spacing: 10) {
+                    Image(systemName: "sunrise.fill")
+                        .foregroundStyle(.orange)
+                        .frame(width: 20)
+                    VStack(alignment: .leading, spacing: 2) {
+                        Text("Launch at Login")
+                            .font(.subheadline)
+                        Text("Start VocaMac automatically when you log in")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+                }
+            }
+            .toggleStyle(.switch)
+            .controlSize(.small)
+            .padding()
+            .background(Color.blue.opacity(0.05))
+            .cornerRadius(8)
+
             Spacer()
 
             Text("You can adjust settings anytime from the VocaMac menu.")

--- a/Sources/VocaMac/Views/SettingsView.swift
+++ b/Sources/VocaMac/Views/SettingsView.swift
@@ -147,9 +147,14 @@ struct GeneralSettingsTab: View {
                     .foregroundStyle(.secondary)
             }
             Section("Behavior") {
+                Toggle("Launch at Login", isOn: Binding(
+                    get: { appState.launchAtLogin },
+                    set: { appState.setLaunchAtLogin($0) }
+                ))
+
                 Toggle("Preserve clipboard after text injection", isOn: $appState.preserveClipboard)
 
-            Toggle("Show mic indicator near cursor while recording", isOn: $appState.showCursorIndicator)
+                Toggle("Show mic indicator near cursor while recording", isOn: $appState.showCursorIndicator)
 
                 Text("When enabled, your clipboard contents are restored after injecting text.")
                     .font(.caption)

--- a/Tests/VocaMacTests/VocaMacTests.swift
+++ b/Tests/VocaMacTests/VocaMacTests.swift
@@ -5,6 +5,7 @@
 // Run with: swift test
 
 import XCTest
+import ServiceManagement
 @testable import VocaMac
 
 // MARK: - SystemInfo Tests
@@ -604,6 +605,87 @@ final class AudioEngineTests: XCTestCase {
                 "Audio buffer should NOT be empty when max duration is reached — " +
                 "frames must be appended before the max duration check")
         }
+    }
+}
+
+// MARK: - Launch at Login Tests
+
+final class LaunchAtLoginTests: XCTestCase {
+
+    override func setUp() {
+        super.setUp()
+        UserDefaults.standard.removeObject(forKey: "vocamac.launchAtLogin")
+    }
+
+    override func tearDown() {
+        // Clean up: ensure we don't leave the app registered as a login item from tests
+        UserDefaults.standard.removeObject(forKey: "vocamac.launchAtLogin")
+        try? SMAppService.mainApp.unregister()
+        super.tearDown()
+    }
+
+    @MainActor
+    func testLaunchAtLoginDefaultsToFalse() {
+        let appState = AppState()
+        XCTAssertFalse(appState.launchAtLogin)
+    }
+
+    @MainActor
+    func testLaunchAtLoginPersistence() {
+        UserDefaults.standard.set(true, forKey: "vocamac.launchAtLogin")
+        let appState = AppState()
+        XCTAssertTrue(appState.launchAtLogin)
+    }
+
+    @MainActor
+    func testSetLaunchAtLoginEnableUpdatesPreference() {
+        let appState = AppState()
+        XCTAssertFalse(appState.launchAtLogin)
+
+        appState.setLaunchAtLogin(true)
+
+        // The preference should reflect the requested state
+        // (SMAppService.mainApp.register() may or may not succeed depending
+        // on the test environment, but the method should not crash)
+        // If registration succeeded, launchAtLogin will be true.
+        // If it failed, launchAtLogin will match the actual system state.
+        // Either way, the value should be consistent with SMAppService.mainApp.status
+        let expected = SMAppService.mainApp.status == .enabled
+        XCTAssertEqual(appState.launchAtLogin, expected)
+    }
+
+    @MainActor
+    func testSetLaunchAtLoginDisableUpdatesPreference() {
+        let appState = AppState()
+        appState.setLaunchAtLogin(true)
+        appState.setLaunchAtLogin(false)
+
+        // After disabling, launchAtLogin should match the system state
+        let expected = SMAppService.mainApp.status == .enabled
+        XCTAssertEqual(appState.launchAtLogin, expected)
+    }
+
+    @MainActor
+    func testSetLaunchAtLoginToggleRoundTrip() {
+        let appState = AppState()
+
+        // Enable
+        appState.setLaunchAtLogin(true)
+        let afterEnable = appState.launchAtLogin
+
+        // Disable
+        appState.setLaunchAtLogin(false)
+        let afterDisable = appState.launchAtLogin
+
+        // The states should be different (assuming SMAppService works in this env)
+        // If SMAppService isn't available, both will match the system state
+        if SMAppService.mainApp.status != .enabled {
+            XCTAssertFalse(afterDisable,
+                "After disabling, launchAtLogin should be false")
+        }
+        // Just verify no crashes occurred during the round-trip
+        XCTAssertNotNil(afterEnable)
+        XCTAssertNotNil(afterDisable)
     }
 }
 


### PR DESCRIPTION
Closes #60

## Summary

Adds a **Launch at Login** feature using the modern `SMAppService` API (macOS 13+). The toggle appears in two places:
1. **Setup Wizard → "You're All Set!" step** — natural place to enable it during first-time setup
2. **Settings → General → Behavior** — for changing the preference later

Both toggles stay in sync via the same `setLaunchAtLogin()` method. No helper app or additional entitlements required.

## Implementation

### AppState (`AppState.swift`)
- **`setLaunchAtLogin(_ enabled: Bool)`** — Registers/unregisters via `SMAppService.mainApp`. On failure, reverts the `launchAtLogin` preference to match the actual system state so the toggle never gets out of sync.
- **`syncLaunchAtLogin()`** — Called once on init to reconcile the persisted `@AppStorage` preference with the system's login item state. Handles edge cases like re-installs, or the user toggling the setting directly in System Settings → General → Login Items.
- Added `import ServiceManagement`

### SettingsView (`SettingsView.swift`)
- Added a `Toggle("Launch at Login", ...)` as the first item in the **Behavior** section
- Uses a custom `Binding` that routes through `setLaunchAtLogin()`

### OnboardingView (`OnboardingView.swift`)
- Added a Launch at Login toggle on the Setup Wizard's completion step ("You're All Set!")
- Styled with a sunrise icon, description text, and blue-tinted background card
- Uses the same custom `Binding` through `setLaunchAtLogin()`, staying in sync with the Settings toggle

### No entitlement changes needed
`SMAppService.mainApp` works with both ad-hoc signed and Developer ID signed apps without any additional entitlements.

## Tests Added

5 new tests in `LaunchAtLoginTests`:
- `testLaunchAtLoginDefaultsToFalse` — verifies the default preference
- `testLaunchAtLoginPersistence` — verifies `@AppStorage` round-trip
- `testSetLaunchAtLoginEnableUpdatesPreference` — verifies enable syncs with system state
- `testSetLaunchAtLoginDisableUpdatesPreference` — verifies disable syncs with system state
- `testSetLaunchAtLoginToggleRoundTrip` — verifies enable → disable doesn't crash and stays consistent

## Testing

All 62 tests pass (`swift test`). Manually verified:
- Toggle appears on Setup Wizard completion step
- Toggle appears in Settings → General → Behavior
- Both toggles stay in sync
- App correctly registers/unregisters as a login item