### PR TITLE
chore: bump version to v0.3.0-beta

### DIFF
--- a/README.md
+++ b/README.md
@@ -359,7 +359,7 @@ VocaMac is the macOS member of the Voca family:
 | Platform | Project | Status |
 |----------|---------|--------|
 |  Linux | [VocaLinux](https://github.com/jatinkrmalik/vocalinux) | ✅ Available |
-|  macOS | [VocaMac](https://github.com/jatinkrmalik/vocamac) | 🚧 Alpha |
+|  macOS | [VocaMac](https://github.com/jatinkrmalik/vocamac) | 🚀 Beta |
 | 🪟 Windows | [VocaWin](https://vocawin.com) | 📋 Planned |
 
 Each platform uses native technologies for the best possible integration, while sharing the same UX patterns and Whisper model family.

--- a/Sources/VocaMac/Views/SettingsView.swift
+++ b/Sources/VocaMac/Views/SettingsView.swift
@@ -629,7 +629,7 @@ struct AboutTab: View {
                 .multilineTextAlignment(.center)
                 .fixedSize(horizontal: false, vertical: true)
 
-            Text("Version 0.2.0 (Alpha)")
+            Text("Version 0.3.0 (Beta)")
                 .font(.caption)
                 .foregroundStyle(.tertiary)
 

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -122,9 +122,9 @@ cat > "${APP_DIR}/Contents/Info.plist" << EOF
     <key>CFBundleDisplayName</key>
     <string>${APP_NAME}</string>
     <key>CFBundleVersion</key>
-    <string>0.2.0</string>
+    <string>0.3.0</string>
     <key>CFBundleShortVersionString</key>
-    <string>0.2.0</string>
+    <string>0.3.0</string>
     <key>CFBundlePackageType</key>
     <string>APPL</string>
     <key>LSMinimumSystemVersion</key>

--- a/web/layouts/index.html
+++ b/web/layouts/index.html
@@ -36,7 +36,7 @@
             "Open source (AGPL-3.0 license)"
         ],
         "screenshot": "https://vocamac.com/og-image.png",
-        "softwareVersion": "0.2.0",
+        "softwareVersion": "0.3.0",
         "softwareRequirements": "macOS 13 (Ventura) or later, Xcode 15+ or Swift 5.9+ toolchain, 8 GB RAM minimum"
     }
     </script>
@@ -48,8 +48,8 @@
         <div class="container hero__container">
             <div class="hero__content">
                 <div class="hero__badges">
-                    <span class="badge badge--alpha">ALPHA RELEASE</span>
-                    <span class="badge badge--outline" id="version-badge">v0.2.0</span>
+                    <span class="badge badge--beta">BETA RELEASE</span>
+                    <span class="badge badge--outline" id="version-badge">v0.3.0</span>
                 </div>
                 <h1 class="hero__headline">
                     Your Voice,<br>
@@ -367,9 +367,9 @@
     <section class="install" id="install">
         <div class="container">
             <div class="section-header">
-                <span class="badge badge--alpha">ALPHA</span>
+                <span class="badge badge--beta">BETA</span>
                 <h2>Get Started in Minutes</h2>
-                <p class="text-secondary">Download the DMG or build from source. We're in alpha. Early adopters welcome.</p>
+                <p class="text-secondary">Download the DMG or build from source. Now in beta. Stable and ready for daily use.</p>
             </div>
 
             <!-- Install Options Tabs -->
@@ -505,7 +505,7 @@
                         <svg role="img" viewBox="0 0 24 24" width="36" height="36" xmlns="http://www.w3.org/2000/svg"><title>Apple</title><path d="M12.152 6.896c-.948 0-2.415-1.078-3.96-1.04-2.04.027-3.91 1.183-4.961 3.014-2.117 3.675-.546 9.103 1.519 12.09 1.013 1.454 2.208 3.09 3.792 3.039 1.52-.065 2.09-.987 3.935-.987 1.831 0 2.35.987 3.96.948 1.637-.026 2.676-1.48 3.676-2.948 1.156-1.688 1.636-3.325 1.662-3.415-.039-.013-3.182-1.221-3.22-4.857-.026-3.04 2.48-4.494 2.597-4.559-1.429-2.09-3.623-2.324-4.39-2.376-2-.156-3.675 1.09-4.61 1.09zM15.53 3.83c.843-1.012 1.4-2.427 1.245-3.83-1.207.052-2.662.805-3.532 1.818-.78.896-1.454 2.338-1.273 3.714 1.338.104 2.715-.688 3.559-1.701" fill="var(--text-primary)"/></svg>
                     </div>
                     <div class="family-card__name">VocaMac</div>
-                    <div class="family-card__status badge badge--alpha">Alpha</div>
+                    <div class="family-card__status badge badge--beta">Beta</div>
                     <p>Native macOS menu bar app. WhisperKit + CoreML.</p>
                     <span class="family-card__link">vocamac.com</span>
                 </div>

--- a/web/static/style.css
+++ b/web/static/style.css
@@ -93,10 +93,10 @@ h4 { font-size: 16px; font-weight: 600; }
     border-radius: 6px;
     line-height: 1.4;
 }
-.badge--alpha {
-    background: rgba(239, 68, 68, 0.15);
-    color: #EF4444;
-    border: 1px solid rgba(239, 68, 68, 0.3);
+.badge--beta {
+    background: rgba(34, 197, 94, 0.15);
+    color: #22C55E;
+    border: 1px solid rgba(34, 197, 94, 0.3);
 }
 .badge--outline {
     background: transparent;
@@ -210,9 +210,10 @@ h4 { font-size: 16px; font-weight: 600; }
     background-clip: text;
 }
 /* Badge adjustments */
-.badge--alpha {
-    background: rgba(239, 68, 68, 0.1);
-    border-color: rgba(239, 68, 68, 0.2);
+.badge--beta {
+    background: rgba(34, 197, 94, 0.1);
+    border-color: rgba(34, 197, 94, 0.2);
+    color: #22C55E;
 }
 .badge--primary {
     background: rgba(0, 113, 227, 0.1);


### PR DESCRIPTION
## v0.3.0-beta Release Preparation

VocaMac moves from **Alpha** to **Beta**! The app has been stable under continuous daily use, with significant bug fixes and new features since v0.2.0.

---

## 🚀 What's New

### New Features
- **Launch at Login** — Start VocaMac automatically when you log in, powered by the modern `SMAppService` API. Toggle in Settings → General → Behavior or during the Setup Wizard. (#63)
- **Auto-detect permission changes** — Accessibility and Input Monitoring permissions are now detected automatically within seconds of being granted. No more restarting the app or clicking "Recheck Permissions". (#64)

### Bug Fixes
- **Fixed audio buffer truncation** — Recording no longer cuts off the last few seconds of speech. Audio frames are now always buffered before silence/max-duration checks, ensuring no audio is ever lost. (#61)
- **Eliminated recording start delay** — Removed the ~1 second lag between pressing the hotkey and the mic activating. The blocking `playStartSoundAsync()` call has been replaced with fire-and-forget playback. (#61)
- **Fixed `#Preview` CLI build error** — Wrapped SwiftUI preview macros in `#if DEBUG` to allow building with Xcode Command Line Tools only. Thanks to @slatlasdev! (#62)

### Website
- **Migrated to Hugo** — The marketing website is now built with Hugo for easy content management and template reuse. (#66)
- **12 feature deep-dive pages** — Every feature tile on the homepage links to a comprehensive, SEO-optimized page. (#67)
- **Updated content** — Fixed license (MIT → AGPL-3.0), added missing features, screenshots page, direct DMG download, Google Analytics. (#65)

---

## 📋 Version Bump Details

| File | Change |
|------|--------|
| `scripts/build.sh` | CFBundleVersion + CFBundleShortVersionString: 0.2.0 → 0.3.0 |
| `SettingsView.swift` | About tab: "Version 0.2.0 (Alpha)" → "Version 0.3.0 (Beta)" |
| `web/layouts/index.html` | JSON-LD, hero badges, install text, Voca Family card |
| `README.md` | Platform table: 🚧 Alpha → 🚀 Beta |
| `web/static/style.css` | `.badge--alpha` → `.badge--beta` (red → green theme) |

---

## 🙏 Contributors

Thank you to everyone who contributed to this release:

- **@jatinkrmalik** — Launch at Login, audio buffer fix, recording delay fix, permission polling, website overhaul
- **@slatlasdev** — Fixed `#Preview` macro build error for CLI-only environments (#62)

---

## 📦 Release Checklist

After merging this PR:
1. `git tag v0.3.0` on main
2. `git push origin v0.3.0`
3. Create GitHub Release with tag `v0.3.0`
4. Attach DMG artifact from the release workflow
5. Website deploys automatically (Hugo build in CI)