### PR TITLE
docs: explain GitHub 403 update-check error on shared/VPN networks

### DIFF
--- a/README.md
+++ b/README.md
@@ -389,6 +389,16 @@ tccutil reset All com.vocamac.app
 
 This clears all permission entries (Microphone, Accessibility, Input Monitoring) for VocaMac. On next launch, macOS will prompt you to re-grant them. With Developer ID signing, permissions normally persist across updates — this reset is only needed for troubleshooting.
 
+**"Update check failed (HTTP 403)" on a shared / corporate / VPN network:** VocaMac checks for new releases by calling GitHub's public REST API, which is rate-limited to **60 unauthenticated requests per hour, per source IP**. When several people share the same egress IP (common on office VPNs, NAT'd networks, or busy CI runners), that quota is collectively exhausted and GitHub returns `HTTP 403` to every client from that IP — including VocaMac.
+
+This is **not a bug in VocaMac** and there is nothing wrong with your install. To recover:
+
+1. Disconnect from the VPN (or switch to a different network, e.g. your phone's hotspot).
+2. Open VocaMac → **Settings → About → "Check for Updates…"** and wait for it to complete.
+3. Reconnect to the VPN.
+
+After one successful check, VocaMac caches the response's `ETag` and sends it as `If-None-Match` on every subsequent request. GitHub then replies with `304 Not Modified`, which **does not count against the rate limit**, so future checks succeed even from a rate-limited IP — until a new release ships and the ETag changes (at which point one fresh `200` response per machine is needed before `304`s resume).
+
 ---
 
 


### PR DESCRIPTION
## What

Adds a Troubleshooting entry to `README.md` explaining the `Update check failed (HTTP 403)` error that some users (including teammates on a shared office VPN) have been seeing in their VocaMac logs.

## Why

GitHub's public REST API rate-limits **unauthenticated** requests to **60 per hour, per source IP**. When several VocaMac users share the same egress IP (office VPN, NAT'd corporate network, busy CI runner, etc.), that quota is collectively burned through and GitHub starts returning `HTTP 403` to **every** client from that IP — including VocaMac.

Confirmed live from the affected IP:

```
HTTP/2 403
x-ratelimit-limit: 60
x-ratelimit-remaining: 0
x-ratelimit-used: 60
x-ratelimit-reset: 1776963299
```

This is **not a bug in VocaMac**. The existing ETag caching (#115) already handles the steady state correctly — once a successful `200` response is cached, subsequent checks send `If-None-Match` and GitHub responds with `304 Not Modified`, which doesn't count against the rate limit.

The only gap is the **first** check on a fresh install (or after `UserDefaults` is wiped) when the egress IP is already rate-limited — there's no cached ETag yet, so every check fails until the rate limit window resets (or the user temporarily switches networks to populate the cache).

## Workaround documented

1. Disconnect from the VPN (or use a phone hotspot).
2. **Settings → About → Check for Updates…** to populate the ETag cache.
3. Reconnect to the VPN.

After that, `304`s flow freely from the rate-limited IP.

## Why no code change

- The behaviour is fundamentally a GitHub-side limit on shared IPs.
- ETag caching is already in place and correctly handles steady state.
- Adding a friendlier error message + backoff is possible but felt out of scope for this docs PR — happy to follow up in a separate change if desired.

## Test plan

- [x] Re-rendered `README.md` locally — new section appears under existing **Troubleshooting** heading, formatting consistent with surrounding entries.
- [x] No code changes, so `swift build` / `swift test` are unaffected.