### PR TITLE
fix: resolve Swift concurrency warnings in VocaMacApp

### DIFF
--- a/Sources/VocaMac/App/VocaMacApp.swift
+++ b/Sources/VocaMac/App/VocaMacApp.swift
@@ -105,9 +105,10 @@ final class OnboardingWindowManager: ObservableObject {
             object: window,
             queue: .main
         ) { [weak self] _ in
-            self?.onboardingWindow = nil
-            // Hide from dock when onboarding closes
-            DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
+            Task { @MainActor [weak self] in
+                self?.onboardingWindow = nil
+                // Hide from dock when onboarding closes
+                try? await Task.sleep(nanoseconds: 500_000_000)
                 NSApp.setActivationPolicy(.accessory)
             }
         }
@@ -157,7 +158,7 @@ struct VocaMacApp: App {
         .menuBarExtraStyle(.window)
     }
 
-    init() {
+    @MainActor init() {
         // Ensure only one instance of VocaMac is running
         Self.ensureSingleInstance()
 
@@ -173,7 +174,9 @@ struct VocaMacApp: App {
             object: nil,
             queue: .main
         ) { [self] _ in
-            self.onboardingManager.open(appState: self.appState, force: true)
+            Task { @MainActor [self] in
+                self.onboardingManager.open(appState: self.appState, force: true)
+            }
         }
 
         // Show onboarding on first launch


### PR DESCRIPTION
## Summary

Fixes two Swift concurrency warnings that appeared during `make install`:

### Warning 1 — `OnboardingWindowManager` line 108
`main actor-isolated property 'onboardingWindow' can not be mutated from a Sendable closure`

The `NotificationCenter` observer closure is `Sendable`, losing `@MainActor` isolation even though the closure runs on `.main` queue. Fixed by wrapping the mutation in `Task { @MainActor in }` and replacing `DispatchQueue.main.asyncAfter` with `Task.sleep`.

### Warning 2 — `VocaMacApp.init` line 176
`call to main actor-isolated instance method 'open(appState:force:)' in a synchronous nonisolated context`

Same root cause — the `NotificationCenter` observer closure for `.showOnboarding` is `Sendable`, so calling a `@MainActor` method directly warns. Fixed by wrapping the call in `Task { @MainActor in }`.

## Testing
- `make install` produces **zero warnings** ✅
- All 155 tests pass ✅