### PR TITLE
Fix macOS 26 button crash by stabilizing app and audio lifecycles

### DIFF
--- a/Sources/VocaMac/Models/AppState.swift
+++ b/Sources/VocaMac/Models/AppState.swift
@@ -160,7 +160,7 @@ final class AppState: ObservableObject {
         self.permissionManager = permissionManager ?? PermissionManager(audioEngine: audioEngine, hotKeyManager: hotKeyManager)
         self.skipSystemIntegration = skipSystemIntegration
 
-        VocaLogger.info(.appState, "Initializing...")
+        VocaLogger.info(.appState, "Initializing... id=\(ObjectIdentifier(self))")
         if !skipSystemIntegration {
             syncLaunchAtLogin()
         }
@@ -174,11 +174,21 @@ final class AppState: ObservableObject {
             .store(in: &cancellables)
     }
 
+    /// Single production AppState instance for the process.
+    ///
+    /// SwiftUI can recreate the `App` value during scene setup, especially for
+    /// menu bar apps. Keeping the production instance outside the `App` value's
+    /// stored-property initialization prevents duplicate service graphs, event
+    /// taps, audio observers, and stale SwiftUI environment objects.
+    @MainActor
+    private static let sharedProductionInstance = AppState(cursorOverlay: CursorOverlayManager())
+
     /// Convenience factory for creating AppState with all real services.
     /// Needed because CursorOverlayManager is @MainActor and can't be a default parameter.
     @MainActor
     static func production() -> AppState {
-        AppState(cursorOverlay: CursorOverlayManager())
+        VocaLogger.debug(.appState, "Using production AppState id=\(ObjectIdentifier(sharedProductionInstance))")
+        return sharedProductionInstance
     }
 
     /// Called once from the SwiftUI lifecycle to complete initialization.

--- a/Sources/VocaMac/Services/AudioEngine.swift
+++ b/Sources/VocaMac/Services/AudioEngine.swift
@@ -13,8 +13,13 @@ final class AudioEngine {
 
     private let engine = AVAudioEngine()
     private var audioBuffer: [Float] = []
-    private(set) var isCurrentlyRecording = false
+    private var _isCurrentlyRecording = false
     private let bufferQueue = DispatchQueue(label: "com.vocamac.audio-buffer", qos: .userInteractive)
+    private let lifecycleQueue = DispatchQueue(label: "com.vocamac.audio-engine.lifecycle", qos: .userInitiated)
+
+    var isCurrentlyRecording: Bool {
+        lifecycleQueue.sync { _isCurrentlyRecording }
+    }
 
     // Silence detection
     private var lastSoundTime: Date = Date()
@@ -80,28 +85,31 @@ final class AudioEngine {
     /// is invalidated — the installed tap references a stale format and no audio
     /// flows. We must stop, reset, and notify AppState so it can recover.
     @objc private func handleAudioConfigurationChange(_ notification: Notification) {
-        VocaLogger.info(.audioEngine, "Audio configuration changed (device plug/unplug or route change)")
+        lifecycleQueue.async { [weak self] in
+            guard let self = self else { return }
+            VocaLogger.info(.audioEngine, "Audio configuration changed (device plug/unplug or route change)")
 
-        let wasRecording = isCurrentlyRecording
+            let wasRecording = self._isCurrentlyRecording
 
-        if wasRecording {
-            VocaLogger.warning(.audioEngine, "Configuration changed while recording — forcing stop and reset")
-            // Tear down the stale recording state
-            isCurrentlyRecording = false
-            silenceCallbackFired = false
-            maxDurationCallbackFired = false
-            engine.inputNode.removeTap(onBus: 0)
-            engine.stop()
-        }
+            if wasRecording {
+                VocaLogger.warning(.audioEngine, "Configuration changed while recording — forcing stop and reset")
+                // Tear down the stale recording state
+                self._isCurrentlyRecording = false
+                self.silenceCallbackFired = false
+                self.maxDurationCallbackFired = false
+                self.engine.inputNode.removeTap(onBus: 0)
+                self.engine.stop()
+            }
 
-        // Reset the engine so it picks up the new audio device/format
-        engine.reset()
-        VocaLogger.info(.audioEngine, "Audio engine reset after configuration change")
+            // Reset the engine so it picks up the new audio device/format
+            self.engine.reset()
+            VocaLogger.info(.audioEngine, "Audio engine reset after configuration change")
 
-        if wasRecording {
-            // Notify AppState on the main queue so it can handle the interrupted recording
-            DispatchQueue.main.async { [weak self] in
-                self?.onAudioDeviceChanged?()
+            if wasRecording {
+                // Notify AppState on the main queue so it can handle the interrupted recording
+                DispatchQueue.main.async { [weak self] in
+                    self?.onAudioDeviceChanged?()
+                }
             }
         }
     }
@@ -143,54 +151,58 @@ final class AudioEngine {
         silenceDuration: Double = 2.0,
         maxDuration: TimeInterval = 60.0
     ) {
-        guard !isCurrentlyRecording else { return }
+        lifecycleQueue.sync {
+            guard !self._isCurrentlyRecording else { return }
 
-        self.silenceThreshold = silenceThreshold
-        self.silenceDuration = silenceDuration
-        self.maxDuration = maxDuration
+            self.silenceThreshold = silenceThreshold
+            self.silenceDuration = silenceDuration
+            self.maxDuration = maxDuration
 
-        // Reset state
-        bufferQueue.sync {
-            audioBuffer.removeAll(keepingCapacity: true)
-        }
-        lastSoundTime = Date()
-        recordingStartTime = Date()
-        silenceCallbackFired = false
-        maxDurationCallbackFired = false
-        isCurrentlyRecording = true
+            // Reset state
+            bufferQueue.sync {
+                audioBuffer.removeAll(keepingCapacity: true)
+            }
+            lastSoundTime = Date()
+            recordingStartTime = Date()
+            silenceCallbackFired = false
+            maxDurationCallbackFired = false
+            _isCurrentlyRecording = true
 
-        let inputNode = engine.inputNode
-        let inputFormat = inputNode.outputFormat(forBus: 0)
+            let inputNode = engine.inputNode
+            let inputFormat = inputNode.outputFormat(forBus: 0)
 
-        // Install a tap on the input node to capture audio
-        inputNode.installTap(onBus: 0, bufferSize: 4096, format: inputFormat) { [weak self] buffer, _ in
-            self?.processAudioBuffer(buffer, inputFormat: inputFormat)
-        }
+            // Install a tap on the input node to capture audio
+            inputNode.installTap(onBus: 0, bufferSize: 4096, format: inputFormat) { [weak self] buffer, _ in
+                self?.processAudioBuffer(buffer, inputFormat: inputFormat)
+            }
 
-        do {
-            try engine.start()
-        } catch {
-            VocaLogger.error(.audioEngine, "Failed to start audio engine: \(error)")
-            isCurrentlyRecording = false
+            do {
+                try engine.start()
+            } catch {
+                VocaLogger.error(.audioEngine, "Failed to start audio engine: \(error)")
+                _isCurrentlyRecording = false
+            }
         }
     }
 
     /// Stop recording and return the captured audio samples
     /// - Returns: Array of Float32 PCM samples at 16kHz mono
     func stopRecording() -> [Float] {
-        guard isCurrentlyRecording else { return [] }
+        lifecycleQueue.sync {
+            guard _isCurrentlyRecording else { return [] }
 
-        isCurrentlyRecording = false
-        engine.inputNode.removeTap(onBus: 0)
-        engine.stop()
+            _isCurrentlyRecording = false
+            engine.inputNode.removeTap(onBus: 0)
+            engine.stop()
 
-        let samples: [Float] = bufferQueue.sync {
-            let copy = audioBuffer
-            audioBuffer.removeAll(keepingCapacity: true)
-            return copy
+            let samples: [Float] = bufferQueue.sync {
+                let copy = audioBuffer
+                audioBuffer.removeAll(keepingCapacity: true)
+                return copy
+            }
+
+            return samples
         }
-
-        return samples
     }
 
     /// Forcibly reset the audio engine to a clean state, regardless of current state.
@@ -198,22 +210,24 @@ final class AudioEngine {
     /// taps, stops the engine, clears buffers, and resets all flags.
     /// Use when the engine is suspected to be in an inconsistent state.
     func forceReset() {
-        VocaLogger.warning(.audioEngine, "Force reset requested (wasRecording=\(isCurrentlyRecording))")
+        lifecycleQueue.sync {
+            VocaLogger.warning(.audioEngine, "Force reset requested (wasRecording=\(_isCurrentlyRecording))")
 
-        isCurrentlyRecording = false
-        silenceCallbackFired = false
-        maxDurationCallbackFired = false
+            _isCurrentlyRecording = false
+            silenceCallbackFired = false
+            maxDurationCallbackFired = false
 
-        // Safely remove tap — may throw if no tap is installed, but that's fine
-        engine.inputNode.removeTap(onBus: 0)
-        engine.stop()
-        engine.reset()
+            // Safely remove tap — may throw if no tap is installed, but that's fine
+            engine.inputNode.removeTap(onBus: 0)
+            engine.stop()
+            engine.reset()
 
-        bufferQueue.sync {
-            audioBuffer.removeAll(keepingCapacity: true)
+            bufferQueue.sync {
+                audioBuffer.removeAll(keepingCapacity: true)
+            }
+
+            VocaLogger.info(.audioEngine, "Force reset complete — engine is clean")
         }
-
-        VocaLogger.info(.audioEngine, "Force reset complete — engine is clean")
     }
 
     // MARK: - Audio Processing


### PR DESCRIPTION
## Summary

Fixes #129.

This PR addresses the recurring macOS 26 crash seen in VocaMac 0.6.1 where SwiftUI button dispatch crashes inside `MainActor.assumeIsolated` after prior audio route/device changes.

The validated crash report shows the fault occurs in SwiftUI's `_ButtonGesture` path, before app button action code is visible in the stack. That means the previous `Task { @MainActor in ... }` fix likely did not cover the actual failing frame.

## Changes

- Stabilize production `AppState` lifetime by backing `AppState.production()` with one process-wide `sharedProductionInstance`.
  - This avoids creating duplicate production service graphs when SwiftUI recreates the `App` value during menu-bar scene setup.
  - Adds object identity logging so future crash logs can confirm whether one or more production instances exist.
- Serialize `AudioEngine` lifecycle mutation through a dedicated serial queue.
  - `startRecording`, `stopRecording`, `forceReset`, and `AVAudioEngineConfigurationChange` reset handling now mutate engine/tap/recording state on the same queue.
  - This removes a plausible race between route-change notifications and user-driven recording stop/reset paths.

## Notes

The issue investigation originally suspected duplicate `AppState` initialization in the crashed process. Timestamp validation showed the provided duplicate initialization logs were likely post-crash relaunch logs, not pre-crash evidence. This PR still fixes the underlying lifetime instability because production state was still constructed from the SwiftUI `App` property initializer and could create duplicate service graphs.

## Validation

- `swift test --filter AppStateRecordingTests/testTriggerStartupIdempotent`
- `swift test` — 166 tests passing
- `swift build`
