### PR TITLE
feat: Sign, notarize, and version nightly builds

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -6,6 +6,12 @@ on:
     - cron: '0 0 * * *'
   workflow_dispatch:
     # Allow manual trigger for testing
+    inputs:
+      skip_notarize:
+        description: 'Skip notarization (faster builds for debugging)'
+        required: false
+        default: false
+        type: boolean
 
 permissions:
   contents: write
@@ -138,7 +144,7 @@ jobs:
     needs: check-for-changes
     if: needs.check-for-changes.outputs.has_changes == 'true'
     runs-on: macos-15
-    timeout-minutes: 30
+    timeout-minutes: 45
 
     steps:
       - name: Checkout
@@ -158,48 +164,124 @@ jobs:
       - name: Initialize Xcode tools
         run: sudo xcodebuild -runFirstLaunch
 
-      - name: Build release app bundle
-        run: ./scripts/build.sh release
+      # ── Code Signing Setup ──────────────────────────────────────────────────
+      - name: Import Developer ID certificate
+        env:
+          DEVELOPER_ID_CERT_P12:          ${{ secrets.DEVELOPER_ID_CERT_P12 }}
+          DEVELOPER_ID_CERT_PASSWORD:     ${{ secrets.DEVELOPER_ID_CERT_PASSWORD }}
+        run: |
+          # Create a temporary keychain so the cert is isolated to this job
+          KEYCHAIN_PATH="$RUNNER_TEMP/build.keychain"
+          KEYCHAIN_PASSWORD="$(openssl rand -hex 16)"
+
+          security create-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+          security set-keychain-settings -lut 21600 "$KEYCHAIN_PATH"
+          security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+
+          # Decode and import the p12
+          echo "$DEVELOPER_ID_CERT_P12" | base64 --decode > "$RUNNER_TEMP/cert.p12"
+          security import "$RUNNER_TEMP/cert.p12" \
+            -k "$KEYCHAIN_PATH" \
+            -P "$DEVELOPER_ID_CERT_PASSWORD" \
+            -T /usr/bin/codesign \
+            -T /usr/bin/security
+
+          # Allow codesign to access the key without a passphrase prompt
+          security set-key-partition-list \
+            -S apple-tool:,apple:,codesign: \
+            -s -k "$KEYCHAIN_PASSWORD" \
+            "$KEYCHAIN_PATH"
+
+          # Add to keychain search list
+          security list-keychains -d user -s "$KEYCHAIN_PATH" $(security list-keychains -d user | xargs)
+
+          # Store the keychain path for later steps
+          echo "KEYCHAIN_PATH=$KEYCHAIN_PATH" >> "$GITHUB_ENV"
+          echo "KEYCHAIN_PASSWORD=$KEYCHAIN_PASSWORD" >> "$GITHUB_ENV"
+
+          # Verify the identity
+          IDENTITY=$(security find-identity -v -p codesigning "$KEYCHAIN_PATH" \
+            | grep "Developer ID Application" | head -1 | sed 's/.*"\(.*\)"/\1/')
+          if [ -z "$IDENTITY" ]; then
+            echo "❌ Developer ID certificate not found after import"
+            exit 1
+          fi
+          echo "✅ Imported: $IDENTITY"
+          echo "CODE_SIGN_IDENTITY=$IDENTITY" >> "$GITHUB_ENV"
+
+      - name: Store notarization credentials
+        if: ${{ !inputs.skip_notarize }}
+        env:
+          NOTARIZE_APPLE_ID:   ${{ secrets.NOTARIZE_APPLE_ID }}
+          NOTARIZE_TEAM_ID:    ${{ secrets.NOTARIZE_TEAM_ID }}
+          NOTARIZE_PASSWORD:   ${{ secrets.NOTARIZE_PASSWORD }}
+        run: |
+          xcrun notarytool store-credentials "AC_PASSWORD" \
+            --apple-id  "$NOTARIZE_APPLE_ID" \
+            --team-id   "$NOTARIZE_TEAM_ID" \
+            --password  "$NOTARIZE_PASSWORD"
+
+      # ── Nightly Version ────────────────────────────────────────────────────
+      - name: Set nightly version
+        run: |
+          NIGHTLY_DATE=$(date -u +%Y%m%d)
+          SHORT_SHA="${{ needs.check-for-changes.outputs.short_sha }}"
+          BASE_VERSION=$(grep -A1 'CFBundleShortVersionString' scripts/build.sh \
+            | grep 'APP_VERSION' | sed 's/.*:-\(.*\)}.*/\1/' || echo "0.5.0")
+          # Fallback: extract the default value from APP_VERSION="${APP_VERSION:-X.Y.Z}"
+          if [ -z "$BASE_VERSION" ] || [ "$BASE_VERSION" = "0.5.0" ]; then
+            BASE_VERSION="0.5.0"
+          fi
+          APP_VERSION="${BASE_VERSION}-nightly.${NIGHTLY_DATE}+${SHORT_SHA}"
+          echo "APP_VERSION=${APP_VERSION}" >> "$GITHUB_ENV"
+          echo "📌 Nightly version: ${APP_VERSION}"
+
+      # ── Build & Package ─────────────────────────────────────────────────────
+      - name: Build signed, notarized DMG via dist.sh
+        run: |
+          DIST_FLAGS=""
+          if [ "${{ inputs.skip_notarize }}" = "true" ]; then
+            DIST_FLAGS="--skip-notarize"
+          fi
+          ./scripts/dist.sh $DIST_FLAGS
+        env:
+          APP_VERSION: ${{ env.APP_VERSION }}
 
       - name: Verify code signature
-        run: codesign -v --deep VocaMac.app || echo "Signature verification note - expected for ad-hoc nightly builds"
+        run: codesign -v --deep --strict VocaMac.app
 
-      - name: Create DMG
+      - name: Rename artifacts for nightly
         run: |
           NIGHTLY_DATE=$(date -u +%Y%m%d)
           SHORT_SHA="${{ needs.check-for-changes.outputs.short_sha }}"
-          DMG_NAME="VocaMac-nightly-${NIGHTLY_DATE}-${SHORT_SHA}-arm64.dmg"
+          ARCH=$(uname -m)
 
-          mkdir -p dmg-staging
-          cp -R VocaMac.app dmg-staging/
-          ln -s /Applications dmg-staging/Applications
-
-          hdiutil create -volname "VocaMac Nightly" \
-            -srcfolder dmg-staging \
-            -ov -format UDZO \
-            "$DMG_NAME"
-
+          # Rename the DMG from dist/ to nightly naming convention
+          DIST_DMG=$(ls dist/VocaMac-*.dmg | head -1)
+          DMG_NAME="VocaMac-nightly-${NIGHTLY_DATE}-${SHORT_SHA}-${ARCH}.dmg"
+          cp "$DIST_DMG" "$DMG_NAME"
           echo "DMG_NAME=${DMG_NAME}" >> "$GITHUB_ENV"
-          echo "DMG created:"
-          ls -lh "$DMG_NAME"
 
-      - name: Create ZIP archive
-        run: |
-          NIGHTLY_DATE=$(date -u +%Y%m%d)
-          SHORT_SHA="${{ needs.check-for-changes.outputs.short_sha }}"
-          ZIP_NAME="VocaMac-nightly-${NIGHTLY_DATE}-${SHORT_SHA}-arm64.zip"
-
+          # Create ZIP from the signed .app
+          ZIP_NAME="VocaMac-nightly-${NIGHTLY_DATE}-${SHORT_SHA}-${ARCH}.zip"
           ditto -c -k --sequesterRsrc --keepParent VocaMac.app "$ZIP_NAME"
-
           echo "ZIP_NAME=${ZIP_NAME}" >> "$GITHUB_ENV"
-          echo "ZIP created:"
-          ls -lh "$ZIP_NAME"
+
+          echo "Artifacts created:"
+          ls -lh "$DMG_NAME" "$ZIP_NAME"
 
       - name: Generate checksums
         run: |
           shasum -a 256 VocaMac-nightly-*.dmg VocaMac-nightly-*.zip > checksums.txt
           cat checksums.txt
 
+      # ── Cleanup ─────────────────────────────────────────────────────────────
+      - name: Delete temporary keychain
+        if: always()
+        run: |
+          security delete-keychain "$KEYCHAIN_PATH" 2>/dev/null || true
+
+      # ── Release ─────────────────────────────────────────────────────────────
       - name: Delete existing nightly release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -230,6 +312,16 @@ jobs:
             STABLE_LINK="[**${LATEST_TAG}**](${REPO_URL}/releases/tag/${LATEST_TAG})"
           else
             STABLE_LINK="_No stable release available yet._"
+          fi
+
+          # Determine signing status for release notes
+          if [ "${{ inputs.skip_notarize }}" = "true" ]; then
+            SIGNING_NOTE="> **Note:** This nightly build is **Developer ID signed** but not notarized."
+            SIGNING_NOTE="${SIGNING_NOTE}"$'\n'"> macOS may show a Gatekeeper warning on first open."
+            SIGNING_NOTE="${SIGNING_NOTE}"$'\n'"> To bypass: right-click VocaMac.app → Open → click Open in the dialog."
+          else
+            SIGNING_NOTE="> This nightly build is **Developer ID signed and notarized** by Apple."
+            SIGNING_NOTE="${SIGNING_NOTE}"$'\n'"> macOS will open it without any security warnings."
           fi
 
           # Write release notes to a file (avoids heredoc indentation issues)
@@ -265,9 +357,7 @@ jobs:
             echo "3. Open VocaMac from Applications"
             echo "4. Grant Microphone, Accessibility, and Input Monitoring permissions when prompted"
             echo ""
-            echo "> **Note:** Nightly builds are ad-hoc signed (not notarized). macOS may show a Gatekeeper warning."
-            echo "> To bypass: right-click VocaMac.app → Open → click Open in the dialog."
-            echo "> For a fully signed + notarized build, use a [stable release](${REPO_URL}/releases/latest)."
+            echo "$SIGNING_NOTE"
             echo ""
             echo "### Checksums (SHA-256)"
             echo "\`\`\`"

--- a/Sources/VocaMac/Views/SettingsView.swift
+++ b/Sources/VocaMac/Views/SettingsView.swift
@@ -668,7 +668,7 @@ struct AboutTab: View {
                 .multilineTextAlignment(.center)
                 .fixedSize(horizontal: false, vertical: true)
 
-            Text("Version \(appVersionDisplay) (Beta)")
+            Text("Version \(appVersionDisplay) (\(buildChannelLabel))")
                 .font(.caption)
                 .foregroundStyle(.tertiary)
 
@@ -773,6 +773,10 @@ struct AboutTab: View {
 
     private var appVersionDisplay: String {
         Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "Unknown"
+    }
+
+    private var buildChannelLabel: String {
+        appVersionDisplay.contains("nightly") ? "Nightly" : "Beta"
     }
 
     private var updateStatusText: String {

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -8,6 +8,8 @@
 # 3. Code signs — Developer ID if CODE_SIGN_IDENTITY is set, ad-hoc otherwise
 #
 # Environment variables:
+#   APP_VERSION         — Version string to embed in Info.plist. Defaults to 0.5.0.
+#                         Set by CI for nightly builds (e.g., 0.5.0-nightly.20260414+abc1234).
 #   CODE_SIGN_IDENTITY  — Signing identity to use. Defaults to auto-detect
 #                         Developer ID Application in the login keychain.
 #                         Set to "-" to force ad-hoc signing.
@@ -27,6 +29,7 @@ BUNDLE_ID="com.vocamac.app"
 APP_NAME="VocaMac"
 APP_DIR="${APP_NAME}.app"
 ENTITLEMENTS="VocaMac.entitlements"
+APP_VERSION="${APP_VERSION:-0.5.0}"
 
 # Resolve signing identity:
 # 1. Use CODE_SIGN_IDENTITY env var if set
@@ -148,9 +151,9 @@ cat > "${APP_DIR}/Contents/Info.plist" << EOF
     <key>CFBundleDisplayName</key>
     <string>${APP_NAME}</string>
     <key>CFBundleVersion</key>
-    <string>0.5.0</string>
+    <string>${APP_VERSION}</string>
     <key>CFBundleShortVersionString</key>
-    <string>0.5.0</string>
+    <string>${APP_VERSION}</string>
     <key>CFBundlePackageType</key>
     <string>APPL</string>
     <key>LSMinimumSystemVersion</key>

--- a/scripts/dist.sh
+++ b/scripts/dist.sh
@@ -36,8 +36,8 @@ for arg in "$@"; do
     esac
 done
 
-# Get version from build.sh's Info.plist template
-VERSION=$(grep -A1 'CFBundleShortVersionString' scripts/build.sh | grep '<string>' | sed 's/.*<string>\(.*\)<\/string>/\1/' | head -1)
+# Get version from APP_VERSION env var (if set) or from build.sh's Info.plist template
+VERSION="${APP_VERSION:-$(grep -A1 'CFBundleShortVersionString' scripts/build.sh | grep '<string>' | sed 's/.*<string>\(.*\)<\/string>/\1/' | head -1)}"
 ARCH=$(uname -m)
 APP_NAME="VocaMac"
 DMG_NAME="${APP_NAME}-${VERSION}-${ARCH}.dmg"


### PR DESCRIPTION
## Summary

Nightly builds are now **Developer ID signed and notarized** by Apple, matching the same quality bar as stable releases. Users no longer see Gatekeeper warnings when opening nightly DMGs.

Additionally, nightly builds now embed a **SemVer pre-release version** (e.g. `0.5.0-nightly.20260414+abc1234`) so users can identify exactly which nightly they're running — both in the About tab and in bug reports.

## Changes

### `.github/workflows/nightly.yml`
- **Signing:** Import Developer ID certificate into a temporary keychain (same pattern as `release.yml`)
- **Notarization:** Store Apple notarization credentials and submit via `notarytool`
- **Reuse `dist.sh`:** Replace the bare `hdiutil` DMG creation with `dist.sh`, which produces a branded, signed, notarized DMG
- **Version injection:** Set `APP_VERSION` env var to `{base}-nightly.{YYYYMMDD}+{sha}` before building
- **Manual toggle:** Added `skip_notarize` input to `workflow_dispatch` for debugging (faster builds without waiting for Apple)
- **Release notes:** Dynamically reflect signing/notarization status instead of always warning about Gatekeeper
- **Keychain cleanup:** Added `always()` step to delete the temporary keychain

### `scripts/build.sh`
- Accept optional `APP_VERSION` environment variable (defaults to `0.5.0`)
- Use `${APP_VERSION}` in the generated `Info.plist` for both `CFBundleVersion` and `CFBundleShortVersionString`
- Backward compatible — existing `release.yml` and local dev workflows are unaffected

### `scripts/dist.sh`
- Respect `APP_VERSION` env var when set, otherwise fall back to scraping the default from `build.sh`

### `Sources/VocaMac/Views/SettingsView.swift`
- About tab now shows "Nightly" instead of "Beta" when the version string contains `nightly`
- No changes needed to version display logic — it already reads from `Bundle.main.infoDictionary`

## Testing

- All 160 existing tests pass (`swift test`)
- No new runtime dependencies — uses the same secrets already configured for `release.yml`

## Version Display

**Stable build About tab:** `Version 0.5.0 (Beta)`
**Nightly build About tab:** `Version 0.5.0-nightly.20260414+abc1234 (Nightly)`
