### PR TITLE
chore: bump version to 0.5.0

### DIFF
--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -54,9 +54,9 @@ Pre-release versions use suffixes: `v0.1.0-alpha`, `v0.1.0-beta.1`
 2. **GitHub Actions automatically**:
    - Imports the Developer ID certificate from repository secrets
    - Builds the release binary with Developer ID signing
-   - Creates a beautiful branded DMG (`VocaMac-0.4.0-arm64.dmg`)
+   - Creates a beautiful branded DMG (`VocaMac-0.5.0-arm64.dmg`)
    - Notarizes with Apple and staples the ticket
-   - Packages as ZIP (`VocaMac-0.4.0-arm64.zip`)
+   - Packages as ZIP (`VocaMac-0.5.0-arm64.zip`)
    - Generates SHA-256 checksums
    - Creates a **draft** GitHub Release with all artifacts
 

--- a/docs/RELEASE_NOTES_v0.5.0.md
+++ b/docs/RELEASE_NOTES_v0.5.0.md
@@ -1,0 +1,34 @@
+# VocaMac v0.5.0
+
+## In-App Updates
+
+VocaMac can now check for updates automatically and download the latest release right from the app. On launch (once every 24 hours), it queries GitHub Releases and shows an update banner in the menu bar popover when a newer version is available. One-click download with real-time progress, SHA-256 integrity verification, and guided drag-to-Applications install.
+
+Manual check available at **Settings > About > Check for Updates**.
+
+## Improved Mic Indicator Placement
+
+The floating mic indicator now uses a 4-tier Accessibility API fallback strategy instead of the previous binary caret-or-mouse approach:
+
+| Tier | Method | Works In |
+|------|--------|----------|
+| 1 | Exact caret position | Native AppKit/SwiftUI apps |
+| 2 | Focused element bounds | Electron apps, terminal emulators |
+| 3 | Focused window position | Almost all apps |
+| 4 | Mouse cursor | Last resort |
+
+This significantly improves indicator placement in apps like **Cursor** and **iTerm2** that don't implement full AX text attributes.
+
+## Other Changes
+
+- **Fixed large-v3 model incorrectly marked as unsupported** due to substring matching against disabled model variants. The recommendation engine now checks the supported list directly and falls back to the best supported model when the default is too large for the device.
+- **Improved log rotation efficiency** — reduced max log size from 5 MB to 1 MB, cached date formatter, eliminated per-write `fsync`, and added proper error handling during rotation.
+- **Tests run 2x faster** with zero system side effects — all service dependencies (audio, hotkeys, sounds, permissions) are now injected via protocols with mock implementations.
+
+## Full Changelog
+
+- feat: add in-app GitHub Releases update flow (#96)
+- fix: add tiered fallback for cursor indicator positioning (#93)
+- fix: large-v3 model incorrectly marked as unsupported due to substring matching bug (#92)
+- fix: improve log rotation efficiency and reduce max log size from 5MB to 1MB (#94)
+- fix: inject mock services in tests to eliminate system side effects (#95)

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -148,9 +148,9 @@ cat > "${APP_DIR}/Contents/Info.plist" << EOF
     <key>CFBundleDisplayName</key>
     <string>${APP_NAME}</string>
     <key>CFBundleVersion</key>
-    <string>0.4.0</string>
+    <string>0.5.0</string>
     <key>CFBundleShortVersionString</key>
-    <string>0.4.0</string>
+    <string>0.5.0</string>
     <key>CFBundlePackageType</key>
     <string>APPL</string>
     <key>LSMinimumSystemVersion</key>

--- a/web/layouts/index.html
+++ b/web/layouts/index.html
@@ -36,7 +36,7 @@
             "Open source (AGPL-3.0 license)"
         ],
         "screenshot": "https://vocamac.com/og-image.png",
-        "softwareVersion": "0.4.0",
+        "softwareVersion": "0.5.0",
         "softwareRequirements": "macOS 13 (Ventura) or later, Apple Silicon (M1 or later), 8 GB RAM minimum"
     }
     </script>
@@ -49,7 +49,7 @@
             <div class="hero__content">
                 <div class="hero__badges">
                     <span class="badge badge--beta">BETA RELEASE</span>
-                    <span class="badge badge--outline" id="version-badge">v0.4.0</span>
+                    <span class="badge badge--outline" id="version-badge">v0.5.0</span>
                 </div>
                 <h1 class="hero__headline">
                     Your Voice,<br>


### PR DESCRIPTION
## Summary

Bumps version from `0.4.0` to `0.5.0` and prepares release notes.

**Why 0.5.0 (minor) instead of 0.4.1 (patch):** Since v0.4.0, there is one significant new feature — **in-app GitHub Releases update flow** (#96) — which warrants a minor version bump per semver. The remaining changes are bug fixes and test infrastructure improvements.

## Changes

### Version bump (`0.4.0` → `0.5.0`)
- `scripts/build.sh` — `CFBundleVersion` and `CFBundleShortVersionString`
- `web/layouts/index.html` — JSON-LD `softwareVersion` and hero version badge
- `docs/RELEASE.md` — example DMG/ZIP filenames

### Release notes
- `docs/RELEASE_NOTES_v0.5.0.md` — full release notes covering all 5 PRs since v0.4.0

## Included in this release

| PR | Type | Description |
|----|------|-------------|
| #96 | feat | In-app GitHub Releases update flow |
| #93 | fix | Tiered fallback for cursor indicator positioning |
| #92 | fix | large-v3 model incorrectly marked as unsupported |
| #94 | fix | Log rotation efficiency, reduced max size 5MB→1MB |
| #95 | fix | Mock service injection, 2x faster tests |

## After merge

```bash
git tag -a v0.5.0 -m "VocaMac v0.5.0"
git push origin v0.5.0
```

Then review and publish the draft GitHub Release that CI creates. The website auto-deploys on publish.