### PR TITLE
ci: use Python venv for huggingface-cli on macOS 15 runners

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -237,7 +237,11 @@ jobs:
 
       # ── Bundled Tiny Model ─────────────────────────────────────────────────
       - name: Set up Python for huggingface-cli
-        run: pip3 install -U huggingface_hub
+        run: |
+          python3 -m venv "$RUNNER_TEMP/hf-venv"
+          source "$RUNNER_TEMP/hf-venv/bin/activate"
+          pip install -U huggingface_hub
+          echo "$RUNNER_TEMP/hf-venv/bin" >> "$GITHUB_PATH"
 
       - name: Fetch bundled tiny model from Hugging Face
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -83,7 +83,11 @@ jobs:
 
       # ── Bundled Tiny Model ─────────────────────────────────────────────────
       - name: Set up Python for huggingface-cli
-        run: pip3 install -U huggingface_hub
+        run: |
+          python3 -m venv "$RUNNER_TEMP/hf-venv"
+          source "$RUNNER_TEMP/hf-venv/bin/activate"
+          pip install -U huggingface_hub
+          echo "$RUNNER_TEMP/hf-venv/bin" >> "$GITHUB_PATH"
 
       - name: Fetch bundled tiny model from Hugging Face
         run: |


### PR DESCRIPTION
## Problem

The `macos-15` GitHub Actions runner ships Homebrew-managed Python, which blocks bare `pip3 install` per [PEP 668](https://peps.python.org/pep-0668/):

```
error: externally-managed-environment
× This environment is externally managed
```

This broke both the nightly and release workflows after PR #110 added the `huggingface-cli` step to download the bundled tiny model.

**Failed run:** https://github.com/jatinkrmalik/vocamac/actions/runs/24525193017

## Fix

Create a temporary Python virtual environment at `$RUNNER_TEMP/hf-venv`, install `huggingface_hub` inside it, and add its `bin` directory to `$GITHUB_PATH` so the `hf` CLI is available in subsequent workflow steps.

Applied to both `nightly.yml` and `release.yml`.

## Testing

Merge this PR, then manually trigger the nightly workflow to verify.