### PR TITLE
fix: add ETag caching to UpdateChecker to avoid GitHub rate limits

### DIFF
--- a/Sources/VocaMac/Services/UpdateChecker.swift
+++ b/Sources/VocaMac/Services/UpdateChecker.swift
@@ -58,6 +58,16 @@ final class UpdateChecker: ObservableObject {
     private let lastCheckKey = "vocamac.update.lastCheck"
     private let skippedVersionKey = "vocamac.update.skippedVersion"
 
+    // MARK: - ETag Cache Keys
+    /// Persisted ETag from the last successful GitHub API response.
+    /// Sent as `If-None-Match` on subsequent requests so GitHub returns
+    /// 304 Not Modified (free — doesn't count against the 60 req/hr limit)
+    /// when the latest release hasn't changed.
+    private let etagKey = "vocamac.update.etag"
+    /// Raw JSON body of the last successful GitHub API response, stored so
+    /// we can serve a cached result on 304 without a second network call.
+    private let cachedResponseKey = "vocamac.update.cachedResponse"
+
     func checkOnLaunchIfNeeded() async {
         let lastCheckTime = UserDefaults.standard.double(forKey: lastCheckKey)
         let shouldCheck = Date().timeIntervalSince1970 - lastCheckTime > checkInterval
@@ -164,11 +174,18 @@ final class UpdateChecker: ObservableObject {
     }
 
     private func fetchLatestRelease() async throws -> GitHubRelease {
+        let appVersion = currentAppVersion()
         var request = URLRequest(url: apiURL)
         request.httpMethod = "GET"
         request.setValue("application/vnd.github+json", forHTTPHeaderField: "Accept")
-        request.setValue("VocaMac", forHTTPHeaderField: "User-Agent")
+        request.setValue("VocaMac/\(appVersion)", forHTTPHeaderField: "User-Agent")
         request.timeoutInterval = 15
+
+        // Send cached ETag so GitHub returns 304 Not Modified (rate-limit free)
+        // when the release hasn't changed since our last check.
+        if let cachedETag = UserDefaults.standard.string(forKey: etagKey) {
+            request.setValue(cachedETag, forHTTPHeaderField: "If-None-Match")
+        }
 
         let (data, response) = try await URLSession.shared.data(for: request)
 
@@ -176,11 +193,32 @@ final class UpdateChecker: ObservableObject {
             throw UpdateCheckerError.invalidResponse
         }
 
-        guard httpResponse.statusCode == 200 else {
+        switch httpResponse.statusCode {
+        case 200:
+            // Fresh response — persist ETag and body for future conditional requests
+            if let newETag = httpResponse.value(forHTTPHeaderField: "ETag") {
+                UserDefaults.standard.set(newETag, forKey: etagKey)
+            }
+            if let jsonString = String(data: data, encoding: .utf8) {
+                UserDefaults.standard.set(jsonString, forKey: cachedResponseKey)
+            }
+            VocaLogger.debug(.updateChecker, "GitHub API: 200 OK — fresh release data received")
+            return try JSONDecoder().decode(GitHubRelease.self, from: data)
+
+        case 304:
+            // Not Modified — serve from cache, no rate-limit cost
+            VocaLogger.debug(.updateChecker, "GitHub API: 304 Not Modified — serving cached release")
+            guard let cachedJSON = UserDefaults.standard.string(forKey: cachedResponseKey),
+                  let cachedData = cachedJSON.data(using: .utf8) else {
+                // Cache miss despite 304 (e.g. UserDefaults cleared) — clear ETag and retry next time
+                UserDefaults.standard.removeObject(forKey: etagKey)
+                throw UpdateCheckerError.invalidResponse
+            }
+            return try JSONDecoder().decode(GitHubRelease.self, from: cachedData)
+
+        default:
             throw UpdateCheckerError.invalidStatusCode(httpResponse.statusCode)
         }
-
-        return try JSONDecoder().decode(GitHubRelease.self, from: data)
     }
 
     private func buildUpdateInfo(from release: GitHubRelease) -> UpdateInfo? {


### PR DESCRIPTION
## Problem

Every launch logs:
```
[ERROR] [UpdateChecker] Update check failed: Update check failed (HTTP 403)
```

## Root Causes

### 1. No conditional request caching
Every update check consumed one of GitHub's **60 unauthenticated requests/hour per IP**. On shared networks (NAT, VPN, office, CI runners) the pool is trivially exhausted — especially since the nightly build CI also hits the same API.

### 2. Bare User-Agent string
The request sent `User-Agent: VocaMac` instead of `User-Agent: VocaMac/0.5.0`. GitHub recommends including the app version so they can identify and contact clients that misbehave.

## Fix

**ETag conditional caching:**
- On **200 OK**: persist the `ETag` response header and raw JSON body to `UserDefaults`
- On subsequent requests: send `If-None-Match: <cached-etag>`
- On **304 Not Modified**: decode and return the cached JSON — **304s don't count against the rate limit** and are served from GitHub's CDN edge
- On **304 with missing cache** (UserDefaults cleared): evict the ETag so the next check gets a fresh 200 response

**Versioned User-Agent:** `VocaMac/<bundle-version>` resolved at runtime.

## Result

| Scenario | Before | After |
|----------|--------|-------|
| First check | 1 request consumed | 1 request consumed |
| Subsequent checks (same release) | 1 request consumed | 0 requests consumed (304 served from CDN) |
| New release published | 1 request consumed | 1 request consumed |
| Shared IP / rate limited | HTTP 403 | Served from local cache |

## Testing

All 163 tests pass.