### PR TITLE
fix: resolve stuck recording, broken model loading, and double initialization

### DIFF
--- a/Sources/VocaMac/App/VocaMacApp.swift
+++ b/Sources/VocaMac/App/VocaMacApp.swift
@@ -145,6 +145,14 @@ struct VocaMacApp: App {
                 .environmentObject(appState)
         } label: {
             MenuBarIcon(appStatus: appState.appStatus, audioLevel: appState.audioLevel)
+                .onAppear {
+                    // Trigger startup from the SwiftUI lifecycle so it only runs
+                    // on the AppState instance that SwiftUI actually retains.
+                    // Previously, startup ran in AppState.init() which caused
+                    // double initialization (and double event taps) because
+                    // SwiftUI may instantiate the App struct more than once.
+                    appState.triggerStartupIfNeeded()
+                }
         }
         .menuBarExtraStyle(.window)
     }

--- a/Sources/VocaMac/Models/AppState.swift
+++ b/Sources/VocaMac/Models/AppState.swift
@@ -231,8 +231,22 @@ final class AppState: ObservableObject {
             Task { @MainActor in
                 guard let self = self else { return }
                 if self.activationMode == .doubleTapToggle && self.isRecording {
+                    VocaLogger.info(.appState, "Silence detected — auto-stopping recording (double-tap mode)")
                     await self.stopRecordingAndTranscribe()
                 }
+            }
+        }
+
+        // Setup max recording duration callback.
+        // AudioEngine fires this when the recording reaches maxRecordingDuration.
+        // This is the primary duration limit — the HotKeyManager safety timer
+        // (maxRecordingDuration + 5s) acts as a backstop in case this callback
+        // fails or the key-up event is lost entirely.
+        audioEngine.onMaxDurationReached = { [weak self] in
+            Task { @MainActor in
+                guard let self = self, self.isRecording else { return }
+                VocaLogger.info(.appState, "Max recording duration (\(self.maxRecordingDuration)s) reached — auto-stopping")
+                await self.stopRecordingAndTranscribe()
             }
         }
 
@@ -292,7 +306,8 @@ final class AppState: ObservableObject {
                     self.hotKeyManager.startListening(
                         keyCode: self.hotKeyCode,
                         mode: self.activationMode,
-                        doubleTapThreshold: self.doubleTapThreshold
+                        doubleTapThreshold: self.doubleTapThreshold,
+                        safetyTimeout: Double(self.maxRecordingDuration) + 5.0
                     )
                     VocaLogger.info(.appState, "Hotkey listener started after permission grant")
                 }
@@ -694,7 +709,8 @@ final class AppState: ObservableObject {
         hotKeyManager.startListening(
             keyCode: hotKeyCode,
             mode: activationMode,
-            doubleTapThreshold: doubleTapThreshold
+            doubleTapThreshold: doubleTapThreshold,
+            safetyTimeout: Double(maxRecordingDuration) + 5.0
         )
         if hotKeyManager.isListening {
             VocaLogger.info(.appState, "Hotkey listener active (keyCode=\(hotKeyCode), mode=\(activationMode.rawValue))")

--- a/Sources/VocaMac/Models/AppState.swift
+++ b/Sources/VocaMac/Models/AppState.swift
@@ -691,15 +691,20 @@ final class AppState: ObservableObject {
         // Start polling if any permission is still missing
         startPermissionPolling()
 
-        // 3. Load the user's preferred model (or auto-select on first launch)
-        if let preferredSize = ModelSize(rawValue: selectedModelSize),
-           modelManager.isModelDownloaded(preferredSize) {
-            VocaLogger.info(.appState, "Loading preferred model: \(preferredSize.displayName)...")
-            await loadModel(preferredSize)
-        } else {
-            VocaLogger.info(.appState, "Loading WhisperKit model (auto-select)...")
-            await loadModel()
+        // 3. Load the user's preferred model.
+        // On first launch the preferred model (tiny by default) won't be
+        // downloaded yet. We download it explicitly so the UI can show real
+        // progress, rather than delegating to WhisperKit's opaque auto-select
+        // which provides no progress callbacks and may pick a different model.
+        let preferredSize = ModelSize(rawValue: selectedModelSize) ?? .tiny
+
+        if !modelManager.isModelDownloaded(preferredSize) {
+            VocaLogger.info(.appState, "Preferred model \(preferredSize.displayName) not downloaded — downloading now...")
+            await downloadModel(preferredSize)
         }
+
+        VocaLogger.info(.appState, "Loading model: \(preferredSize.displayName)...")
+        await loadModel(preferredSize)
         NSLog("[AppState] Model loaded: %@", whisperService.loadedModelName ?? "none")
 
         // 4. Always attempt to start hotkey listener

--- a/Sources/VocaMac/Models/AppState.swift
+++ b/Sources/VocaMac/Models/AppState.swift
@@ -132,11 +132,29 @@ final class AppState: ObservableObject {
 
     // MARK: - Initialization
 
+    /// Whether `performStartup()` has already run. Guards against duplicate calls
+    /// if SwiftUI re-evaluates the body of the `App` struct.
+    private var hasStarted = false
+
     init() {
         VocaLogger.info(.appState, "Initializing...")
         syncLaunchAtLogin()
         setupServices()
-        // Trigger startup automatically
+        // NOTE: performStartup() is NOT called here. SwiftUI may instantiate
+        // AppState more than once (the discarded instance's deinit tears down
+        // the event tap that the surviving instance just created). Instead,
+        // startup is triggered from onAppear/task in VocaMacApp to ensure it
+        // only runs on the instance SwiftUI actually keeps.
+    }
+
+    /// Called once from the SwiftUI lifecycle to complete initialization.
+    /// Safe to call multiple times — only the first call takes effect.
+    func triggerStartupIfNeeded() {
+        guard !hasStarted else {
+            VocaLogger.debug(.appState, "triggerStartupIfNeeded called again — skipping (already started)")
+            return
+        }
+        hasStarted = true
         Task {
             await performStartup()
         }
@@ -392,7 +410,19 @@ final class AppState: ObservableObject {
     // MARK: - Recording Flow
 
     func startRecording() async {
-        guard appStatus == .idle else { return }
+        // If we're already recording, this is a recovery attempt — the user
+        // pressed the hotkey again because a previous key-up was missed.
+        // Stop the current recording and transcribe what we have.
+        if appStatus == .recording || isRecording {
+            VocaLogger.warning(.appState, "startRecording called while already recording — treating as stop (recovery)")
+            await stopRecordingAndTranscribe()
+            return
+        }
+
+        guard appStatus == .idle else {
+            VocaLogger.warning(.appState, "startRecording called in non-idle state: \(appStatus.rawValue) — ignoring")
+            return
+        }
         guard micPermission == .granted else {
             errorMessage = "Microphone permission is required. Please grant access in System Settings."
             appStatus = .error
@@ -424,7 +454,10 @@ final class AppState: ObservableObject {
     }
 
     func stopRecordingAndTranscribe() async {
-        guard isRecording else { return }
+        // Accept stop if we're recording OR if the audio engine thinks
+        // it's recording (covers stuck-state recovery scenarios where
+        // isRecording and appStatus may be out of sync).
+        guard isRecording || appStatus == .recording else { return }
 
         let audioData = audioEngine.stopRecording()
         isRecording = false
@@ -496,52 +529,84 @@ final class AppState: ObservableObject {
             modelName = nil  // Let WhisperKit auto-select
         }
 
-        // Mark the model as loading
-        if let size = size, let idx = availableModels.firstIndex(where: { $0.size == size }) {
+        // Resolve which ModelSize we're loading. When size is nil (auto-select),
+        // we don't know yet — we'll detect it after loading completes.
+        let targetSize = size
+
+        // Mark the model as loading in the UI
+        if let targetSize = targetSize, let idx = availableModels.firstIndex(where: { $0.size == targetSize }) {
             availableModels[idx].isLoading = true
             availableModels[idx].loadingStatus = "Preparing…"
         }
 
         do {
             // If model is downloaded locally, use the local folder
-            let folder = size.flatMap { modelManager.modelFolder(for: $0) }
+            let folder = targetSize.flatMap { modelManager.modelFolder(for: $0) }
 
             // Update status: unpacking
-            if let size = size, let idx = availableModels.firstIndex(where: { $0.size == size }) {
+            if let targetSize = targetSize, let idx = availableModels.firstIndex(where: { $0.size == targetSize }) {
                 availableModels[idx].loadingStatus = "Unpacking model…"
             }
 
             // Load model with status callback
             try await whisperService.loadModel(name: modelName, folder: folder) { [weak self] phase in
                 Task { @MainActor in
-                    guard let self = self, let size = size,
-                          let idx = self.availableModels.firstIndex(where: { $0.size == size }) else { return }
-                    self.availableModels[idx].loadingStatus = phase
+                    guard let self = self else { return }
+                    if let targetSize = targetSize,
+                       let idx = self.availableModels.firstIndex(where: { $0.size == targetSize }) {
+                        self.availableModels[idx].loadingStatus = phase
+                    }
                 }
             }
 
-            if let size = size {
-                selectedModelSize = size.rawValue
+            // Determine which ModelSize was actually loaded.
+            // When auto-selecting, WhisperKit chooses the model and we need
+            // to detect which one it picked by inspecting the loaded model name.
+            let resolvedSize: ModelSize
+            if let targetSize = targetSize {
+                resolvedSize = targetSize
+            } else {
+                let loadedName = (whisperService.loadedModelName ?? "").lowercased()
+                // Check from largest to smallest to avoid "base" matching inside "large-v3"
+                if loadedName.contains("large") {
+                    resolvedSize = .largeV3
+                } else if loadedName.contains("medium") {
+                    resolvedSize = .medium
+                } else if loadedName.contains("small") {
+                    resolvedSize = .small
+                } else if loadedName.contains("base") {
+                    resolvedSize = .base
+                } else {
+                    resolvedSize = .tiny
+                }
+                VocaLogger.info(.appState, "Auto-selected model resolved to: \(resolvedSize.displayName) (from '\(whisperService.loadedModelName ?? "unknown")')")
             }
 
-            // Update model states
-            let loadedName = whisperService.loadedModelName ?? ""
+            // Persist the resolved model as the user's preference
+            selectedModelSize = resolvedSize.rawValue
+
+            // Update model states — clear all, then mark the loaded one as active
             for i in availableModels.indices {
-                let matches = size != nil
-                    ? availableModels[i].size == size
-                    : loadedName.contains(availableModels[i].size.rawValue)
+                let matches = availableModels[i].size == resolvedSize
                 availableModels[i].isActive = matches
                 availableModels[i].isLoading = false
+                availableModels[i].loadingStatus = "Loading…"
                 if matches {
+                    // Refresh download status in case the auto-select downloaded it
+                    availableModels[i].isDownloaded = modelManager.isModelDownloaded(resolvedSize)
                     currentModel = availableModels[i]
                 }
             }
+
+            VocaLogger.info(.appState, "Model ready: \(resolvedSize.displayName)")
         } catch {
-            // Clear loading state on error
-            if let size = size, let idx = availableModels.firstIndex(where: { $0.size == size }) {
-                availableModels[idx].isLoading = false
+            // Clear loading state on error for all models (covers auto-select case)
+            for i in availableModels.indices {
+                availableModels[i].isLoading = false
+                availableModels[i].loadingStatus = "Loading…"
             }
             errorMessage = "Failed to load model: \(error.localizedDescription)"
+            VocaLogger.error(.appState, "Failed to load model: \(error.localizedDescription)")
         }
     }
 

--- a/Sources/VocaMac/Services/HotKeyManager.swift
+++ b/Sources/VocaMac/Services/HotKeyManager.swift
@@ -41,6 +41,15 @@ final class HotKeyManager {
     /// Whether we are currently in a "recording" toggle state (for double-tap mode)
     private var isToggled = false
 
+    /// Safety timer that auto-fires key-up if a real key-up event is missed.
+    /// macOS can drop flagsChanged events when multiple modifiers interact,
+    /// leaving push-to-talk stuck in the "recording" state.
+    private var keyHeldSafetyTimer: DispatchWorkItem?
+
+    /// Maximum duration (seconds) before the safety timer forces a key-up.
+    /// Matches the app's max recording duration with a small buffer.
+    private static let safetyTimeoutSeconds: Double = 120.0
+
     // MARK: - Callbacks
 
     /// Called when recording should start
@@ -134,6 +143,8 @@ final class HotKeyManager {
         isListening = false
         isKeyHeld = false
         isToggled = false
+        previousFlags = []
+        cancelSafetyTimer()
 
         VocaLogger.info(.hotKeyManager, "Stopped listening")
     }
@@ -189,29 +200,75 @@ final class HotKeyManager {
     }
 
     /// Handle modifier key events (Option, Command, Control, Shift, Fn)
-    /// Modifier keys generate flagsChanged events, not keyDown/keyUp
+    /// Modifier keys generate flagsChanged events, not keyDown/keyUp.
+    ///
+    /// **Key insight:** Modifier flags like `.maskAlternate` are shared between
+    /// left and right variants (e.g., Left Option and Right Option both set
+    /// `.maskAlternate`). A `flagsChanged` event fires whenever *any* modifier
+    /// changes, so we can't simply check the flag — pressing Left Option while
+    /// Right Option is already held would still show `.maskAlternate` as set,
+    /// and releasing Right Option while Left Option is held would *not* clear
+    /// the flag, causing the key-up to be missed.
+    ///
+    /// **Fix:** We track the raw flags value and detect transitions. When the
+    /// target key code fires a `flagsChanged` event, we compare the current
+    /// flags with the previous snapshot to determine if the *specific* key
+    /// was pressed or released.
+    private var previousFlags: CGEventFlags = []
+
     private func handleModifierKeyEvent(keyCode: Int, event: CGEvent) {
         guard keyCode == targetKeyCode else { return }
 
-        // Determine if the key is pressed or released by checking modifier flags
         let flags = event.flags
 
-        // Map key codes to their corresponding flag masks
-        let isPressed: Bool
+        // The flag mask that corresponds to this key's modifier group
+        let relevantMask: CGEventFlags
         switch keyCode {
         case 61, 58:  // Right Option (61) or Left Option (58)
-            isPressed = flags.contains(.maskAlternate)
+            relevantMask = .maskAlternate
         case 54, 55:  // Right Command (54) or Left Command (55)
-            isPressed = flags.contains(.maskCommand)
+            relevantMask = .maskCommand
         case 60, 56:  // Right Shift (60) or Left Shift (56)
-            isPressed = flags.contains(.maskShift)
+            relevantMask = .maskShift
         case 62, 59:  // Right Control (62) or Left Control (59)
-            isPressed = flags.contains(.maskControl)
+            relevantMask = .maskControl
         case 63:      // Fn key
-            isPressed = flags.contains(.maskSecondaryFn)
+            relevantMask = .maskSecondaryFn
         default:
             return
         }
+
+        // A flagsChanged event for this keyCode means the key was either
+        // pressed or released. We determine which by comparing the flag
+        // state with our expectation:
+        //
+        // • If the modifier flag is set AND we weren't already tracking
+        //   this key as held → key was pressed.
+        // • If the modifier flag is cleared → key was definitely released.
+        // • If the modifier flag is still set BUT macOS sent a flagsChanged
+        //   event specifically for our keyCode → the *specific* physical key
+        //   changed state. Since a flagsChanged for keyCode X only fires when
+        //   key X changes, if we were already holding it, this means it was
+        //   released (the flag may still be set because the *other* key in
+        //   the pair, e.g. Left Option, is still down).
+        let flagIsSet = flags.contains(relevantMask)
+
+        let isPressed: Bool
+        if !flagIsSet {
+            // Flag is clear — the key is definitely released
+            isPressed = false
+        } else if !isKeyHeld {
+            // Flag is set and we weren't tracking this key — it was pressed
+            isPressed = true
+        } else {
+            // Flag is still set but we're already tracking the key as held,
+            // and macOS sent a flagsChanged event for this exact keyCode.
+            // This means the physical key was released (the flag persists
+            // because another key in the same modifier group is still held).
+            isPressed = false
+        }
+
+        previousFlags = flags
 
         if isPressed {
             handleKeyDown()
@@ -238,12 +295,24 @@ final class HotKeyManager {
 
         switch mode {
         case .pushToTalk:
-            // Push-to-talk: start recording on key down (if not already held)
             if !isKeyHeld {
+                // Normal case: start recording on key down
                 isKeyHeld = true
                 VocaLogger.debug(.hotKeyManager, "Push-to-talk: START recording")
+                startSafetyTimer()
                 DispatchQueue.main.async { [weak self] in
                     self?.onRecordingStart?()
+                }
+            } else {
+                // Recovery: key-down while already held means the previous
+                // key-up was missed (macOS dropped the flagsChanged event).
+                // Treat this as a stop → the user is pressing the key again
+                // because recording is stuck.
+                VocaLogger.warning(.hotKeyManager, "Push-to-talk: key DOWN while already held — forcing STOP (recovery)")
+                isKeyHeld = false
+                cancelSafetyTimer()
+                DispatchQueue.main.async { [weak self] in
+                    self?.onRecordingStop?()
                 }
             }
 
@@ -279,6 +348,7 @@ final class HotKeyManager {
             // Push-to-talk: stop recording on key release
             if isKeyHeld {
                 isKeyHeld = false
+                cancelSafetyTimer()
                 VocaLogger.debug(.hotKeyManager, "Push-to-talk: STOP recording")
                 DispatchQueue.main.async { [weak self] in
                     self?.onRecordingStop?()
@@ -289,6 +359,31 @@ final class HotKeyManager {
             // No action on key up for toggle mode
             break
         }
+    }
+
+    // MARK: - Safety Timer
+
+    /// Start a safety timer that forces a key-up if the real event is never received.
+    /// This prevents the app from getting stuck in a "recording" state indefinitely.
+    private func startSafetyTimer() {
+        cancelSafetyTimer()
+
+        let work = DispatchWorkItem { [weak self] in
+            guard let self = self, self.isKeyHeld else { return }
+            VocaLogger.warning(.hotKeyManager, "Safety timer fired — forcing key-up (key held for >\(Self.safetyTimeoutSeconds)s)")
+            self.isKeyHeld = false
+            DispatchQueue.main.async { [weak self] in
+                self?.onRecordingStop?()
+            }
+        }
+        keyHeldSafetyTimer = work
+        DispatchQueue.main.asyncAfter(deadline: .now() + Self.safetyTimeoutSeconds, execute: work)
+    }
+
+    /// Cancel the safety timer (called on normal key-up)
+    private func cancelSafetyTimer() {
+        keyHeldSafetyTimer?.cancel()
+        keyHeldSafetyTimer = nil
     }
 
     // MARK: - Deinit

--- a/Sources/VocaMac/Services/HotKeyManager.swift
+++ b/Sources/VocaMac/Services/HotKeyManager.swift
@@ -47,8 +47,11 @@ final class HotKeyManager {
     private var keyHeldSafetyTimer: DispatchWorkItem?
 
     /// Maximum duration (seconds) before the safety timer forces a key-up.
-    /// Matches the app's max recording duration with a small buffer.
-    private static let safetyTimeoutSeconds: Double = 120.0
+    /// Set via `startListening(safetyTimeout:)` — should match (or slightly
+    /// exceed) the app's max recording duration so the safety timer acts as
+    /// a last-resort backstop *after* AudioEngine's own max-duration callback
+    /// has had a chance to fire.
+    private var safetyTimeoutSeconds: Double = 65.0
 
     // MARK: - Callbacks
 
@@ -75,10 +78,15 @@ final class HotKeyManager {
     ///   - keyCode: The virtual key code to listen for (default: 61 = Right Option)
     ///   - mode: The activation mode (push-to-talk or double-tap toggle)
     ///   - doubleTapThreshold: Time window for double-tap detection (seconds)
+    ///   - safetyTimeout: Maximum seconds before the safety timer forces a key-up
+    ///     in push-to-talk mode. Should be slightly longer than the app's max
+    ///     recording duration so AudioEngine's own limit fires first. The safety
+    ///     timer is a last-resort backstop for when a key-up event is lost entirely.
     func startListening(
         keyCode: Int = 61,
         mode: ActivationMode = .pushToTalk,
-        doubleTapThreshold: Double = 0.4
+        doubleTapThreshold: Double = 0.4,
+        safetyTimeout: Double = 65.0
     ) {
         guard !isListening else {
             VocaLogger.debug(.hotKeyManager, "Already listening")
@@ -88,6 +96,7 @@ final class HotKeyManager {
         self.targetKeyCode = keyCode
         self.mode = mode
         self.doubleTapThreshold = doubleTapThreshold
+        self.safetyTimeoutSeconds = safetyTimeout
         self.lastKeyDownTime = 0
         self.isKeyHeld = false
         self.isToggled = false
@@ -150,14 +159,23 @@ final class HotKeyManager {
     }
 
     /// Update the configuration while listening
+    /// - Parameters:
+    ///   - keyCode: New key code to listen for
+    ///   - mode: New activation mode
+    ///   - doubleTapThreshold: New double-tap detection window (seconds)
+    ///   - safetyTimeout: New safety timer duration (seconds). Should be
+    ///     `maxRecordingDuration + 5` to act as a backstop after AudioEngine's
+    ///     own max-duration callback.
     func updateConfiguration(
         keyCode: Int? = nil,
         mode: ActivationMode? = nil,
-        doubleTapThreshold: Double? = nil
+        doubleTapThreshold: Double? = nil,
+        safetyTimeout: Double? = nil
     ) {
         if let keyCode = keyCode { self.targetKeyCode = keyCode }
         if let mode = mode { self.mode = mode }
         if let threshold = doubleTapThreshold { self.doubleTapThreshold = threshold }
+        if let timeout = safetyTimeout { self.safetyTimeoutSeconds = timeout }
     }
 
     // MARK: - Event Tap Callback
@@ -365,19 +383,25 @@ final class HotKeyManager {
 
     /// Start a safety timer that forces a key-up if the real event is never received.
     /// This prevents the app from getting stuck in a "recording" state indefinitely.
+    ///
+    /// The timeout is set via `startListening(safetyTimeout:)` and should be
+    /// slightly longer than `maxRecordingDuration` so that AudioEngine's own
+    /// max-duration callback fires first under normal conditions. The safety
+    /// timer only kicks in when a key-up event is completely lost.
     private func startSafetyTimer() {
         cancelSafetyTimer()
 
+        let timeout = safetyTimeoutSeconds
         let work = DispatchWorkItem { [weak self] in
             guard let self = self, self.isKeyHeld else { return }
-            VocaLogger.warning(.hotKeyManager, "Safety timer fired — forcing key-up (key held for >\(Self.safetyTimeoutSeconds)s)")
+            VocaLogger.warning(.hotKeyManager, "Safety timer fired — forcing key-up (key held for >\(timeout)s)")
             self.isKeyHeld = false
             DispatchQueue.main.async { [weak self] in
                 self?.onRecordingStop?()
             }
         }
         keyHeldSafetyTimer = work
-        DispatchQueue.main.asyncAfter(deadline: .now() + Self.safetyTimeoutSeconds, execute: work)
+        DispatchQueue.main.asyncAfter(deadline: .now() + timeout, execute: work)
     }
 
     /// Cancel the safety timer (called on normal key-up)

--- a/Sources/VocaMac/Views/MenuBarView.swift
+++ b/Sources/VocaMac/Views/MenuBarView.swift
@@ -125,15 +125,34 @@ struct MenuBarView: View {
                     .fontWeight(.semibold)
 
                 if let model = appState.currentModel {
+                    // Model is loaded and ready
                     Text("Model: \(model.size.displayName)")
                         .font(.subheadline)
                         .foregroundStyle(.secondary)
                 } else if appState.whisperService.isModelLoaded {
+                    // Loaded but currentModel wasn't set (shouldn't happen, but safety net)
                     Text("Model: \(appState.whisperService.loadedModelName ?? "Loaded")")
                         .font(.subheadline)
                         .foregroundStyle(.secondary)
+                } else if let downloadingModel = appState.availableModels.first(where: { $0.downloadProgress != nil }),
+                          let progress = downloadingModel.downloadProgress {
+                    // A model is being downloaded — show progress
+                    VStack(alignment: .leading, spacing: 4) {
+                        Text("Downloading \(downloadingModel.size.displayName)… \(Int(progress * 100))%")
+                            .font(.subheadline)
+                            .foregroundStyle(.orange)
+                        ProgressView(value: progress)
+                            .progressViewStyle(.linear)
+                            .tint(.orange)
+                    }
+                } else if let loadingModel = appState.availableModels.first(where: { $0.isLoading }) {
+                    // A model is being loaded (already downloaded, now initializing)
+                    Text("Loading \(loadingModel.size.displayName)…")
+                        .font(.subheadline)
+                        .foregroundStyle(.orange)
                 } else {
-                    Text("Loading model...")
+                    // Fallback: no model loaded and nothing actively in progress
+                    Text("No model loaded")
                         .font(.subheadline)
                         .foregroundStyle(.orange)
                 }


### PR DESCRIPTION
## Summary

Fixes three interrelated bugs and improves the first-launch experience:

1. **Push-to-talk key release not detected** — recording gets stuck, pressing the key again does nothing, requiring app restart (and losing dictation) by @slatlasdev 
2. **"Loading model..." shown forever** on first install with default Tiny model
3. **Double AppState initialization** on every launch — the root cause of bug #1

Also includes two improvements discovered while fixing the above:
4. **`onMaxDurationReached` was never wired up** — the user's max recording duration setting had no effect
5. **Menu bar popover showed no download/loading progress** — just a static "Loading model..." for all pre-ready states

---

## Root Cause Analysis

### Bug 1 & 3: Stuck Recording

The debug log revealed that **every app launch** showed double initialization:

```
[AppState] Initializing...
[AppState] Initializing...
[AppState] Startup complete!
[AppState] Startup complete!
[HotKeyManager] Stopped listening    ← first instance torn down
```

SwiftUI re-creates the `App` struct, causing two `AppState` instances. Both ran `performStartup()` in `init()`, creating **competing event taps**. When the first (discarded) instance was deallocated, its `deinit` called `stopListening()`, tearing down its event tap.

Additionally, the modifier key detection had a design flaw: `.maskAlternate` is shared between Left and Right Option keys. A `flagsChanged` event for the target keyCode while the modifier flag was still set (e.g., paired modifier interaction) was incorrectly treated as "still pressed."

### Bug 2: Model Loading Forever

On first launch, `loadModel(nil)` was called (auto-select). All UI status updates were gated behind `if let size = size` — which was `nil`. So `currentModel` was never set, `availableModels` was never updated, and the UI stayed stuck on "Loading model..." forever.

---

## Changes

### `HotKeyManager.swift`
- **Smarter modifier key detection**: Tracks `isKeyHeld` state so a `flagsChanged` event for the target keyCode while already held is correctly interpreted as a release — even if the modifier flag persists because the paired key (e.g., Left Option) is still down
- **Recovery on re-press**: In push-to-talk mode, key-down while already held forces a stop and transcribes what was recorded
- **Configurable safety timer**: Last-resort backstop that forces key-up if no release event is ever received. Set to `maxRecordingDuration + 5s` via `startListening(safetyTimeout:)` and `updateConfiguration(safetyTimeout:)`

### `AppState.swift`
- **Deferred startup**: Moved `performStartup()` out of `init()` into `triggerStartupIfNeeded()` with a `hasStarted` guard, called from the SwiftUI lifecycle — eliminates the double initialization
- **Wired up `onMaxDurationReached`**: AudioEngine's max recording duration callback now actually stops recording and transcribes (was previously connected to nothing)
- **Three-layer duration enforcement**:
  1. `AudioEngine.onMaxDurationReached` — primary limit (user-configurable, default 60s)
  2. `HotKeyManager` safety timer — backstop at `maxRecordingDuration + 5s`
  3. Recovery on re-press — manual escape hatch (always works)
- **Recording recovery**: `startRecording()` detects re-entry and stops the current recording instead of silently ignoring
- **Resilient stop**: `stopRecordingAndTranscribe()` accepts stop when `appStatus == .recording` even if `isRecording` flag is out of sync
- **Explicit model download on first launch**: Downloads the preferred model (Tiny by default) with real progress callbacks instead of delegating to WhisperKit's opaque auto-select
- **Auto-select model resolution**: Safety net that detects which `ModelSize` was loaded after auto-select and updates all state correctly

### `VocaMacApp.swift`
- Triggers `appState.triggerStartupIfNeeded()` from the menu bar label's `onAppear` instead of `AppState.init()`

### `MenuBarView.swift`
- **Download progress in popover**: Shows "Downloading Tiny… 42%" with a progress bar during model download
- **Loading status**: Shows "Loading Tiny…" while the model is initializing after download
- **Ready state**: Shows "Model: Tiny" once loaded
- **Empty state**: Shows "No model loaded" if nothing is active

---

## Testing

- All 69 existing tests pass
- Build succeeds on macOS (Apple Silicon)