### PR TITLE
fix: improve permissions persistence guidance and recovery after updates

### DIFF
--- a/Sources/VocaMac/Services/PermissionManager.swift
+++ b/Sources/VocaMac/Services/PermissionManager.swift
@@ -56,14 +56,26 @@ final class PermissionManager: ObservableObject {
     }
 
     /// Re-check all permission statuses from the system.
+    /// Detects permission revocation (common with ad-hoc signed apps after updates)
+    /// and logs a helpful warning when a previously-granted permission is lost.
     func checkPermissions() {
         micPermission = audioEngine.checkPermissionStatus()
 
         let accessibilityGranted = HotKeyManager.checkAccessibilityPermission(prompt: false)
+        let previousAccessibility = accessibilityPermission
         accessibilityPermission = accessibilityGranted ? .granted : .denied
 
         let inputMonitoringGranted = checkInputMonitoringPermission()
+        let previousInputMonitoring = inputMonitoringPermission
         inputMonitoringPermission = inputMonitoringGranted ? .granted : .denied
+
+        // Warn when a permission transitions granted → denied (e.g., after app update)
+        if previousAccessibility == .granted && accessibilityPermission != .granted {
+            VocaLogger.warning(.appState, "Accessibility permission was revoked. This commonly happens after app updates with ad-hoc code signing. Please re-grant in System Settings → Privacy & Security → Accessibility.")
+        }
+        if previousInputMonitoring == .granted && inputMonitoringPermission != .granted {
+            VocaLogger.warning(.appState, "Input Monitoring permission was revoked. This commonly happens after app updates with ad-hoc code signing. Please re-grant in System Settings → Privacy & Security → Input Monitoring.")
+        }
     }
 
     /// Check Input Monitoring permission using multiple strategies since no
@@ -72,7 +84,7 @@ final class PermissionManager: ObservableObject {
     /// 2. Try creating a fresh `.cghidEventTap` (same type HotKeyManager uses)
     private func checkInputMonitoringPermission() -> Bool {
         // Strategy 1: If HotKeyManager has an active tap, check if macOS disabled it.
-        if hotKeyManager.isListening, let tap = hotKeyManager.activeEventTap {
+        if hotKeyManager.isListening, let tap = hotKeyManager.eventTap {
             return CGEvent.tapIsEnabled(tap: tap)
         }
 

--- a/Sources/VocaMac/Views/OnboardingView.swift
+++ b/Sources/VocaMac/Views/OnboardingView.swift
@@ -317,6 +317,20 @@ struct PermissionsStep: View {
             .cornerRadius(8)
             .padding(.horizontal)
 
+            HStack(alignment: .top, spacing: 8) {
+                Image(systemName: "arrow.trianglehead.clockwise.icloud")
+                    .font(.caption)
+                    .foregroundStyle(.orange)
+                Text("**Permissions may reset after updates.** VocaMac uses ad-hoc code signing, so macOS may clear Accessibility and Input Monitoring permissions when the app is updated or reinstalled. If this happens, remove the old VocaMac entry in System Settings \u{2192} Privacy & Security (using the minus \"-\" button), then re-add it.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding()
+            .background(Color.orange.opacity(0.05))
+            .cornerRadius(8)
+            .padding(.horizontal)
+
             Spacer()
         }
         .padding()

--- a/Sources/VocaMac/Views/SettingsView.swift
+++ b/Sources/VocaMac/Views/SettingsView.swift
@@ -742,6 +742,12 @@ struct DebugTab: View {
                     }
                     .controlSize(.small)
 
+                    Button(action: repairPermissions) {
+                        Label("Repair Permissions", systemImage: "wrench.and.screwdriver")
+                    }
+                    .controlSize(.small)
+                    .help("Open System Settings to re-grant permissions. Use this after app updates when permissions stop working.")
+
                     Spacer()
 
                     Button(action: resetPermissions) {
@@ -832,6 +838,48 @@ struct DebugTab: View {
     }
 
     // MARK: - Actions
+
+    /// Guide the user through re-granting permissions after an app update.
+    /// Ad-hoc signed apps lose their TCC grants when the binary changes,
+    /// so we open the relevant System Settings panes and log guidance.
+    private func repairPermissions() {
+        VocaLogger.info(.general, "Repair Permissions: opening System Settings panes for user to re-grant")
+
+        // If all permissions are already granted, inform the user
+        if appState.allPermissionsGranted {
+            let alert = NSAlert()
+            alert.messageText = "All Permissions Granted"
+            alert.informativeText = "Microphone, Accessibility, and Input Monitoring permissions are all active. No repair needed."
+            alert.alertStyle = .informational
+            alert.addButton(withTitle: "OK")
+            alert.runModal()
+            return
+        }
+
+        // Open both privacy panes the user typically needs to fix
+        if appState.accessibilityPermission != .granted {
+            if let url = URL(string: "x-apple.systempreferences:com.apple.preference.security?Privacy_Accessibility") {
+                NSWorkspace.shared.open(url)
+            }
+        }
+
+        if appState.inputMonitoringPermission != .granted {
+            // Small delay so the first pane has time to open
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
+                if let url = URL(string: "x-apple.systempreferences:com.apple.preference.security?Privacy_ListenEvent") {
+                    NSWorkspace.shared.open(url)
+                }
+            }
+        }
+
+        // Re-check after giving the user time to toggle
+        DispatchQueue.main.asyncAfter(deadline: .now() + 5.0) {
+            appState.checkPermissions()
+        }
+
+        // Start polling to auto-detect when permissions are granted
+        appState.startPermissionPolling()
+    }
 
     private func resetPermissions() {
         let alert = NSAlert()


### PR DESCRIPTION
## Summary

Users reported that Accessibility and Input Monitoring permissions don't persist. This is a known macOS behavior with ad-hoc code-signed apps: permissions are tied to the binary's code signature, so they reset whenever the app is updated or reinstalled.

## Changes

### Onboarding (OnboardingView.swift)
- Add a prominent note in the permissions step explaining that permissions may reset after updates
- Include clear instructions on how to fix it (remove old entry, re-add new one)

### Permission Detection (AppState.swift)
- Detect permission revocation and log specific warning messages explaining the ad-hoc signing limitation
- Distinguish between initial denial and post-update revocation for better diagnostics

### Settings → Debug (SettingsView.swift)
- Add a **"Repair Permissions"** button that opens the relevant System Settings panes
- Automatically starts permission polling after repair so the UI updates when permissions are granted
- Complements the existing "Re-check" and "Reset All" buttons

## Testing

- Manual: verify onboarding shows the new note on the permissions step
- Manual: verify "Repair Permissions" button opens System Settings and polling detects changes
- Check logs for revocation warnings after toggling permissions off/on

Closes #40