### PR TITLE
fix: overhaul model recommendation logic and allow force-loading unoptimized models

### DIFF
--- a/Sources/VocaMac/Models/AppState.swift
+++ b/Sources/VocaMac/Models/AppState.swift
@@ -251,6 +251,39 @@ final class AppState: ObservableObject {
             )
         }
 
+        // Enforce monotonic support ordering: if a smaller model is unsupported,
+        // all larger models must also be unsupported. This prevents contradictory
+        // UI states like Medium="Too Large" but Large v3="Recommended".
+        var foundUnsupported = false
+        for i in availableModels.indices {
+            if !availableModels[i].isSupported {
+                foundUnsupported = true
+            }
+            if foundUnsupported {
+                availableModels[i].isSupported = false
+            }
+        }
+
+        // Validate that the recommended model maps to a supported ModelSize.
+        // If the recommendation points to an unsupported model, fall back to
+        // the largest supported model instead.
+        if let recommended = deviceRecommendedModel {
+            let recommendedSize = modelManager.modelSize(from: recommended)
+            let isRecommendedSupported = recommendedSize.map { size in
+                availableModels.first(where: { $0.size == size })?.isSupported == true
+            } ?? false
+
+            if !isRecommendedSupported {
+                // Fall back to the largest supported model
+                if let bestSupported = availableModels.last(where: { $0.isSupported }) {
+                    deviceRecommendedModel = modelManager.whisperKitModelName(for: bestSupported.size)
+                } else {
+                    // No models are supported — clear the recommendation
+                    deviceRecommendedModel = nil
+                }
+            }
+        }
+
         // Setup audio level reporting
         audioEngine.onAudioLevel = { [weak self] level in
             Task { @MainActor in

--- a/Sources/VocaMac/Services/ModelManager.swift
+++ b/Sources/VocaMac/Services/ModelManager.swift
@@ -100,14 +100,42 @@ final class ModelManager {
         ModelSize.allCases.filter { isModelDownloaded($0) }
     }
 
-    /// Check if a model size is supported on this device
+    /// Check if a model size is supported on this device.
+    ///
+    /// Uses exact prefix boundary matching: "openai_whisper-large-v3" matches
+    /// versioned variants like "openai_whisper-large-v3-v20240930_626MB" but NOT
+    /// different models like "openai_whisper-large-v3_turbo-v20240930_626MB".
+    /// Also checks the disabled list — if any exact variant is disabled, the model
+    /// is considered unsupported to avoid recommending models the device can't run.
     func isModelSupported(_ size: ModelSize) -> Bool {
         let rec = WhisperKit.recommendedModels()
-        // A model is supported if any variant of its size appears in the supported list.
-        // We check the supported list (not disabled) to avoid false positives from
-        // substring matching — e.g. "large-v3" matching "large-v3_turbo" in disabled.
         let modelPrefix = whisperKitModelName(for: size)
-        return rec.supported.contains(where: { $0.hasPrefix(modelPrefix) })
+
+        // Match exact model name or versioned variants (prefix + "-")
+        // but not different models that share a prefix (e.g. large-v3_turbo)
+        let matchesModel: (String) -> Bool = { name in
+            name == modelPrefix || name.hasPrefix(modelPrefix + "-")
+        }
+
+        // If any exact variant of this model is in the disabled list, it's unsupported
+        if rec.disabled.contains(where: matchesModel) {
+            return false
+        }
+
+        return rec.supported.contains(where: matchesModel)
+    }
+
+    /// Map a WhisperKit model name back to a ModelSize, if it matches one of our known sizes.
+    ///
+    /// Uses exact prefix boundary matching, same as `isModelSupported`.
+    func modelSize(from whisperKitName: String) -> ModelSize? {
+        for size in ModelSize.allCases {
+            let prefix = whisperKitModelName(for: size)
+            if whisperKitName == prefix || whisperKitName.hasPrefix(prefix + "-") {
+                return size
+            }
+        }
+        return nil
     }
 
     // MARK: - Model Download

--- a/Sources/VocaMac/Services/ServiceProtocols.swift
+++ b/Sources/VocaMac/Services/ServiceProtocols.swift
@@ -93,6 +93,7 @@ protocol ModelManaging: AnyObject {
     func isModelDownloaded(_ size: ModelSize) -> Bool
     func isModelSupported(_ size: ModelSize) -> Bool
     func whisperKitModelName(for size: ModelSize) -> String
+    func modelSize(from whisperKitName: String) -> ModelSize?
     func downloadModel(size: ModelSize, onProgress: @escaping (Double) -> Void) async throws
     func diskUsageDescription() -> String
 }

--- a/Sources/VocaMac/Views/OnboardingView.swift
+++ b/Sources/VocaMac/Views/OnboardingView.swift
@@ -585,7 +585,7 @@ struct ModelSelectionCard: View {
             RoundedRectangle(cornerRadius: 8)
                 .stroke(isRecommended ? Color.orange : Color.clear, lineWidth: 1.5)
         )
-        .alert("Use Unsupported Model?", isPresented: $showForceDownloadAlert) {
+        .alert("Use Unoptimized Model?", isPresented: $showForceDownloadAlert) {
             Button("Cancel", role: .cancel) {}
             Button("Download Anyway", role: .destructive) {
                 onDownload()

--- a/Sources/VocaMac/Views/OnboardingView.swift
+++ b/Sources/VocaMac/Views/OnboardingView.swift
@@ -453,6 +453,7 @@ struct ModelSelectionCard: View {
     let isRecommended: Bool
     let onSelect: () -> Void
     let onDownload: () -> Void
+    @State private var showForceDownloadAlert = false
 
     var body: some View {
         VStack(alignment: .leading, spacing: 12) {
@@ -543,9 +544,21 @@ struct ModelSelectionCard: View {
                         .buttonStyle(.plain)
                     }
                 } else if !modelInfo.isSupported {
-                    Text("Not supported on this device")
+                    Button {
+                        showForceDownloadAlert = true
+                    } label: {
+                        HStack(spacing: 4) {
+                            Image(systemName: "exclamationmark.triangle")
+                            Text("Try Anyway")
+                        }
                         .font(.caption)
-                        .foregroundStyle(.red)
+                        .padding(.horizontal, 12)
+                        .padding(.vertical, 6)
+                        .background(Color.gray.opacity(0.2))
+                        .foregroundStyle(.secondary)
+                        .cornerRadius(6)
+                    }
+                    .buttonStyle(.plain)
                 } else {
                     Button(action: onDownload) {
                         HStack(spacing: 4) {
@@ -572,6 +585,14 @@ struct ModelSelectionCard: View {
             RoundedRectangle(cornerRadius: 8)
                 .stroke(isRecommended ? Color.orange : Color.clear, lineWidth: 1.5)
         )
+        .alert("Use Unsupported Model?", isPresented: $showForceDownloadAlert) {
+            Button("Cancel", role: .cancel) {}
+            Button("Download Anyway", role: .destructive) {
+                onDownload()
+            }
+        } message: {
+            Text("This model may exceed your device's capabilities. It could cause slow performance, high memory usage, or crashes. Are you sure you want to continue?")
+        }
     }
 }
 

--- a/Sources/VocaMac/Views/OnboardingView.swift
+++ b/Sources/VocaMac/Views/OnboardingView.swift
@@ -398,7 +398,10 @@ struct ModelSelectionStep: View {
                 .padding(.horizontal)
 
             if let recommended = appState.deviceRecommendedModel,
-               let recommendedSize = ModelSize.allCases.first(where: { recommended.contains($0.rawValue) }) {
+               let recommendedSize = ModelSize.allCases.first(where: { size in
+                   let prefix = "openai_whisper-\(size.rawValue)"
+                   return recommended == prefix || recommended.hasPrefix(prefix + "-")
+               }) {
                 HStack(spacing: 12) {
                     Image(systemName: "lightbulb.fill")
                         .font(.caption)
@@ -416,7 +419,11 @@ struct ModelSelectionStep: View {
                     ForEach(appState.availableModels) { modelInfo in
                         ModelSelectionCard(
                             modelInfo: modelInfo,
-                            isRecommended: appState.deviceRecommendedModel?.contains(modelInfo.size.rawValue) == true,
+                            isRecommended: {
+                                guard let recommended = appState.deviceRecommendedModel else { return false }
+                                let prefix = "openai_whisper-\(modelInfo.size.rawValue)"
+                                return recommended == prefix || recommended.hasPrefix(prefix + "-")
+                            }(),
                             onSelect: {
                                 Task {
                                     await appState.loadModel(modelInfo.size)

--- a/Sources/VocaMac/Views/SettingsView.swift
+++ b/Sources/VocaMac/Views/SettingsView.swift
@@ -333,11 +333,15 @@ struct ModelSettingsTab: View {
                         .foregroundStyle(.secondary)
                 }
 
-                if let recommended = appState.deviceRecommendedModel {
+                if let recommended = appState.deviceRecommendedModel,
+                   let recommendedSize = ModelSize.allCases.first(where: { size in
+                       let prefix = "openai_whisper-\(size.rawValue)"
+                       return recommended == prefix || recommended.hasPrefix(prefix + "-")
+                   }) {
                     HStack {
                         Image(systemName: "sparkles")
                             .foregroundStyle(.blue)
-                        Text("Recommended for your device: **\(recommended)**")
+                        Text("Recommended for your device: **\(recommendedSize.displayName)**")
                             .font(.callout)
                     }
                 }
@@ -397,15 +401,19 @@ struct ModelRow: View {
                         .fontWeight(model.isActive ? .semibold : .regular)
 
                     if model.isSupported,
-                       let recommended = appState.deviceRecommendedModel,
-                       recommended.contains(model.size.rawValue) {
-                        Text("Recommended")
-                            .font(.caption2)
-                            .padding(.horizontal, 6)
-                            .padding(.vertical, 1)
-                            .background(.blue.opacity(0.2))
-                            .foregroundStyle(.blue)
-                            .cornerRadius(4)
+                       let recommended = appState.deviceRecommendedModel {
+                        // Use exact prefix boundary matching to avoid cross-model
+                        // false positives (e.g. "large-v3" matching "large-v3_turbo")
+                        let prefix = "openai_whisper-\(model.size.rawValue)"
+                        if recommended == prefix || recommended.hasPrefix(prefix + "-") {
+                            Text("Recommended")
+                                .font(.caption2)
+                                .padding(.horizontal, 6)
+                                .padding(.vertical, 1)
+                                .background(.blue.opacity(0.2))
+                                .foregroundStyle(.blue)
+                                .cornerRadius(4)
+                        }
                     }
 
                     if !model.isSupported {

--- a/Sources/VocaMac/Views/SettingsView.swift
+++ b/Sources/VocaMac/Views/SettingsView.swift
@@ -418,12 +418,12 @@ struct ModelRow: View {
                     }
 
                     if !model.isSupported {
-                        Text("Unsupported")
+                        Text("Unoptimized")
                             .font(.caption2)
                             .padding(.horizontal, 6)
                             .padding(.vertical, 1)
-                            .background(.red.opacity(0.2))
-                            .foregroundStyle(.red)
+                            .background(.orange.opacity(0.2))
+                            .foregroundStyle(.orange)
                             .cornerRadius(4)
                     }
                 }
@@ -508,7 +508,7 @@ struct ModelRow: View {
         }
         .padding(.vertical, 8)
         .padding(.horizontal, 4)
-        .alert("Use Unsupported Model?", isPresented: $showForceDownloadAlert) {
+        .alert("Use Unoptimized Model?", isPresented: $showForceDownloadAlert) {
             Button("Cancel", role: .cancel) {}
             Button(model.isDownloaded ? "Load Anyway" : "Download & Load", role: .destructive) {
                 Task {

--- a/Sources/VocaMac/Views/SettingsView.swift
+++ b/Sources/VocaMac/Views/SettingsView.swift
@@ -385,6 +385,7 @@ struct SystemInfoPill: View {
 struct ModelRow: View {
     let model: WhisperModelInfo
     @ObservedObject var appState: AppState
+    @State private var showForceDownloadAlert = false
 
     var body: some View {
         HStack {
@@ -469,9 +470,21 @@ struct ModelRow: View {
                     .font(.caption)
                     .foregroundStyle(.green)
             } else if !model.isSupported {
-                Text("Too Large")
-                    .font(.caption)
+                if model.isLoading || model.downloadProgress != nil {
+                    EmptyView()
+                } else if model.isDownloaded {
+                    Button("Load Anyway") {
+                        showForceDownloadAlert = true
+                    }
+                    .controlSize(.small)
                     .foregroundStyle(.secondary)
+                } else {
+                    Button("Try Anyway") {
+                        showForceDownloadAlert = true
+                    }
+                    .controlSize(.small)
+                    .foregroundStyle(.secondary)
+                }
             } else if model.isLoading || model.downloadProgress != nil {
                 // Show nothing - progress indicator handles the feedback
                 EmptyView()
@@ -495,6 +508,21 @@ struct ModelRow: View {
         }
         .padding(.vertical, 8)
         .padding(.horizontal, 4)
+        .alert("Use Unsupported Model?", isPresented: $showForceDownloadAlert) {
+            Button("Cancel", role: .cancel) {}
+            Button(model.isDownloaded ? "Load Anyway" : "Download & Load", role: .destructive) {
+                Task {
+                    if !model.isDownloaded {
+                        await appState.downloadModel(model.size)
+                    }
+                    if model.isDownloaded || appState.availableModels.first(where: { $0.size == model.size })?.isDownloaded == true {
+                        await appState.loadModel(model.size)
+                    }
+                }
+            }
+        } message: {
+            Text("This model may exceed your device's capabilities. It could cause slow performance, high memory usage, or crashes. Are you sure you want to continue?")
+        }
     }
 }
 

--- a/Tests/VocaMacTests/Mocks/MockServices.swift
+++ b/Tests/VocaMacTests/Mocks/MockServices.swift
@@ -238,6 +238,16 @@ final class MockModelManager: ModelManaging {
         "openai_whisper-\(size.rawValue)"
     }
 
+    func modelSize(from whisperKitName: String) -> ModelSize? {
+        for size in ModelSize.allCases {
+            let prefix = whisperKitModelName(for: size)
+            if whisperKitName == prefix || whisperKitName.hasPrefix(prefix + "-") {
+                return size
+            }
+        }
+        return nil
+    }
+
     func downloadModel(size: ModelSize, onProgress: @escaping (Double) -> Void) async throws {
         downloadedModels.insert(size)
     }


### PR DESCRIPTION
## Summary

- Fix contradictory model support states where Medium showed "Too Large" but Large v3 showed "Recommended" due to loose prefix matching and missing disabled-list checks
- Enforce monotonic support ordering so larger models can't appear supported when smaller ones aren't
- Allow users to override and force-download/load unoptimized models with a confirmation warning
- Replace harsh "Unsupported" red badge with softer "Unoptimized" orange badge and matching alert text
- Show friendly model display names in the recommendation footer instead of raw WhisperKit IDs

## Root Cause

`isModelSupported()` used `hasPrefix` matching that couldn't distinguish between `large-v3` and `large-v3_turbo` variants, and never checked WhisperKit's disabled list. The recommendation badge used `.contains(rawValue)` substring matching with the same cross-model issue. Together, these caused models to appear both "Too Large" and "Recommended" simultaneously.

## Changes

### Bug Fixes
- **`ModelManager.isModelSupported()`** — Exact prefix boundary matching (prefix + `-`) and disabled list check
- **`ModelManager.modelSize(from:)`** — New helper to map WhisperKit model names back to `ModelSize`
- **`AppState.setupServices()`** — Monotonic support enforcement + recommendation validation with fallback
- **`SettingsView` / `OnboardingView`** — Fixed recommendation badge matching to use exact prefix boundaries

### New Feature
- Unsupported models now show "Try Anyway" / "Load Anyway" buttons instead of a dead-end "Too Large" label
- Clicking triggers a confirmation alert explaining potential performance risks before proceeding

### UI Polish
- "Unsupported" red badge → "Unoptimized" orange badge
- "Use Unsupported Model?" alert → "Use Unoptimized Model?"
- Recommendation footer shows display name (e.g. "Small") instead of raw WhisperKit ID

## Files Changed

- `Sources/VocaMac/Services/ModelManager.swift`
- `Sources/VocaMac/Services/ServiceProtocols.swift`
- `Sources/VocaMac/Models/AppState.swift`
- `Sources/VocaMac/Views/SettingsView.swift`
- `Sources/VocaMac/Views/OnboardingView.swift`
- `Tests/VocaMacTests/Mocks/MockServices.swift`