### PR TITLE
fix: pass APP_VERSION env var to dist.sh in release workflow to fix DMG naming

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -115,6 +115,7 @@ jobs:
         run: ./scripts/dist.sh
         env:
           VOCAMAC_BUNDLED_MODEL_SOURCE: ${{ env.VOCAMAC_BUNDLED_MODEL_SOURCE }}
+          APP_VERSION: ${{ steps.version.outputs.VERSION }}
 
       - name: Verify code signature
         run: codesign -v --deep --strict VocaMac.app


### PR DESCRIPTION
## Problem

The v0.6.0 release produced a broken DMG artifact named `VocaMac-.APP_VERSION.-arm64.dmg` instead of `VocaMac-0.6.0-arm64.dmg`.

## Root Cause

`dist.sh` resolves the version via:
```bash
VERSION="${APP_VERSION:-$(grep -A1 'CFBundleShortVersionString' scripts/build.sh | grep '<string>' | sed ...)}"}"
```

The fallback grep scrapes `build.sh` for the line after `CFBundleShortVersionString`, which contains the **literal shell template** `${APP_VERSION}` — not a resolved version number. Since `APP_VERSION` is not set in the subshell, sed returns the raw string `${APP_VERSION}`, and the DMG ends up named `VocaMac-${APP_VERSION}-arm64.dmg` → `VocaMac-.APP_VERSION.-arm64.dmg`.

The release workflow **did** extract the correct version from the git tag:
```yaml
- name: Extract version from tag
  id: version
  run: echo "VERSION=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
```

But it was stored only as a **step output** and never wired through as an env var to the `dist.sh` step.

## Fix

One line — pass `APP_VERSION` explicitly to the `dist.sh` step:

```yaml
- name: Build and create signed, notarized DMG
  run: ./scripts/dist.sh
  env:
    VOCAMAC_BUNDLED_MODEL_SOURCE: ${{ env.VOCAMAC_BUNDLED_MODEL_SOURCE }}
    APP_VERSION: ${{ steps.version.outputs.VERSION }}   # ← added
```

`dist.sh` now picks up `APP_VERSION=0.6.0` directly, skips the fallback grep entirely, and produces `VocaMac-0.6.0-arm64.dmg` correctly.