### PR TITLE
ci: optimize pipeline to skip unnecessary builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: Build & Test
+name: CI
 
 on:
   push:
@@ -11,8 +11,38 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  # Detect which files changed to decide which jobs to run
+  changes:
+    name: Detect Changes
+    runs-on: ubuntu-latest
+    outputs:
+      app: ${{ steps.filter.outputs.app }}
+      web: ${{ steps.filter.outputs.web }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Check paths
+        uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            app:
+              - 'Sources/**'
+              - 'Tests/**'
+              - 'Package.swift'
+              - 'Package.resolved'
+              - 'scripts/**'
+              - 'Makefile'
+              - 'VocaMac.entitlements'
+            web:
+              - 'web/**'
+
+  # Build and test Swift app (only when app source changes)
   build-and-test:
-    name: Build & Test
+    name: Build & Test App
+    needs: changes
+    if: needs.changes.outputs.app == 'true'
     runs-on: macos-15
     timeout-minutes: 30
 
@@ -47,3 +77,24 @@ jobs:
           codesign -v VocaMac.app
           test -f VocaMac.app/Contents/Resources/Assets.car || echo "⚠️ Assets.car missing"
           echo "App bundle verified"
+
+  # Build website (only when web files change)
+  build-website:
+    name: Build Website
+    needs: changes
+    if: needs.changes.outputs.web == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Hugo
+        uses: peaceiris/actions-hugo@v3
+        with:
+          hugo-version: 'latest'
+          extended: true
+
+      - name: Build Hugo site
+        run: cd web && hugo --minify


### PR DESCRIPTION
## Summary

Optimizes the CI pipeline to only run relevant jobs based on which files changed.

## Problem

Previously, every push/PR triggered a full Swift build + test cycle on a `macos-15` runner (up to 30 minutes), even for website-only changes like CSS tweaks or content updates.

## Solution

Uses [`dorny/paths-filter`](https://github.com/dorny/paths-filter) to detect changes and conditionally run jobs:

| Job | Runs when | Runner | Timeout |
|-----|-----------|--------|---------|
| **Detect Changes** | Always | `ubuntu-latest` | ~10s |
| **Build & Test App** | `Sources/**`, `Tests/**`, `Package.swift`, `Package.resolved`, `scripts/**`, `Makefile`, `VocaMac.entitlements` | `macos-15` | 30 min |
| **Build Website** | `web/**` | `ubuntu-latest` | 5 min |

## Impact

- Website-only PRs: skip the expensive macOS build entirely
- App-only PRs: skip the website build
- Mixed PRs: both jobs run as before
- Docs-only PRs (README, AGENTS.md, etc.): neither build runs