### PR TITLE
fix: large-v3 model incorrectly marked as unsupported due to substring matching bug

### DIFF
--- a/Sources/VocaMac/Models/AppState.swift
+++ b/Sources/VocaMac/Models/AppState.swift
@@ -197,9 +197,19 @@ final class AppState: ObservableObject {
         // Detect system capabilities
         systemCapabilities = SystemInfo.detect()
 
-        // Get WhisperKit's device recommendation
+        // Get WhisperKit's device recommendation.
+        // WhisperKit's `.default` is its global best pick and may be in the
+        // disabled list for this device (e.g. large-v3 on a low-RAM Mac).
+        // If so, fall back to the best supported model instead.
         let recommendation = modelManager.deviceRecommendation()
-        deviceRecommendedModel = recommendation.defaultModel
+        let defaultIsDisabled = recommendation.disabled.contains(
+            where: { $0.contains(recommendation.defaultModel) || recommendation.defaultModel.contains($0) }
+        )
+        if defaultIsDisabled, let bestSupported = recommendation.supported.last {
+            deviceRecommendedModel = bestSupported
+        } else {
+            deviceRecommendedModel = recommendation.defaultModel
+        }
 
         // Initialize available models list
         availableModels = ModelSize.allCases.map { size in

--- a/Sources/VocaMac/Models/AppState.swift
+++ b/Sources/VocaMac/Models/AppState.swift
@@ -198,14 +198,11 @@ final class AppState: ObservableObject {
         systemCapabilities = SystemInfo.detect()
 
         // Get WhisperKit's device recommendation.
-        // WhisperKit's `.default` is its global best pick and may be in the
-        // disabled list for this device (e.g. large-v3 on a low-RAM Mac).
-        // If so, fall back to the best supported model instead.
+        // WhisperKit's `.default` may not be in the supported list for some
+        // devices. If so, fall back to the best supported model instead.
         let recommendation = modelManager.deviceRecommendation()
-        let defaultIsDisabled = recommendation.disabled.contains(
-            where: { $0.contains(recommendation.defaultModel) || recommendation.defaultModel.contains($0) }
-        )
-        if defaultIsDisabled, let bestSupported = recommendation.supported.last {
+        let defaultIsSupported = recommendation.supported.contains(recommendation.defaultModel)
+        if !defaultIsSupported, let bestSupported = recommendation.supported.last {
             deviceRecommendedModel = bestSupported
         } else {
             deviceRecommendedModel = recommendation.defaultModel

--- a/Sources/VocaMac/Services/ModelManager.swift
+++ b/Sources/VocaMac/Services/ModelManager.swift
@@ -103,8 +103,11 @@ final class ModelManager {
     /// Check if a model size is supported on this device
     func isModelSupported(_ size: ModelSize) -> Bool {
         let rec = WhisperKit.recommendedModels()
-        // A model is supported if it's not in the disabled list
-        return !rec.disabled.contains(where: { $0.contains(size.rawValue) })
+        // A model is supported if any variant of its size appears in the supported list.
+        // We check the supported list (not disabled) to avoid false positives from
+        // substring matching — e.g. "large-v3" matching "large-v3_turbo" in disabled.
+        let modelPrefix = whisperKitModelName(for: size)
+        return rec.supported.contains(where: { $0.hasPrefix(modelPrefix) })
     }
 
     // MARK: - Model Download

--- a/Sources/VocaMac/Views/SettingsView.swift
+++ b/Sources/VocaMac/Views/SettingsView.swift
@@ -337,7 +337,7 @@ struct ModelSettingsTab: View {
                     HStack {
                         Image(systemName: "sparkles")
                             .foregroundStyle(.blue)
-                        Text("WhisperKit recommends: **\(recommended)**")
+                        Text("Recommended for your device: **\(recommended)**")
                             .font(.callout)
                     }
                 }

--- a/Sources/VocaMac/Views/SettingsView.swift
+++ b/Sources/VocaMac/Views/SettingsView.swift
@@ -396,7 +396,8 @@ struct ModelRow: View {
                         .font(.callout)
                         .fontWeight(model.isActive ? .semibold : .regular)
 
-                    if let recommended = appState.deviceRecommendedModel,
+                    if model.isSupported,
+                       let recommended = appState.deviceRecommendedModel,
                        recommended.contains(model.size.rawValue) {
                         Text("Recommended")
                             .font(.caption2)


### PR DESCRIPTION
## Summary

- Large v3 model was incorrectly showing both "Recommended" and "Unsupported" badges on M1 Macs with 32 GB RAM
- Root cause was a substring matching bug in `ModelManager.isModelSupported()`

<img width="672" height="670" alt="image" src="https://github.com/user-attachments/assets/5c9c582f-b7fc-4ed6-88e2-a2491da8c8c3" />


## Root Cause

WhisperKit computes a `disabled` list per device — all known models across every device category minus what's supported for the current device. On an M1 Mac, plain `openai_whisper-large-v3` **is** supported, but turbo/quantized variants from other device categories (e.g. `openai_whisper-large-v3_turbo_954MB`) are not — they only appear in M2/M3/M4 supported lists, so they end up in M1's disabled list.

The old check was:

```swift
!rec.disabled.contains(where: { $0.contains(size.rawValue) })
```

Since `"openai_whisper-large-v3_turbo_954MB".contains("large-v3")` evaluates to `true`, the function incorrectly concluded that plain `large-v3` was disabled.

## Fix

- **`ModelManager.isModelSupported()`** — Check the `supported` list with `hasPrefix` on the full WhisperKit model name (e.g. `openai_whisper-large-v3`) instead of substring-matching against the disabled list
- **`AppState.setupServices()`** — Defensive fallback: if WhisperKit's default recommendation isn't in the supported list, use the best supported model instead
- **`SettingsView`** — Only show the "Recommended" badge when `model.isSupported` is also true; updated bottom label to "Recommended for your device"
