### PR TITLE
feat: add Bitbucket release pipeline and dual-remote release script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,9 @@ dist/
 Sources/CWhisper/
 VocaMac.iconset/
 
+# Bitbucket Pipelines (lives only on Bitbucket's release branch, not GitHub)
+bitbucket-pipelines.yml
+
 # Tool artifacts
 .desloppify/
 .claude/

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # VocaMac — Makefile
 # Run `make help` for available commands.
 
-.PHONY: build install install-cli dmg test clean run help
+.PHONY: build install install-cli dmg release test clean run help
 
 ## Build .app bundle in repo root (fast, for development)
 build:
@@ -18,6 +18,10 @@ install-cli:
 ## Build DMG for distribution
 dmg:
 	@./scripts/dist.sh
+
+## Release to GitHub + Bitbucket (usage: make release VERSION=0.3.0)
+release:
+	@./scripts/release.sh $(VERSION)
 
 ## Run tests
 test:
@@ -44,6 +48,7 @@ help:
 	@echo "  make install      Build + install to /Applications (recommended)"
 	@echo "  make install-cli  Install CLI commands to ~/.local/bin"
 	@echo "  make dmg          Build DMG for distribution (output in dist/)"
+	@echo "  make release VERSION=X.Y.Z  Release to GitHub + Bitbucket"
 	@echo "  make test         Run tests"
 	@echo "  make run          Launch the locally built .app"
 	@echo "  make clean        Remove build artifacts"

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,0 +1,81 @@
+#!/bin/bash
+# release.sh — Release VocaMac to GitHub and Bitbucket
+# Usage: ./scripts/release.sh <version>
+# Example: ./scripts/release.sh 0.3.0
+#
+# This script:
+# 1. Syncs main from GitHub to Bitbucket
+# 2. Rebases Bitbucket's release branch (which has bitbucket-pipelines.yml)
+# 3. Tags on both remotes to trigger CI/CD
+#
+# Prerequisites:
+#   - Two remotes configured: origin (GitHub) and atlassian (Bitbucket)
+#   - Bitbucket 'release' branch exists with bitbucket-pipelines.yml commit
+
+set -euo pipefail
+
+VERSION="${1:?Usage: ./scripts/release.sh <version> (e.g., 0.3.0)}"
+TAG="v${VERSION}"
+
+# Validate we're not already on a tag
+if git rev-parse "$TAG" >/dev/null 2>&1; then
+    echo "❌ Tag ${TAG} already exists. Aborting."
+    exit 1
+fi
+
+# Validate remotes exist
+for remote in origin atlassian; do
+    if ! git remote get-url "$remote" >/dev/null 2>&1; then
+        echo "❌ Remote '${remote}' not found. Run: git remote add ${remote} <url>"
+        exit 1
+    fi
+done
+
+echo "🚀 Releasing VocaMac ${TAG}"
+echo ""
+
+# Step 1: Ensure we're on main and up to date
+echo "📥 Pulling latest main from GitHub..."
+git checkout main
+git pull origin main
+
+# Step 2: Sync main to Bitbucket
+echo "📤 Syncing main to Bitbucket..."
+git push atlassian main
+
+# Step 3: Rebase Bitbucket's release branch onto updated main
+echo "🔄 Rebasing Bitbucket release branch..."
+git fetch atlassian release
+git checkout -B bb-release atlassian/release
+git rebase main
+
+# Step 4: Push the rebased release branch to Bitbucket
+git push atlassian bb-release:release --force-with-lease
+
+# Step 5: Tag on main (for GitHub) and push
+git checkout main
+git tag "${TAG}"
+echo "🏷️  Pushing tag ${TAG} to GitHub..."
+git push origin "${TAG}"
+
+# Step 6: Tag on release branch (for Bitbucket) and push
+git checkout bb-release
+git tag -f "${TAG}"
+echo "🏷️  Pushing tag ${TAG} to Bitbucket..."
+git push atlassian "${TAG}" --force
+
+# Clean up local temp branch
+git checkout main
+git branch -D bb-release
+
+echo ""
+echo "✅ Release ${TAG} triggered on both remotes!"
+echo ""
+echo "   📦 GitHub Actions (ad-hoc signed):"
+echo "      https://github.com/jatinkrmalik/vocamac/actions"
+echo ""
+echo "   📦 Bitbucket Pipelines (signed + notarized):"
+echo "      https://bitbucket.org/atlassian/vocamac/pipelines"
+echo ""
+echo "   Once the Bitbucket pipeline completes, download the signed DMG"
+echo "   from the pipeline artifacts and attach it to the GitHub Release."

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -39,9 +39,9 @@ echo "📥 Pulling latest main from GitHub..."
 git checkout main
 git pull origin main
 
-# Step 2: Sync main to Bitbucket
+# Step 2: Sync main to Bitbucket (main-mirror branch)
 echo "📤 Syncing main to Bitbucket..."
-git push atlassian main
+git push atlassian main:main-mirror
 
 # Step 3: Rebase Bitbucket's release branch onto updated main
 echo "🔄 Rebasing Bitbucket release branch..."


### PR DESCRIPTION
## Summary

Adds infrastructure for producing properly signed and notarized macOS DMGs via Atlassian's internal Bitbucket Pipelines, while keeping GitHub as the primary development repo.

### Problem
VocaMac is currently ad-hoc signed. Users must run `xattr -cr /Applications/VocaMac.app` to bypass Gatekeeper — a friction point [reported by multiple Atlassians](https://hello.atlassian.net/wiki/spaces/~70121f90859b038d84dfb9ac5dfbad2120808/blog/2026/03/05/6586381551).

### Solution
A dual-remote release workflow that triggers both GitHub Actions (ad-hoc signed) and Bitbucket Pipelines (signed + notarized with Atlassian's Developer ID certificate).

### Changes
- **`scripts/release.sh`** (new) — Orchestrates releases across both remotes: syncs main to Bitbucket's `main-mirror` branch, rebases the `release` branch, tags both remotes to trigger CI/CD
- **`Makefile`** — Added `make release VERSION=X.Y.Z` target
- **`.gitignore`** — Added `bitbucket-pipelines.yml` (this file lives only on Bitbucket's `release` branch, never on GitHub)

### Not in this PR (by design)
- `bitbucket-pipelines.yml` — Created separately, pushed only to Bitbucket's `release` branch. It handles: ephemeral macOS M1 runners, Hancock cert install, code signing with `Developer ID Application: Atlassian Pty Ltd (UPXU4CQZ5P)`, DMG creation, Apple notarization & stapling.

### Architecture
```
GitHub (origin)                    Bitbucket (atlassian)
─────────────────                  ──────────────────────
main ──────────────sync──────────► main-mirror
  │                                  │
  ├── tag v0.3.0 ──────────────────► release branch (main-mirror + pipelines.yml)
  │       │                               │
  │       ▼                               ▼
  │   GitHub Actions                 Bitbucket Pipelines
  │   (ad-hoc signed DMG)           (signed + notarized DMG)
  │       │                               │
  │       ▼                               ▼
  └── GitHub Release ◄───── attach signed DMG from BB artifacts
```

