### PR TITLE
chore: bump version to 0.6.1

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -8,8 +8,8 @@
 # 3. Code signs — Developer ID if CODE_SIGN_IDENTITY is set, ad-hoc otherwise
 #
 # Environment variables:
-#   APP_VERSION         — Version string to embed in Info.plist. Defaults to 0.6.0.
-#                         Set by CI for nightly builds (e.g., 0.6.0-nightly.20260414+abc1234).
+#   APP_VERSION         — Version string to embed in Info.plist. Defaults to 0.6.1.
+#                         Set by CI for nightly builds (e.g., 0.6.1-nightly.20260424+abc1234).
 #   CODE_SIGN_IDENTITY  — Signing identity to use. Defaults to auto-detect
 #                         Developer ID Application in the login keychain.
 #                         Set to "-" to force ad-hoc signing.
@@ -29,7 +29,7 @@ BUNDLE_ID="com.vocamac.app"
 APP_NAME="VocaMac"
 APP_DIR="${APP_NAME}.app"
 ENTITLEMENTS="VocaMac.entitlements"
-APP_VERSION="${APP_VERSION:-0.6.0}"
+APP_VERSION="${APP_VERSION:-0.6.1}"
 
 # Resolve signing identity:
 # 1. Use CODE_SIGN_IDENTITY env var if set

--- a/web/layouts/index.html
+++ b/web/layouts/index.html
@@ -36,7 +36,7 @@
             "Open source (AGPL-3.0 license)"
         ],
         "screenshot": "https://vocamac.com/og-image.png",
-        "softwareVersion": "0.6.0",
+        "softwareVersion": "0.6.1",
         "softwareRequirements": "macOS 13 (Ventura) or later, Apple Silicon (M1 or later), 8 GB RAM minimum"
     }
     </script>
@@ -49,7 +49,7 @@
             <div class="hero__content">
                 <div class="hero__badges">
                     <span class="badge badge--beta">BETA RELEASE</span>
-                    <span class="badge badge--outline" id="version-badge">v0.6.0</span>
+                    <span class="badge badge--outline" id="version-badge">v0.6.1</span>
                 </div>
                 <h1 class="hero__headline">
                     Your Voice,<br>


### PR DESCRIPTION
## Summary

Prepares the **v0.6.1** patch release.

> **Note:** Per the new policy in #126 (`docs/RELEASE.md` → "Release Notes (out-of-tree)"), this PR no longer creates a tracked `docs/RELEASE_NOTES_v0.6.1.md` file. The release notes are stashed locally and will be pasted directly into the GitHub Release on publish.

### Why 0.6.1 (not 0.7.0)?

All changes since [v0.6.0](https://github.com/jatinkrmalik/vocamac/releases/tag/v0.6.0) are bug fixes, docs, and CI hygiene — no new features, no breaking changes. Per the project's [SemVer policy](https://github.com/jatinkrmalik/vocamac/blob/main/docs/RELEASE.md#versioning), this warrants a **PATCH** bump.

### Changes since v0.6.0

| PR | Type | Summary |
|---|---|---|
| #120 | docs | Explain GitHub 403 update-check error on shared/VPN networks |
| #121 | **fix** | SIGSEGV crash when stopping recording after mic replug + stale AudioEngine flags |
| #122 | ci | Bump GitHub Actions to Node.js 24-compatible versions |
| #125 | **fix** | Paste failure on Dvorak and other non-QWERTY keyboard layouts (closes #123) |

### Files updated

- `scripts/build.sh` — `APP_VERSION` default `0.6.0` → `0.6.1` + comment
- `web/layouts/index.html` — JSON-LD `softwareVersion` and hero version badge

### Verification

- `swift build` ✅
- `swift test` ✅ — all **166 tests** pass on the rebased branch (includes the 3 new `TextInjector` keycode-resolver tests from #125)
- Nightly build off `main` (with the Dvorak fix) ran successfully — see [run 24907516846](https://github.com/jatinkrmalik/vocamac/actions/runs/24907516846)

### Release plan after merge

```bash
git checkout main && git pull
git tag -a v0.6.1 -m "VocaMac v0.6.1"
git push origin v0.6.1
```

That triggers `release.yml` which builds, signs, notarizes, packages the DMG/ZIP, and creates a draft GitHub Release. Paste the v0.6.1 notes (kept locally at `/tmp/RELEASE_NOTES_v0.6.1.md`) into the draft, publish, then delete the local scratch file.