### PR TITLE
fix: keep SPM resource bundles flat in Contents/MacOS to fix startup crash

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -281,40 +281,52 @@ jobs:
           echo "🔍 Checking SPM resource bundle layout..."
           FAIL=0
 
-          # Every *.bundle in Contents/MacOS must be FLAT — resources at the
-          # bundle root, not nested under Contents/Resources/. A nested layout
-          # breaks the SwiftPM-generated Bundle.module accessor at runtime and
-          # causes an EXC_BREAKPOINT / fatalError crash on end-user machines.
-          for bundle in VocaMac.app/Contents/MacOS/*.bundle; do
+          # xcodebuild's Bundle.module accessor checks Bundle.main.resourceURL
+          # which resolves to Contents/Resources/ for .app bundles.
+          # Bundles must NOT be at the .app root (codesign rejects that).
+          if ls VocaMac.app/*.bundle 1>/dev/null 2>&1; then
+            echo "❌ Found .bundle at app root — will break codesign!"
+            ls VocaMac.app/*.bundle
+            FAIL=1
+          fi
+
+          FOUND_ANY=false
+          for bundle in VocaMac.app/Contents/Resources/*.bundle; do
             [ -d "$bundle" ] || continue
+            FOUND_ANY=true
             name="$(basename "$bundle")"
-
-            # Fail if the old (wrong) deep Contents/ hierarchy is present
-            if [ -d "$bundle/Contents/Resources" ]; then
-              echo "❌ $name has a Contents/Resources/ hierarchy — Bundle.module will crash at runtime!"
-              FAIL=1
-            fi
-
-            # Fail if Info.plist is missing (codesign will reject it)
-            if [ ! -f "$bundle/Info.plist" ]; then
-              echo "❌ $name is missing a root-level Info.plist"
-              FAIL=1
-            fi
-
-            echo "✅ $name — flat layout OK"
+            echo "✅ $name — present in Contents/Resources/"
           done
 
-          # Verify the critical WhisperKit tokenizer fallback resources are
-          # present in the swift-transformers_Hub bundle
-          HUB="VocaMac.app/Contents/MacOS/swift-transformers_Hub.bundle"
-          for f in gpt2_tokenizer_config.json t5_tokenizer_config.json; do
-            if [ ! -f "$HUB/$f" ]; then
-              echo "❌ Missing $f in swift-transformers_Hub.bundle"
-              FAIL=1
-            else
-              echo "✅ $HUB/$f present"
-            fi
-          done
+          if [ "$FOUND_ANY" = false ]; then
+            echo "❌ No .bundle directories found in Contents/Resources/!"
+            FAIL=1
+          fi
+
+          # Verify the critical WhisperKit tokenizer fallback resources
+          HUB="VocaMac.app/Contents/Resources/swift-transformers_Hub.bundle"
+          if [ ! -d "$HUB" ]; then
+            echo "❌ swift-transformers_Hub.bundle missing!"
+            FAIL=1
+          else
+            for f in gpt2_tokenizer_config.json t5_tokenizer_config.json; do
+              if [ ! -f "$HUB/$f" ]; then
+                echo "❌ Missing $f in swift-transformers_Hub.bundle"
+                FAIL=1
+              else
+                echo "✅ $HUB/$f present"
+              fi
+            done
+          fi
+
+          # Verify the binary uses the xcodebuild accessor (contains resourceURL)
+          if strings VocaMac.app/Contents/MacOS/VocaMac | grep -q 'resourceURL'; then
+            echo "✅ Binary uses xcodebuild Bundle.module accessor"
+          else
+            echo "❌ Binary does NOT contain resourceURL — wrong accessor!"
+            echo "   Ensure build.sh uses xcodebuild, not swift build."
+            FAIL=1
+          fi
 
           if [ "$FAIL" -ne 0 ]; then
             echo ""

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -276,6 +276,53 @@ jobs:
       - name: Verify code signature
         run: codesign -v --deep --strict VocaMac.app
 
+      - name: Verify SPM resource bundles are correctly staged
+        run: |
+          echo "🔍 Checking SPM resource bundle layout..."
+          FAIL=0
+
+          # Every *.bundle in Contents/MacOS must be FLAT — resources at the
+          # bundle root, not nested under Contents/Resources/. A nested layout
+          # breaks the SwiftPM-generated Bundle.module accessor at runtime and
+          # causes an EXC_BREAKPOINT / fatalError crash on end-user machines.
+          for bundle in VocaMac.app/Contents/MacOS/*.bundle; do
+            [ -d "$bundle" ] || continue
+            name="$(basename "$bundle")"
+
+            # Fail if the old (wrong) deep Contents/ hierarchy is present
+            if [ -d "$bundle/Contents/Resources" ]; then
+              echo "❌ $name has a Contents/Resources/ hierarchy — Bundle.module will crash at runtime!"
+              FAIL=1
+            fi
+
+            # Fail if Info.plist is missing (codesign will reject it)
+            if [ ! -f "$bundle/Info.plist" ]; then
+              echo "❌ $name is missing a root-level Info.plist"
+              FAIL=1
+            fi
+
+            echo "✅ $name — flat layout OK"
+          done
+
+          # Verify the critical WhisperKit tokenizer fallback resources are
+          # present in the swift-transformers_Hub bundle
+          HUB="VocaMac.app/Contents/MacOS/swift-transformers_Hub.bundle"
+          for f in gpt2_tokenizer_config.json t5_tokenizer_config.json; do
+            if [ ! -f "$HUB/$f" ]; then
+              echo "❌ Missing $f in swift-transformers_Hub.bundle"
+              FAIL=1
+            else
+              echo "✅ $HUB/$f present"
+            fi
+          done
+
+          if [ "$FAIL" -ne 0 ]; then
+            echo ""
+            echo "Bundle layout validation failed. See above for details."
+            exit 1
+          fi
+          echo "✅ All SPM resource bundles are correctly staged."
+
       - name: Rename artifacts for nightly
         run: |
           NIGHTLY_DATE=$(date -u +%Y%m%d)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -119,7 +119,54 @@ jobs:
 
       - name: Verify code signature
         run: codesign -v --deep --strict VocaMac.app
-        
+
+      - name: Verify SPM resource bundles are correctly staged
+        run: |
+          echo "🔍 Checking SPM resource bundle layout..."
+          FAIL=0
+
+          # Every *.bundle in Contents/MacOS must be FLAT — resources at the
+          # bundle root, not nested under Contents/Resources/. A nested layout
+          # breaks the SwiftPM-generated Bundle.module accessor at runtime and
+          # causes an EXC_BREAKPOINT / fatalError crash on end-user machines.
+          for bundle in VocaMac.app/Contents/MacOS/*.bundle; do
+            [ -d "$bundle" ] || continue
+            name="$(basename "$bundle")"
+
+            # Fail if the old (wrong) deep Contents/ hierarchy is present
+            if [ -d "$bundle/Contents/Resources" ]; then
+              echo "❌ $name has a Contents/Resources/ hierarchy — Bundle.module will crash at runtime!"
+              FAIL=1
+            fi
+
+            # Fail if Info.plist is missing (codesign will reject it)
+            if [ ! -f "$bundle/Info.plist" ]; then
+              echo "❌ $name is missing a root-level Info.plist"
+              FAIL=1
+            fi
+
+            echo "✅ $name — flat layout OK"
+          done
+
+          # Verify the critical WhisperKit tokenizer fallback resources are
+          # present in the swift-transformers_Hub bundle
+          HUB="VocaMac.app/Contents/MacOS/swift-transformers_Hub.bundle"
+          for f in gpt2_tokenizer_config.json t5_tokenizer_config.json; do
+            if [ ! -f "$HUB/$f" ]; then
+              echo "❌ Missing $f in swift-transformers_Hub.bundle"
+              FAIL=1
+            else
+              echo "✅ $HUB/$f present"
+            fi
+          done
+
+          if [ "$FAIL" -ne 0 ]; then
+            echo ""
+            echo "Bundle layout validation failed. See above for details."
+            exit 1
+          fi
+          echo "✅ All SPM resource bundles are correctly staged."
+
       - name: Rename artifacts with version
         run: |
           ARCH=$(uname -m)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -125,40 +125,52 @@ jobs:
           echo "🔍 Checking SPM resource bundle layout..."
           FAIL=0
 
-          # Every *.bundle in Contents/MacOS must be FLAT — resources at the
-          # bundle root, not nested under Contents/Resources/. A nested layout
-          # breaks the SwiftPM-generated Bundle.module accessor at runtime and
-          # causes an EXC_BREAKPOINT / fatalError crash on end-user machines.
-          for bundle in VocaMac.app/Contents/MacOS/*.bundle; do
+          # xcodebuild's Bundle.module accessor checks Bundle.main.resourceURL
+          # which resolves to Contents/Resources/ for .app bundles.
+          # Bundles must NOT be at the .app root (codesign rejects that).
+          if ls VocaMac.app/*.bundle 1>/dev/null 2>&1; then
+            echo "❌ Found .bundle at app root — will break codesign!"
+            ls VocaMac.app/*.bundle
+            FAIL=1
+          fi
+
+          FOUND_ANY=false
+          for bundle in VocaMac.app/Contents/Resources/*.bundle; do
             [ -d "$bundle" ] || continue
+            FOUND_ANY=true
             name="$(basename "$bundle")"
-
-            # Fail if the old (wrong) deep Contents/ hierarchy is present
-            if [ -d "$bundle/Contents/Resources" ]; then
-              echo "❌ $name has a Contents/Resources/ hierarchy — Bundle.module will crash at runtime!"
-              FAIL=1
-            fi
-
-            # Fail if Info.plist is missing (codesign will reject it)
-            if [ ! -f "$bundle/Info.plist" ]; then
-              echo "❌ $name is missing a root-level Info.plist"
-              FAIL=1
-            fi
-
-            echo "✅ $name — flat layout OK"
+            echo "✅ $name — present in Contents/Resources/"
           done
 
-          # Verify the critical WhisperKit tokenizer fallback resources are
-          # present in the swift-transformers_Hub bundle
-          HUB="VocaMac.app/Contents/MacOS/swift-transformers_Hub.bundle"
-          for f in gpt2_tokenizer_config.json t5_tokenizer_config.json; do
-            if [ ! -f "$HUB/$f" ]; then
-              echo "❌ Missing $f in swift-transformers_Hub.bundle"
-              FAIL=1
-            else
-              echo "✅ $HUB/$f present"
-            fi
-          done
+          if [ "$FOUND_ANY" = false ]; then
+            echo "❌ No .bundle directories found in Contents/Resources/!"
+            FAIL=1
+          fi
+
+          # Verify the critical WhisperKit tokenizer fallback resources
+          HUB="VocaMac.app/Contents/Resources/swift-transformers_Hub.bundle"
+          if [ ! -d "$HUB" ]; then
+            echo "❌ swift-transformers_Hub.bundle missing!"
+            FAIL=1
+          else
+            for f in gpt2_tokenizer_config.json t5_tokenizer_config.json; do
+              if [ ! -f "$HUB/$f" ]; then
+                echo "❌ Missing $f in swift-transformers_Hub.bundle"
+                FAIL=1
+              else
+                echo "✅ $HUB/$f present"
+              fi
+            done
+          fi
+
+          # Verify the binary uses the xcodebuild accessor (contains resourceURL)
+          if strings VocaMac.app/Contents/MacOS/VocaMac | grep -q 'resourceURL'; then
+            echo "✅ Binary uses xcodebuild Bundle.module accessor"
+          else
+            echo "❌ Binary does NOT contain resourceURL — wrong accessor!"
+            echo "   Ensure build.sh uses xcodebuild, not swift build."
+            FAIL=1
+          fi
 
           if [ "$FAIL" -ne 0 ]; then
             echo ""

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Swift / Xcode
 .build/
+.xcode-build/
 *.xcodeproj/
 *.xcworkspace/
 xcuserdata/

--- a/Makefile
+++ b/Makefile
@@ -33,6 +33,7 @@ clean:
 	@swift package clean 2>/dev/null || true
 	@rm -rf VocaMac.app
 	@rm -rf .build
+	@rm -rf .xcode-build
 	@rm -rf dist
 	@echo "✅ Clean complete"
 

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -106,7 +106,9 @@ cp -f "$BINARY" "${APP_DIR}/Contents/MacOS/${APP_NAME}"
 #
 # Fix: copy bundles to both Contents/Resources/ (standard macOS convention) and
 # Contents/MacOS/ (where SPM's accessor looks at runtime). Bundles in MacOS/
-# must have a proper Info.plist so codesign accepts them as nested bundles.
+# must be kept FLAT (resources at the bundle root) so Bundle.module can find
+# them. codesign accepts an Info.plist at the bundle root for flat bundles —
+# it does NOT require a Contents/ hierarchy for non-framework bundles.
 #
 # Clean up any stale bundles / symlinks at the app root from previous builds.
 find "${APP_DIR}" -maxdepth 1 -name "*.bundle" ! -name "Contents" -exec rm -rf {} + 2>/dev/null || true
@@ -115,19 +117,22 @@ find ".build/arm64-apple-macosx/${CONFIG}" -maxdepth 1 -name "*.bundle" | while 
     bundle_name="$(basename "$bundle")"
     cp -rf "$bundle" "${APP_DIR}/Contents/Resources/"
 
-    # Copy to Contents/MacOS/ with a valid bundle structure for codesign.
-    # codesign requires bundles to have Contents/Info.plist and resources in
-    # Contents/Resources/. SPM builds flat bundles, so we restructure them.
+    # Copy to Contents/MacOS/ keeping the SPM flat layout so that the
+    # SwiftPM-generated Bundle.module accessor (which does:
+    #   Bundle.main.bundleURL/<name>.bundle/<resource>
+    # at runtime) can find resources directly at the bundle root.
+    #
+    # codesign also requires an Info.plist, but for flat (non-framework)
+    # bundles it accepts one at the bundle root — no Contents/ hierarchy needed.
     DEST="${APP_DIR}/Contents/MacOS/${bundle_name}"
     rm -rf "$DEST"
-    mkdir -p "${DEST}/Contents/Resources"
-    # Copy all original files into Contents/Resources/.
-    cp -rf "$bundle"/* "${DEST}/Contents/Resources/" 2>/dev/null || true
-    cp -rf "$bundle"/.[!.]* "${DEST}/Contents/Resources/" 2>/dev/null || true
-    # Add a minimal Info.plist if one doesn't already exist.
-    if [ ! -f "${DEST}/Contents/Info.plist" ]; then
+    mkdir -p "$DEST"
+    # Copy all original files flat into the bundle root.
+    cp -rf "$bundle"/. "$DEST/" 2>/dev/null || true
+    # Add a minimal Info.plist at the bundle root if one doesn't already exist.
+    if [ ! -f "${DEST}/Info.plist" ]; then
         bundle_id="com.vocamac.resource.$(echo "${bundle_name%.bundle}" | tr '_ ' '-')"
-        cat > "${DEST}/Contents/Info.plist" << BPLIST
+        cat > "${DEST}/Info.plist" << BPLIST
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -60,10 +60,33 @@ if pgrep -f "VocaMac" > /dev/null 2>&1; then
 fi
 
 echo "🔨 Building VocaMac ($CONFIG)..."
-swift build -c "$CONFIG"
+
+# ── Build with xcodebuild ───────────────────────────────────────────────────
+#
+# We use xcodebuild instead of swift build because xcodebuild generates a
+# Bundle.module accessor that checks Bundle.main.resourceURL (Contents/Resources/)
+# in addition to Bundle.main.bundleURL (the .app root). This is critical for
+# .app bundles where:
+#   - Bundle.main.bundleURL resolves to the .app root (e.g. VocaMac.app/)
+#   - codesign forbids placing bundles at the .app root
+#   - Bundle.main.resourceURL resolves to Contents/Resources/ which IS allowed
+#
+# swift build generates a simpler accessor that only checks bundleURL + a
+# hardcoded build-time path, which causes a fatalError crash on end-user machines.
+
+DERIVED_DATA=".xcode-build"
+XCODE_CONFIG="$(echo "${CONFIG}" | sed 's/release/Release/; s/debug/Debug/')"
+
+xcodebuild build \
+    -scheme VocaMac \
+    -configuration "$XCODE_CONFIG" \
+    -derivedDataPath "$DERIVED_DATA" \
+    -destination 'platform=macOS,arch=arm64' \
+    ONLY_ACTIVE_ARCH=YES \
+    -quiet
 
 # Find the built binary
-BINARY=".build/arm64-apple-macosx/${CONFIG}/${APP_NAME}"
+BINARY="${DERIVED_DATA}/Build/Products/${XCODE_CONFIG}/${APP_NAME}"
 if [ ! -f "$BINARY" ]; then
     echo "❌ Build failed — binary not found at $BINARY"
     exit 1
@@ -96,43 +119,22 @@ fi
 # Update binary
 cp -f "$BINARY" "${APP_DIR}/Contents/MacOS/${APP_NAME}"
 
-# Update resource bundles
-# SPM's auto-generated Bundle.module accessor looks for resource bundles at
-# Bundle.main.bundleURL/<name>.bundle. For an SPM executable in a .app wrapper,
-# Bundle.main.bundleURL resolves to Contents/MacOS/ at runtime. The accessor
-# also hardcodes the developer's build-time path, which only works on the
-# machine that built it. On end-user machines neither path resolves →
-# fatalError → crash.
+# Update resource bundles — copy to Contents/Resources/
+# xcodebuild's Bundle.module accessor checks Bundle.main.resourceURL first,
+# which resolves to Contents/Resources/ for .app bundles. This is the correct
+# and codesign-compatible location.
 #
-# Fix: copy bundles to both Contents/Resources/ (standard macOS convention) and
-# Contents/MacOS/ (where SPM's accessor looks at runtime). Bundles in MacOS/
-# must be kept FLAT (resources at the bundle root) so Bundle.module can find
-# them. codesign accepts an Info.plist at the bundle root for flat bundles —
-# it does NOT require a Contents/ hierarchy for non-framework bundles.
-#
-# Clean up any stale bundles / symlinks at the app root from previous builds.
+# Clean up any stale bundles at the app root from previous builds.
 find "${APP_DIR}" -maxdepth 1 -name "*.bundle" ! -name "Contents" -exec rm -rf {} + 2>/dev/null || true
 
-find ".build/arm64-apple-macosx/${CONFIG}" -maxdepth 1 -name "*.bundle" | while read -r bundle; do
+find "${DERIVED_DATA}/Build/Products/${XCODE_CONFIG}" -maxdepth 1 -name "*.bundle" | while read -r bundle; do
     bundle_name="$(basename "$bundle")"
     cp -rf "$bundle" "${APP_DIR}/Contents/Resources/"
 
-    # Copy to Contents/MacOS/ keeping the SPM flat layout so that the
-    # SwiftPM-generated Bundle.module accessor (which does:
-    #   Bundle.main.bundleURL/<name>.bundle/<resource>
-    # at runtime) can find resources directly at the bundle root.
-    #
-    # codesign also requires an Info.plist, but for flat (non-framework)
-    # bundles it accepts one at the bundle root — no Contents/ hierarchy needed.
-    DEST="${APP_DIR}/Contents/MacOS/${bundle_name}"
-    rm -rf "$DEST"
-    mkdir -p "$DEST"
-    # Copy all original files flat into the bundle root.
-    cp -rf "$bundle"/. "$DEST/" 2>/dev/null || true
-    # Add a minimal Info.plist at the bundle root if one doesn't already exist.
-    if [ ! -f "${DEST}/Info.plist" ]; then
+    # Add a minimal Info.plist if missing so codesign accepts the bundle.
+    if [ ! -f "${APP_DIR}/Contents/Resources/${bundle_name}/Info.plist" ]; then
         bundle_id="com.vocamac.resource.$(echo "${bundle_name%.bundle}" | tr '_ ' '-')"
-        cat > "${DEST}/Info.plist" << BPLIST
+        cat > "${APP_DIR}/Contents/Resources/${bundle_name}/Info.plist" << BPLIST
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
@@ -240,8 +242,8 @@ if [ "$CODE_SIGN_IDENTITY" != "-" ]; then
     CODESIGN_OPTIONS="--options runtime"
 fi
 
-# Sign nested bundles first (in both Resources/ and MacOS/)
-find "${APP_DIR}/Contents/Resources" "${APP_DIR}/Contents/MacOS" -name "*.bundle" -exec \
+# Sign nested bundles in Contents/Resources/
+find "${APP_DIR}/Contents/Resources" -maxdepth 1 -name "*.bundle" -exec \
     codesign --force --sign "$CODE_SIGN_IDENTITY" $CODESIGN_OPTIONS {} \; 2>/dev/null || true
 
 # Sign the main app


### PR DESCRIPTION
## Problem

VocaMac crashes instantly on launch for **all users** on a clean install with `EXC_BREAKPOINT / SIGTRAP`.

Crash stack:
```
_assertionFailure
closure #1 in variable initialization expression of static NSBundle.module
LanguageModelConfigurationFromHub.fallbackTokenizerConfig(for:)
ModelUtilities.loadTokenizer(...)
WhisperKit.loadTokenizerIfNeeded()
WhisperKit.init(_:)
WhisperService.loadModel(...)
AppState.performStartup()
```

## Root Cause

`swift build` generates a `Bundle.module` accessor that only checks **two** paths:

1. `Bundle.main.bundleURL/<name>.bundle` — resolves to `VocaMac.app/<name>.bundle`
2. A **hardcoded build-time path** — e.g. `/Users/runner/work/vocamac/vocamac/.build/...`

For a `.app` bundle on macOS, `Bundle.main.bundleURL` **always** resolves to the `.app` root (e.g. `VocaMac.app/`), regardless of how the binary is launched. But `codesign` forbids placing any non-standard items at the `.app` root — only `Contents/` is allowed. So:

- Path 1 → `VocaMac.app/swift-transformers_Hub.bundle` → **doesn't exist** (can't put it there without breaking codesign)
- Path 2 → `/Users/runner/work/.../swift-transformers_Hub.bundle` → **doesn't exist** (CI build machine path)

Both paths fail → `fatalError` → instant crash before any UI appears.

### Why it appeared to work for developers
The hardcoded build-time path (path 2) points to the local `.build/` directory, which **does** exist on the machine that built the binary. So local dev builds never crash. Only clean installs from DMG/Nightly artifacts crash.

### Approaches investigated and rejected

| Approach | Why it doesn't work |
|----------|-------------------|
| Flat bundles in `Contents/MacOS/` | `Bundle.main.bundleURL` is the `.app` root, not `Contents/MacOS/` |
| Bundles at `.app/` root | `codesign` rejects "unsealed contents in the bundle root" |
| Symlinks at `.app/` root | `codesign` rejects those too (even added post-sign) |
| Two-pass build + source patching | `swift build` **regenerates** accessor files on every build, wiping patches |
| Launcher wrapper binary | `Bundle.main.bundleURL` still resolves to `.app/` root regardless of how the binary is launched |
| Binary string patching | Install path is unknown at build time; fragile |

## Fix

**Switch from `swift build` to `xcodebuild`** in `build.sh`.

`xcodebuild` generates a completely different, smarter `Bundle.module` accessor that checks **three** locations:

1. `Bundle.main.resourceURL` → `Contents/Resources/` ✅ **works for .app bundles**
2. `Bundle(for: BundleFinder.self).resourceURL` → framework path ✅
3. `Bundle.main.bundleURL` → `.app/` root (CLI fallback) ✅

Resource bundles are placed in `Contents/Resources/` — the standard macOS location — where both `codesign` and the accessor are happy.

## Changes

- **`scripts/build.sh`** — switch from `swift build` to `xcodebuild`; update bundle staging to use xcodebuild output paths; clean up two-pass hack
- **`.github/workflows/nightly.yml`** — updated bundle validation CI step to check `Contents/Resources/` and verify the binary uses the xcodebuild accessor
- **`.github/workflows/release.yml`** — same validation step
- **`.gitignore`** — add `.xcode-build/`
- **`Makefile`** — clean `.xcode-build/` in clean target

## Verified Locally

- ✅ `codesign -v --deep --strict` passes
- ✅ Binary contains `resourceURL` lookup (xcodebuild accessor)
- ✅ `Bundle.module` resolves resources via `Contents/Resources/`
- ✅ All 163 tests pass (`swift test` unchanged — tests don't need `.app` wrapper)
- ✅ No bundles at `.app/` root
- ✅ No bundles in `Contents/MacOS/` (no longer needed)