### PR TITLE
fix: filter [BLANK_AUDIO] and other hallucination tokens from transcription output

### DIFF
--- a/Sources/VocaMac/Models/AppState.swift
+++ b/Sources/VocaMac/Models/AppState.swift
@@ -457,12 +457,16 @@ final class AppState: ObservableObject {
 
             lastTranscription = result
 
-            // Inject text at cursor position
-            if !result.text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            // Inject text at cursor position (text is already filtered
+            // by WhisperService to remove hallucination tokens like [BLANK_AUDIO])
+            let trimmedText = result.text.trimmingCharacters(in: .whitespacesAndNewlines)
+            if !trimmedText.isEmpty {
                 textInjector.inject(
-                    text: result.text.trimmingCharacters(in: .whitespacesAndNewlines),
+                    text: trimmedText,
                     preserveClipboard: preserveClipboard
                 )
+            } else {
+                VocaLogger.info(.appState, "Transcription produced no usable text (silence or blank audio)")
             }
 
             cursorOverlay.hide()

--- a/Sources/VocaMac/Services/WhisperService.swift
+++ b/Sources/VocaMac/Services/WhisperService.swift
@@ -176,7 +176,11 @@ final class WhisperService: @unchecked Sendable {
             let elapsed = CFAbsoluteTimeGetCurrent() - startTime
 
             // Concatenate all segment texts
-            let fullText = results.map { $0.text }.joined(separator: " ")
+            let rawText = results.map { $0.text }.joined(separator: " ")
+
+            // Filter out WhisperKit hallucination tokens that should not be
+            // exposed to the user (e.g. "[BLANK_AUDIO]", "(blank audio)", etc.)
+            let fullText = Self.filterHallucinationTokens(rawText)
 
             // Get detected language from first result
             let detectedLanguage = results.first?.language ?? language ?? "en"
@@ -215,6 +219,38 @@ final class WhisperService: @unchecked Sendable {
     }
 
     // MARK: - Utilities
+
+    // MARK: - Hallucination Filtering
+
+    /// Tokens that WhisperKit may emit when the audio contains silence,
+    /// background noise, or is too short to produce real speech. These are
+    /// internal model artifacts and should never be shown to the user.
+    private static let hallucinationPatterns: [String] = [
+        "[BLANK_AUDIO]",
+        "(blank audio)",
+        "[NO_SPEECH]",
+        "(no speech)",
+        "[ Silence ]",
+        "[silence]",
+        "(silence)",
+        "[Music]",
+        "(music)",
+        "[Applause]",
+        "(applause)",
+    ]
+
+    /// Remove hallucination tokens from transcribed text.
+    /// Returns the cleaned string, which may be empty if the entire output
+    /// consisted of hallucination tokens.
+    static func filterHallucinationTokens(_ text: String) -> String {
+        var cleaned = text
+        for pattern in hallucinationPatterns {
+            cleaned = cleaned.replacingOccurrences(of: pattern, with: "", options: .caseInsensitive)
+        }
+        // Collapse multiple spaces left behind by removed tokens
+        cleaned = cleaned.replacingOccurrences(of: "  +", with: " ", options: .regularExpression)
+        return cleaned.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
 
     /// Map a model name string to our ModelSize enum
     private func modelSizeFromName(_ name: String) -> ModelSize {

--- a/Tests/VocaMacTests/VocaMacTests.swift
+++ b/Tests/VocaMacTests/VocaMacTests.swift
@@ -725,4 +725,48 @@ final class AppStateOnboardingTests: XCTestCase {
         // Verify it was loaded from UserDefaults
         XCTAssertTrue(appState.hasCompletedOnboarding)
     }
+
+    // MARK: - WhisperService Hallucination Filtering Tests
+
+    func testFilterBlankAudioToken() {
+        let input = "[BLANK_AUDIO]"
+        let result = WhisperService.filterHallucinationTokens(input)
+        XCTAssertEqual(result, "", "Should filter out [BLANK_AUDIO] token completely")
+    }
+
+    func testFilterBlankAudioTokenCaseInsensitive() {
+        let input = "[blank_audio]"
+        let result = WhisperService.filterHallucinationTokens(input)
+        XCTAssertEqual(result, "", "Should filter out [blank_audio] case-insensitively")
+    }
+
+    func testFilterBlankAudioMixedWithText() {
+        let input = "Hello [BLANK_AUDIO] world"
+        let result = WhisperService.filterHallucinationTokens(input)
+        XCTAssertEqual(result, "Hello world", "Should remove token and collapse spaces")
+    }
+
+    func testFilterMultipleHallucinationTokens() {
+        let input = "[BLANK_AUDIO] [NO_SPEECH] some text (silence)"
+        let result = WhisperService.filterHallucinationTokens(input)
+        XCTAssertEqual(result, "some text", "Should remove all hallucination tokens")
+    }
+
+    func testFilterPreservesNormalText() {
+        let input = "This is a normal transcription"
+        let result = WhisperService.filterHallucinationTokens(input)
+        XCTAssertEqual(result, "This is a normal transcription", "Should not modify normal text")
+    }
+
+    func testFilterEmptyInput() {
+        let input = ""
+        let result = WhisperService.filterHallucinationTokens(input)
+        XCTAssertEqual(result, "", "Should handle empty input gracefully")
+    }
+
+    func testFilterOnlyWhitespaceAroundToken() {
+        let input = "   [BLANK_AUDIO]   "
+        let result = WhisperService.filterHallucinationTokens(input)
+        XCTAssertEqual(result, "", "Should return empty after filtering and trimming")
+    }
 }

--- a/Tests/VocaMacTests/VocaMacTests.swift
+++ b/Tests/VocaMacTests/VocaMacTests.swift
@@ -725,8 +725,11 @@ final class AppStateOnboardingTests: XCTestCase {
         // Verify it was loaded from UserDefaults
         XCTAssertTrue(appState.hasCompletedOnboarding)
     }
+}
 
-    // MARK: - WhisperService Hallucination Filtering Tests
+// MARK: - WhisperService Hallucination Filtering Tests
+
+final class WhisperServiceHallucinationTests: XCTestCase {
 
     func testFilterBlankAudioToken() {
         let input = "[BLANK_AUDIO]"


### PR DESCRIPTION
## Summary

WhisperKit may emit special tokens like `[BLANK_AUDIO]`, `[NO_SPEECH]`, `(silence)`, etc. when the audio contains no recognizable speech. These are internal model artifacts that should not be injected into the user's text.

## Changes

- Add `filterHallucinationTokens()` static method to `WhisperService` that strips known hallucination patterns from transcription results
- Apply filtering in the transcription pipeline before returning results
- Log when transcription produces no usable text after filtering (instead of injecting blank/garbage text)
- Add 7 comprehensive unit tests for the filtering logic

## Testing

- `swift test` — all new tests pass
- Manual: record silence → no text is injected (previously `[BLANK_AUDIO]` was pasted)

Closes #72