### PR TITLE
fix: add spacing between GitHub icon and View Source text in navbar

### DIFF
--- a/web/static/style.css
+++ b/web/static/style.css
@@ -185,6 +185,7 @@ h4 { font-size: 16px; font-weight: 600; }
 .navbar__cta {
     display: inline-flex;
     align-items: center;
+    gap: 6px;
     padding: 8px 18px;
     border-radius: var(--radius-sm);
     border: 1px solid var(--border-color);


### PR DESCRIPTION
## Summary

Adds a 6px gap between the GitHub SVG icon and the "View Source" text in the navbar CTA button. Previously they were touching with no spacing.

## Change

Added `gap: 6px` to `.navbar__cta` flex container in `style.css`.

Replaces #74 (which had stale commits from the merged #71 branch).