### PR TITLE
fix: pre-release hygiene — correct dev binary path and add bundle validation to PR builds

### DIFF
--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -153,6 +153,74 @@ jobs:
       - name: Build signed, notarized DMG
         run: ./scripts/dist.sh
 
+      - name: Verify code signature
+        run: codesign -v --deep --strict VocaMac.app
+
+      - name: Verify SPM resource bundles are correctly staged
+        # Mirrors the validation in release.yml and nightly.yml so PR builds
+        # catch bundle-layout regressions (the #119 class of bug) before they
+        # reach a release. xcodebuild's Bundle.module accessor resolves to
+        # Contents/Resources/, and bundles must NOT live at the .app root
+        # (codesign will reject that layout).
+        run: |
+          echo "🔍 Checking SPM resource bundle layout..."
+          FAIL=0
+
+          # Bundles must NOT be at the .app root (codesign rejects that).
+          if ls VocaMac.app/*.bundle 1>/dev/null 2>&1; then
+            echo "❌ Found .bundle at app root — will break codesign!"
+            ls VocaMac.app/*.bundle
+            FAIL=1
+          fi
+
+          FOUND_ANY=false
+          for bundle in VocaMac.app/Contents/Resources/*.bundle; do
+            [ -d "$bundle" ] || continue
+            FOUND_ANY=true
+            name="$(basename "$bundle")"
+            echo "✅ $name — present in Contents/Resources/"
+          done
+
+          if [ "$FOUND_ANY" = false ]; then
+            echo "❌ No .bundle directories found in Contents/Resources/!"
+            FAIL=1
+          fi
+
+          # Verify the critical WhisperKit tokenizer fallback resources.
+          # xcodebuild bundles have the structure: <bundle>/Contents/Resources/<file>
+          HUB="VocaMac.app/Contents/Resources/swift-transformers_Hub.bundle"
+          if [ ! -d "$HUB" ]; then
+            echo "❌ swift-transformers_Hub.bundle missing!"
+            FAIL=1
+          else
+            for f in gpt2_tokenizer_config.json t5_tokenizer_config.json; do
+              if find "$HUB" -name "$f" -print -quit | grep -q .; then
+                echo "✅ $f present in swift-transformers_Hub.bundle"
+              else
+                echo "❌ Missing $f in swift-transformers_Hub.bundle"
+                FAIL=1
+              fi
+            done
+          fi
+
+          # Verify the binary uses the xcodebuild accessor (contains resourceURL)
+          if strings VocaMac.app/Contents/MacOS/VocaMac | grep -q 'resourceURL'; then
+            echo "✅ Binary uses xcodebuild Bundle.module accessor"
+          else
+            echo "❌ Binary does NOT contain resourceURL — wrong accessor!"
+            echo "   Ensure build.sh uses xcodebuild, not swift build."
+            FAIL=1
+          fi
+
+          if [ "$FAIL" -ne 0 ]; then
+            echo ""
+            echo "Bundle layout validation failed. See above for details."
+            exit 1
+          fi
+
+          echo ""
+          echo "✅ All bundle checks passed."
+
       - name: Gather artifacts
         id: artifacts
         run: |

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -276,6 +276,6 @@ if [ "$FIRST_TIME" = true ]; then
         echo ""
         echo "   ⚠️  Permissions reset on every rebuild (ad-hoc signing limitation)."
         echo "   💡 TIP: To avoid this, add your Terminal app to Accessibility & Input Monitoring"
-        echo "      and run VocaMac directly: .build/arm64-apple-macosx/release/VocaMac"
+        echo "      and run the binary directly: ${APP_DIR}/Contents/MacOS/VocaMac"
     fi
 fi


### PR DESCRIPTION
## Summary

Two small pre-release hygiene fixes surfaced by a diligent `v0.6.0..main` review (the *should-fix* items, not blockers — but worth landing before tagging v0.6.1).

## Changes

### 1. `scripts/build.sh` — fix stale dev-binary path tip

The first-time-setup tip printed by `build.sh` referenced the old `swift build` output path:

```
   💡 TIP: To avoid this, add your Terminal app to Accessibility & Input Monitoring
      and run VocaMac directly: .build/arm64-apple-macosx/release/VocaMac   ❌ no longer exists
```

Since #118/#119 the script uses **xcodebuild**, which puts the binary inside the `.app` bundle (`.xcode-build/Build/Products/Release/VocaMac.app/Contents/MacOS/VocaMac`). The tip is shown to anyone doing a fresh ad-hoc-signed local build, so it's an immediate point of confusion for new contributors.

**Fix:** Reference the canonical binary location via the existing `${APP_DIR}` variable — guaranteed-correct regardless of where `APP_DIR` lives:

```
      and run the binary directly: ${APP_DIR}/Contents/MacOS/VocaMac   ✅ always correct
```

### 2. `.github/workflows/pr-build.yml` — backport bundle validation step

The `Verify SPM resource bundles are correctly staged` check (added in c3a3fd2) was applied to **release.yml** and **nightly.yml** but **NOT** to `pr-build.yml`. That means a #119-class regression (`*.bundle` at the `.app` root, missing tokenizer fallbacks, swift-build accessor instead of xcodebuild) could slip past PR review and only get caught at release time — exactly the failure mode the validation step was designed to prevent.

**Fix:** Backport the identical validation step to `pr-build.yml`, plus a `codesign -v --deep --strict` step ahead of it (mirroring the release pipeline). Step is identical in spirit to release.yml; the inline comment explains the rationale and cross-references the source pipelines so future maintainers don't accidentally diverge them.

## Verification

- `bash -n scripts/build.sh` ✅
- YAML structural sanity check on `pr-build.yml` (no tabs, balanced indentation, 18 named steps, 6 pipe-block runs) ✅
- No functional Swift code changes → no `swift test` run needed; the existing 166-test suite is unaffected.
- The PR-build CI on this very PR will exercise the new validation step end-to-end.

## Out of scope

The other findings from the review:

- **Nice-to-have:** TextInjector integration test for `simulatePaste()`, non-ASCII layout test for `keyCode(forCharacter:)`, removal of redundant `Task { @MainActor in }` wrapping (AppState is already `@MainActor`), CI SHA-pinning of third-party actions. These are quality polish, not pre-release blockers — defer to v0.6.2.
- **Should-fix (lower priority):** Inline comment for the hard-coded `arch=arm64` in build.sh:83 (Apple Silicon-only is documented policy). Defer.

## Release impact

Once this merges, **rebase PR #124** (the v0.6.1 version bump) onto the new `main` so the v0.6.1 release ships with both fixes. The pr-build validation will start enforcing on PR #124 itself once rebased.