### PR TITLE
ui: clean up footer links — drop cross-product duplicates, add Changelog

### DIFF
--- a/web/layouts/partials/footer.html
+++ b/web/layouts/partials/footer.html
@@ -6,9 +6,8 @@
             </div>
             <div class="footer__links">
                 <a href="{{ .Site.Params.githubRepo }}" target="_blank" rel="noopener">GitHub</a>
+                <a href="{{ .Site.Params.githubRepo }}/releases" target="_blank" rel="noopener">Changelog</a>
                 <a href="/screenshots/">Screenshots</a>
-                <a href="https://vocalinux.com" target="_blank" rel="noopener">VocaLinux</a>
-                <a href="https://vocawin.com" target="_blank" rel="noopener">VocaWin</a>
             </div>
             <div class="footer__right">
                 Made with ❤️ by <a href="https://x.com/intent/user?screen_name=jatinkrmalik" target="_blank" rel="noopener">Jatin Kumar Malik</a>


### PR DESCRIPTION
## Summary

A tiny footer cleanup that surfaced while reviewing the website ahead of v0.6.1's release announcement.

## What changed

**Before** — 4 links:
```
GitHub | Screenshots | VocaLinux | VocaWin
```

**After** — 3 links:
```
GitHub | Changelog | Screenshots
```

## Rationale

### Why drop `VocaLinux` and `VocaWin`?

The homepage already has a dedicated **"The Voca Family"** section ([`web/layouts/index.html` lines 469–507](https://github.com/jatinkrmalik/vocamac/blob/main/web/layouts/index.html#L469-L507)) showcasing all three platforms in much richer form — platform SVG icons, status badges (`Beta` / `Coming Soon`), one-line descriptions, and direct links. The footer entries are stripped-down duplicates that add visual clutter without adding any discoverability.

### Why add `Changelog`?

A quick site-wide audit confirmed there's **no dedicated changelog surface anywhere on vocamac.com** — first-time visitors (especially the Reddit / HN / r/MacApps drive-by crowd) have no way to answer *"what changed recently?"* or *"is this project actively maintained?"* without leaving for the GitHub repo and digging through the Releases tab.

Linking the GitHub Releases page directly:
- Reuses the **single source of truth** for release notes — exactly matches the policy codified in #126 (`docs/RELEASE.md` → "Release Notes (out-of-tree)")
- **Zero ongoing maintenance** — the Releases page auto-updates with every new tag
- Surfaces the polished v0.6.1 release notes we just published

## Verification

- 1-line addition + 2-line removal in a single Hugo partial; no template-tag changes, no CSS impact, no script changes.
- The mobile menu (`partials/mobile-menu.html`) reuses `.navbar__menu` items from `partials/nav.html`, neither of which is touched.
- `deploy-website.yml` will rebuild and validate on this PR.

## Out of scope

- Adding a Changelog link to the **top nav** as well — could be a follow-up if footer-only feels under-discoverable.
- A custom on-site `/changelog/` page (Option C from the earlier audit) — defer to v0.7 if and when we want SEO control over the changelog.