### PR TITLE
fix: let WhisperKit handle tokenizer fetching instead of pre-validating

### DIFF
--- a/Sources/VocaMac/Models/AppState.swift
+++ b/Sources/VocaMac/Models/AppState.swift
@@ -542,12 +542,12 @@ final class AppState: ObservableObject {
         }
 
         do {
-            // If model is downloaded locally, validate/repair tokenizer assets
-            // before WhisperKit initializes. If validation fails (e.g. partial
-            // download), pass nil and let WhisperKit handle it.
+            // If model is downloaded locally, pass the folder URL so WhisperKit
+            // loads from disk instead of downloading again. WhisperKit handles
+            // tokenizer fetching itself — we don't pre-validate those files.
             let folderURL: URL?
             if let targetSize = targetSize, modelManager.isModelDownloaded(targetSize) {
-                folderURL = try? modelManager.ensureTokenizerAssets(for: targetSize)
+                folderURL = modelManager.modelFolder(for: targetSize)
             } else {
                 folderURL = nil
             }

--- a/Tests/VocaMacTests/AppStateTests.swift
+++ b/Tests/VocaMacTests/AppStateTests.swift
@@ -175,8 +175,12 @@ final class AppStateOnboardingTests: XCTestCase {
 
         await appState.performStartup()
 
+        // Bundled model should have been installed
         XCTAssertEqual(mocks.modelManager.installedBundledModels, [.tiny])
-        XCTAssertEqual(mocks.modelManager.ensuredTokenizerSizes, [.tiny])
+        // WhisperKit handles tokenizer fetching internally — we no longer
+        // pre-validate tokenizer assets before loading. Asserting that
+        // ensuredTokenizerSizes is empty confirms we removed the incorrect check.
+        XCTAssertEqual(mocks.modelManager.ensuredTokenizerSizes, [])
         XCTAssertEqual(mocks.whisperService.loadedModelName, "openai_whisper-tiny")
     }
 }


### PR DESCRIPTION
## Problem

Every fresh install from the nightly shows **"No model loaded"**:

```
[ERROR] [AppState] Failed to load model: Tokenizer assets are missing for model 'openai_whisper-tiny'.
```

This happened on every model, every time, on first launch.

## Root Cause

`AppState.loadModel` was calling `ensureTokenizerAssets(for:)` before passing the model folder to WhisperKit. This check looks for `tokenizer.json` and `tokenizer_config.json` inside the CoreML model directory — but **those files are never there**.

WhisperKit downloads CoreML weights from `argmaxinc/whisperkit-coreml` and tokenizer files from `openai/whisper-<size>` separately **at load time**. They're fetched by WhisperKit internally into its own cache — our code has no business pre-checking for them.

```
~/Library/Application Support/VocaMac/models/models/argmaxinc/whisperkit-coreml/openai_whisper-tiny/
├── config.json            ✅ present after download
├── AudioEncoder.mlmodelc  ✅ present after download
├── generation_config.json ✅ present after download
├── MelSpectrogram.mlmodelc ✅ present after download
├── TextDecoder.mlmodelc   ✅ present after download
├── tokenizer.json         ❌ NEVER HERE — WhisperKit fetches this itself
└── tokenizer_config.json  ❌ NEVER HERE — WhisperKit fetches this itself
```

A secondary bug in `consolidateWhisperKitDownload` also deleted the model during consolidation (source and destination paths were identical, `replaceDirectory` deleted the destination first then tried to copy from the now-missing source).

## Fix

- **Remove `ensureTokenizerAssets` from `loadModel`** — pass `modelFolder(for:)` directly to WhisperKit and let it handle tokenizer fetching as designed
- **Fix `consolidateWhisperKitDownload`** — skip the self-deleting `replaceDirectory` call; only search for and copy tokenizer files if they exist in known locations
- **Update test** — `ensuredTokenizerSizes` should now be empty (confirms the incorrect pre-check was removed)

## Testing

- 163 tests, 0 failures
- Confirmed `tokenizer.json` is never present in the WhisperKit CoreML download directory on disk
- WhisperKit's own source (`ModelUtilities.swift:78`) confirms it downloads tokenizer files itself at load time
