### PR TITLE
fix: copy SPM resource bundles to Contents/MacOS/ to prevent startup crash

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,4 @@ bitbucket-pipelines.yml
 # Tool artifacts
 .desloppify/
 .claude/
+VocaMac.app.bak/

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -207,8 +207,8 @@ if [ "$CODE_SIGN_IDENTITY" != "-" ]; then
     CODESIGN_OPTIONS="--options runtime"
 fi
 
-# Sign nested bundles first
-find "${APP_DIR}/Contents/Resources" -name "*.bundle" -exec \
+# Sign nested bundles first (both in Resources/ and MacOS/)
+find "${APP_DIR}/Contents/Resources" "${APP_DIR}/Contents/MacOS" -name "*.bundle" -exec \
     codesign --force --sign "$CODE_SIGN_IDENTITY" $CODESIGN_OPTIONS {} \; 2>/dev/null || true
 
 # Sign the main app

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -97,16 +97,16 @@ fi
 cp -f "$BINARY" "${APP_DIR}/Contents/MacOS/${APP_NAME}"
 
 # Update resource bundles
-# SPM's auto-generated Bundle.module accessor resolves resource bundles via
-# Bundle.main.bundleURL/<name>.bundle. For an SPM executable wrapped in a .app
-# bundle, Bundle.main.bundleURL resolves to the Contents/MacOS/ directory at
-# runtime. The generated accessor also hardcodes the developer's build-time
-# path as a fallback, which only works on the machine that built it.
+# SPM's auto-generated Bundle.module accessor looks for resource bundles at
+# Bundle.main.bundleURL/<name>.bundle. For an SPM executable in a .app wrapper,
+# Bundle.main.bundleURL resolves to Contents/MacOS/ at runtime. The accessor
+# also hardcodes the developer's build-time path, which only works on the
+# machine that built it. On end-user machines neither path resolves →
+# fatalError → crash.
 #
-# To prevent a fatalError crash on end-user machines, we copy the resource
-# bundles into Contents/MacOS/ (alongside the executable) so the SPM accessor
-# finds them. We also keep a copy in Contents/Resources/ for standard macOS
-# bundle conventions.
+# Fix: copy bundles to both Contents/Resources/ (standard macOS convention) and
+# Contents/MacOS/ (where SPM's accessor looks at runtime). Bundles in MacOS/
+# must have a proper Info.plist so codesign accepts them as nested bundles.
 #
 # Clean up any stale bundles / symlinks at the app root from previous builds.
 find "${APP_DIR}" -maxdepth 1 -name "*.bundle" ! -name "Contents" -exec rm -rf {} + 2>/dev/null || true
@@ -114,31 +114,30 @@ find "${APP_DIR}" -maxdepth 1 -name "*.bundle" ! -name "Contents" -exec rm -rf {
 find ".build/arm64-apple-macosx/${CONFIG}" -maxdepth 1 -name "*.bundle" | while read -r bundle; do
     bundle_name="$(basename "$bundle")"
     cp -rf "$bundle" "${APP_DIR}/Contents/Resources/"
-    # Also copy to Contents/MacOS/ so SPM's Bundle.module accessor can find
-    # them at runtime (it uses Bundle.main.bundleURL which resolves to the
-    # executable's directory for SPM-built .app bundles).
-    cp -rf "$bundle" "${APP_DIR}/Contents/MacOS/"
-    # SPM resource bundles may lack an Info.plist, which causes codesign to
-    # reject them as "bundle format unrecognized". Add a minimal Info.plist
-    # so they can be properly signed as nested bundles.
-    MACOS_BUNDLE="${APP_DIR}/Contents/MacOS/${bundle_name}"
-    if [ ! -f "${MACOS_BUNDLE}/Info.plist" ] && [ ! -f "${MACOS_BUNDLE}/Contents/Info.plist" ]; then
+
+    # Copy to Contents/MacOS/ with a valid bundle structure for codesign.
+    # codesign requires bundles to have Contents/Info.plist and resources in
+    # Contents/Resources/. SPM builds flat bundles, so we restructure them.
+    DEST="${APP_DIR}/Contents/MacOS/${bundle_name}"
+    rm -rf "$DEST"
+    mkdir -p "${DEST}/Contents/Resources"
+    # Copy all original files into Contents/Resources/.
+    cp -rf "$bundle"/* "${DEST}/Contents/Resources/" 2>/dev/null || true
+    cp -rf "$bundle"/.[!.]* "${DEST}/Contents/Resources/" 2>/dev/null || true
+    # Add a minimal Info.plist if one doesn't already exist.
+    if [ ! -f "${DEST}/Contents/Info.plist" ]; then
         bundle_id="com.vocamac.resource.$(echo "${bundle_name%.bundle}" | tr '_ ' '-')"
-        cat > "${MACOS_BUNDLE}/Info.plist" << BPLIST
+        cat > "${DEST}/Contents/Info.plist" << BPLIST
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
     <key>CFBundleIdentifier</key>
     <string>${bundle_id}</string>
-    <key>CFBundleName</key>
-    <string>${bundle_name%.bundle}</string>
     <key>CFBundlePackageType</key>
     <string>BNDL</string>
     <key>CFBundleVersion</key>
     <string>1</string>
-    <key>CFBundleShortVersionString</key>
-    <string>1.0</string>
 </dict>
 </plist>
 BPLIST
@@ -236,7 +235,7 @@ if [ "$CODE_SIGN_IDENTITY" != "-" ]; then
     CODESIGN_OPTIONS="--options runtime"
 fi
 
-# Sign nested bundles first (both in Resources/ and MacOS/)
+# Sign nested bundles first (in both Resources/ and MacOS/)
 find "${APP_DIR}/Contents/Resources" "${APP_DIR}/Contents/MacOS" -name "*.bundle" -exec \
     codesign --force --sign "$CODE_SIGN_IDENTITY" $CODESIGN_OPTIONS {} \; 2>/dev/null || true
 

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -112,8 +112,37 @@ cp -f "$BINARY" "${APP_DIR}/Contents/MacOS/${APP_NAME}"
 find "${APP_DIR}" -maxdepth 1 -name "*.bundle" ! -name "Contents" -exec rm -rf {} + 2>/dev/null || true
 
 find ".build/arm64-apple-macosx/${CONFIG}" -maxdepth 1 -name "*.bundle" | while read -r bundle; do
+    bundle_name="$(basename "$bundle")"
     cp -rf "$bundle" "${APP_DIR}/Contents/Resources/"
+    # Also copy to Contents/MacOS/ so SPM's Bundle.module accessor can find
+    # them at runtime (it uses Bundle.main.bundleURL which resolves to the
+    # executable's directory for SPM-built .app bundles).
     cp -rf "$bundle" "${APP_DIR}/Contents/MacOS/"
+    # SPM resource bundles may lack an Info.plist, which causes codesign to
+    # reject them as "bundle format unrecognized". Add a minimal Info.plist
+    # so they can be properly signed as nested bundles.
+    MACOS_BUNDLE="${APP_DIR}/Contents/MacOS/${bundle_name}"
+    if [ ! -f "${MACOS_BUNDLE}/Info.plist" ] && [ ! -f "${MACOS_BUNDLE}/Contents/Info.plist" ]; then
+        bundle_id="com.vocamac.resource.$(echo "${bundle_name%.bundle}" | tr '_ ' '-')"
+        cat > "${MACOS_BUNDLE}/Info.plist" << BPLIST
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>CFBundleIdentifier</key>
+    <string>${bundle_id}</string>
+    <key>CFBundleName</key>
+    <string>${bundle_name%.bundle}</string>
+    <key>CFBundlePackageType</key>
+    <string>BNDL</string>
+    <key>CFBundleVersion</key>
+    <string>1</string>
+    <key>CFBundleShortVersionString</key>
+    <string>1.0</string>
+</dict>
+</plist>
+BPLIST
+    fi
 done
 
 # Copy app icon and compile Asset Catalog

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -97,8 +97,23 @@ fi
 cp -f "$BINARY" "${APP_DIR}/Contents/MacOS/${APP_NAME}"
 
 # Update resource bundles
+# SPM's auto-generated Bundle.module accessor resolves resource bundles via
+# Bundle.main.bundleURL/<name>.bundle. For an SPM executable wrapped in a .app
+# bundle, Bundle.main.bundleURL resolves to the Contents/MacOS/ directory at
+# runtime. The generated accessor also hardcodes the developer's build-time
+# path as a fallback, which only works on the machine that built it.
+#
+# To prevent a fatalError crash on end-user machines, we copy the resource
+# bundles into Contents/MacOS/ (alongside the executable) so the SPM accessor
+# finds them. We also keep a copy in Contents/Resources/ for standard macOS
+# bundle conventions.
+#
+# Clean up any stale bundles / symlinks at the app root from previous builds.
+find "${APP_DIR}" -maxdepth 1 -name "*.bundle" ! -name "Contents" -exec rm -rf {} + 2>/dev/null || true
+
 find ".build/arm64-apple-macosx/${CONFIG}" -maxdepth 1 -name "*.bundle" | while read -r bundle; do
     cp -rf "$bundle" "${APP_DIR}/Contents/Resources/"
+    cp -rf "$bundle" "${APP_DIR}/Contents/MacOS/"
 done
 
 # Copy app icon and compile Asset Catalog


### PR DESCRIPTION
## Problem

Users are experiencing immediate crashes on app launch (`EXC_BREAKPOINT` / `SIGTRAP` in `NSBundle.module`). The crash occurs during tokenizer loading when `swift-transformers`' Hub module tries to access its embedded resource bundle via SPM's auto-generated `Bundle.module` accessor.

The accessor checks two paths:
1. `Bundle.main.bundleURL/<name>.bundle` → resolves to `Contents/MacOS/` at runtime
2. A **hardcoded absolute path** to the developer's build directory

The build script only copied resource bundles to `Contents/Resources/`, so path #1 failed. Path #2 only works on the machine that built the binary — explaining why it worked for us but crashed for end users.

## Fix

Copy SPM resource bundles into **both** `Contents/Resources/` (standard macOS convention) and `Contents/MacOS/` (where SPM's accessor actually looks at runtime). Also added cleanup of stale bundles at the `.app` root from previous builds.

## Testing

- ✅ Clean build succeeds with valid code signature
- ✅ App launches without crash
- ✅ All 163 tests pass