### PR TITLE
fix: resolve Google Search Console 'Page with redirect' indexing issues

### DIFF
--- a/web/hugo.toml
+++ b/web/hugo.toml
@@ -18,7 +18,8 @@ title = "VocaMac - 100% Local Voice-to-Text for macOS"
   changeFreq = "weekly"
   priority = 0.5
 
-enableRobotsTXT = true
+# robots.txt is served from static/robots.txt
+enableRobotsTXT = false
 
 # Disable Hugo's default taxonomies since we don't need them
 [taxonomies]

--- a/web/layouts/_default/404.html
+++ b/web/layouts/_default/404.html
@@ -1,0 +1,9 @@
+{{ define "main" }}
+    <section class="page-content" style="padding: 120px 0 60px; text-align: center;">
+        <div class="container">
+            <h1 style="font-size: 4rem; margin-bottom: 0.5rem;">404</h1>
+            <p class="text-secondary" style="font-size: 1.25rem; margin-bottom: 2rem;">Page not found. The page you're looking for doesn't exist or has been moved.</p>
+            <a href="/" class="button button--hero-primary">← Back to Home</a>
+        </div>
+    </section>
+{{ end }}

--- a/web/layouts/partials/head.html
+++ b/web/layouts/partials/head.html
@@ -5,7 +5,7 @@
     <title>{{ if .IsHome }}VocaMac - 100% Local Voice-to-Text for macOS{{ else }}{{ .Title }} | VocaMac{{ end }}</title>
     <meta name="title" content="{{ if .IsHome }}VocaMac - 100% Local Voice-to-Text for macOS{{ else }}{{ .Title }} | VocaMac{{ end }}">
     <meta name="description" content="{{ with .Params.description }}{{ . }}{{ else }}{{ .Site.Params.description }}{{ end }}">
-    {{ with .Params.keywords }}<meta name="keywords" content="{{ . }}">{{ end }}
+    {{ with .Params.keywords }}<meta name="keywords" content="{{ if reflect.IsSlice . }}{{ delimit . " " }}{{ else }}{{ . }}{{ end }}">{{ end }}
     {{ if .IsPage }}{{ if not .IsHome }}
     <script type="application/ld+json">
     {

--- a/web/static/robots.txt
+++ b/web/static/robots.txt
@@ -1,4 +1,7 @@
 User-agent: *
 Allow: /
 
+# Prevent indexing of GitHub Pages default domain (redirects to vocamac.com)
+Host: https://vocamac.com
+
 Sitemap: https://vocamac.com/sitemap.xml


### PR DESCRIPTION
## Problem

Google Search Console reported: **'Page with redirect'** preventing pages from being indexed on vocamac.com.

### Root Cause Analysis

Multiple sources of 301 redirects were identified:

1. **GitHub Pages default domain redirect**: `jatinkrmalik.github.io/vocamac/` → `vocamac.com` (301). Google was crawling the default domain and flagging every page as a redirect.
2. **Trailing-slash redirects**: GitHub Pages automatically 301 redirects `/features/push-to-talk` → `/features/push-to-talk/` for directory-style URLs. Any external links without trailing slashes trigger this.
3. **Missing 404 page**: No custom 404.html was present, which can cause unexpected behavior on GitHub Pages.

## Changes

### 1. `robots.txt` — Add `Host` directive
Adds `Host: https://vocamac.com` to signal the preferred domain to search engines, helping Google avoid indexing the GitHub Pages default domain (`jatinkrmalik.github.io/vocamac/`).

### 2. `hugo.toml` — Disable `enableRobotsTXT`
Set `enableRobotsTXT = false` since `robots.txt` is served from `static/`. Having both Hugo-generated and static `robots.txt` is a dual-source conflict (static wins, but the config is misleading).

### 3. `404.html` — Add custom 404 page
GitHub Pages requires a `404.html` at the root for proper 404 handling. Without it, missing pages may behave unpredictably.

### 4. `head.html` — Fix `keywords` meta tag
The `keywords` meta tag was rendering with square brackets: `[keyword1, keyword2]`. Hugo parses YAML keyword strings into a slice, and the default `{{ . }}` rendering wraps slices with `[...]`. Fixed by using `delimit` to properly join the tokens.

## Post-Merge Actions

After deploying these changes, you should also:
1. **Remove the GitHub Pages default URL from Google Search Console** if it was added as a property
2. **Request re-indexing** of affected pages in Google Search Console
3. **Verify** in Search Console that the 'Page with redirect' count decreases over the next few days

## Verification

```bash
cd web && hugo --minify
# 19 pages built (was 18 — new 404.html)
# robots.txt includes Host directive
# Keywords render without brackets
# 404.html exists at public/404.html
```