### PR TITLE
fix: correct version extraction in nightly build workflow

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -226,10 +226,9 @@ jobs:
         run: |
           NIGHTLY_DATE=$(date -u +%Y%m%d)
           SHORT_SHA="${{ needs.check-for-changes.outputs.short_sha }}"
-          BASE_VERSION=$(grep -A1 'CFBundleShortVersionString' scripts/build.sh \
-            | grep 'APP_VERSION' | sed 's/.*:-\(.*\)}.*/\1/' || echo "0.5.0")
-          # Fallback: extract the default value from APP_VERSION="${APP_VERSION:-X.Y.Z}"
-          if [ -z "$BASE_VERSION" ] || [ "$BASE_VERSION" = "0.5.0" ]; then
+          # Extract the default version from APP_VERSION="${APP_VERSION:-X.Y.Z}" in build.sh
+          BASE_VERSION=$(grep '^APP_VERSION=' scripts/build.sh | sed 's/.*:-\(.*\)}.*/\1/')
+          if [ -z "$BASE_VERSION" ]; then
             BASE_VERSION="0.5.0"
           fi
           APP_VERSION="${BASE_VERSION}-nightly.${NIGHTLY_DATE}+${SHORT_SHA}"


### PR DESCRIPTION
## Problem

The nightly build ([#12](https://github.com/jatinkrmalik/vocamac/actions/runs/24430053195)) has been failing at the DMG creation step with:

```
hdiutil: convert failed - No such file or directory
```

## Root Cause

The "Set nightly version" step extracted the base version using:

```bash
grep -A1 'CFBundleShortVersionString' scripts/build.sh | grep 'APP_VERSION' | sed 's/.*:-\(.*\)}.*/\1/'
```

This matched the **Info.plist template line** `<string>${APP_VERSION}</string>` instead of the **variable declaration** `APP_VERSION="${APP_VERSION:-0.5.0}"`. The sed pattern found no `:-` to match in the XML string, so the raw XML passed through unchanged, producing:

```
APP_VERSION = <string>${APP_VERSION}</string>-nightly.20260415+5dc94fe
```

The `<` and `>` characters made the DMG filename invalid, causing `hdiutil convert` to fail.

## Fix

Changed the grep to target the actual version declaration at the top of `build.sh`:

```bash
# Before (broken — matched XML template):
grep -A1 'CFBundleShortVersionString' scripts/build.sh | grep 'APP_VERSION' | sed ...

# After (fixed — matches variable declaration):
grep '^APP_VERSION=' scripts/build.sh | sed 's/.*:-\(.*\)}.*/\1/'
```

## Verification

Tested locally — produces clean version string:
```
BASE_VERSION: 0.5.0
APP_VERSION:  0.5.0-nightly.20260415+5dc94fe
```

After merging, we should manually trigger the nightly workflow to confirm the fix.