### PR TITLE
fix: harden audio engine tap lifecycle

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -20,10 +20,17 @@ let package = Package(
         .package(url: "https://github.com/argmaxinc/WhisperKit.git", from: "0.9.4"),
     ],
     targets: [
+        // Objective-C helpers used by the Swift app.
+        .target(
+            name: "VocaMacObjC",
+            path: "Sources/VocaMacObjC",
+            publicHeadersPath: "include"
+        ),
         // Main application target
         .executableTarget(
             name: "VocaMac",
             dependencies: [
+                "VocaMacObjC",
                 .product(name: "WhisperKit", package: "WhisperKit"),
             ],
             path: "Sources/VocaMac",

--- a/Sources/VocaMac/Services/AudioEngine.swift
+++ b/Sources/VocaMac/Services/AudioEngine.swift
@@ -6,6 +6,7 @@
 
 import Foundation
 import AVFoundation
+import VocaMacObjC
 
 final class AudioEngine {
 
@@ -97,7 +98,7 @@ final class AudioEngine {
                 self._isCurrentlyRecording = false
                 self.silenceCallbackFired = false
                 self.maxDurationCallbackFired = false
-                self.engine.inputNode.removeTap(onBus: 0)
+                self.removeInputTap(reason: "audio configuration change")
                 self.engine.stop()
             }
 
@@ -158,29 +159,51 @@ final class AudioEngine {
             self.silenceDuration = silenceDuration
             self.maxDuration = maxDuration
 
-            // Reset state
-            bufferQueue.sync {
-                audioBuffer.removeAll(keepingCapacity: true)
-            }
-            lastSoundTime = Date()
-            recordingStartTime = Date()
-            silenceCallbackFired = false
-            maxDurationCallbackFired = false
+            resetRecordingState()
             _isCurrentlyRecording = true
 
             let inputNode = engine.inputNode
             let inputFormat = inputNode.outputFormat(forBus: 0)
 
-            // Install a tap on the input node to capture audio
-            inputNode.installTap(onBus: 0, bufferSize: 4096, format: inputFormat) { [weak self] buffer, _ in
-                self?.processAudioBuffer(buffer, inputFormat: inputFormat)
+            guard isValidInputFormat(inputFormat) else {
+                VocaLogger.error(
+                    .audioEngine,
+                    "Invalid input format before recording start: sampleRate=\(inputFormat.sampleRate), channels=\(inputFormat.channelCount)"
+                )
+                recoverFromStartFailure(notifyAppState: true)
+                return
             }
 
-            do {
-                try engine.start()
-            } catch {
-                VocaLogger.error(.audioEngine, "Failed to start audio engine: \(error)")
-                _isCurrentlyRecording = false
+            // A previous failed start can leave a tap installed even when our
+            // recording flag is false. Remove any stale tap before installing a
+            // fresh one; otherwise AVAudioEngine raises an uncaught NSException.
+            removeInputTap(reason: "pre-start cleanup")
+
+            var startError: Error?
+            let exception = VocaObjCExceptionCatcher.catchException { [weak self] in
+                guard let self = self else { return }
+
+                inputNode.installTap(onBus: 0, bufferSize: 4096, format: inputFormat) { [weak self] buffer, _ in
+                    self?.processAudioBuffer(buffer, inputFormat: inputFormat)
+                }
+
+                do {
+                    try self.engine.start()
+                } catch {
+                    startError = error
+                }
+            }
+
+            if let exception {
+                VocaLogger.error(.audioEngine, "AVAudioEngine exception while starting recording: \(exception.localizedDescription)")
+                recoverFromStartFailure(notifyAppState: true)
+                return
+            }
+
+            if let startError {
+                VocaLogger.error(.audioEngine, "Failed to start audio engine: \(startError.localizedDescription)")
+                recoverFromStartFailure(notifyAppState: true)
+                return
             }
         }
     }
@@ -192,15 +215,10 @@ final class AudioEngine {
             guard _isCurrentlyRecording else { return [] }
 
             _isCurrentlyRecording = false
-            engine.inputNode.removeTap(onBus: 0)
+            removeInputTap(reason: "stop recording")
             engine.stop()
 
-            let samples: [Float] = bufferQueue.sync {
-                let copy = audioBuffer
-                audioBuffer.removeAll(keepingCapacity: true)
-                return copy
-            }
-
+            let samples = capturedSamplesAndResetBuffer()
             return samples
         }
     }
@@ -217,16 +235,74 @@ final class AudioEngine {
             silenceCallbackFired = false
             maxDurationCallbackFired = false
 
-            // Safely remove tap — may throw if no tap is installed, but that's fine
-            engine.inputNode.removeTap(onBus: 0)
+            removeInputTap(reason: "force reset")
             engine.stop()
             engine.reset()
-
-            bufferQueue.sync {
-                audioBuffer.removeAll(keepingCapacity: true)
-            }
+            clearAudioBuffer()
 
             VocaLogger.info(.audioEngine, "Force reset complete — engine is clean")
+        }
+    }
+
+    // MARK: - Lifecycle Helpers
+
+    /// Resets per-recording state before a new capture attempt.
+    private func resetRecordingState() {
+        clearAudioBuffer()
+        lastSoundTime = Date()
+        recordingStartTime = Date()
+        silenceCallbackFired = false
+        maxDurationCallbackFired = false
+    }
+
+    /// Clears captured audio samples while preserving buffer capacity.
+    private func clearAudioBuffer() {
+        bufferQueue.sync {
+            audioBuffer.removeAll(keepingCapacity: true)
+        }
+    }
+
+    /// Returns captured samples and clears the backing buffer.
+    private func capturedSamplesAndResetBuffer() -> [Float] {
+        bufferQueue.sync {
+            let copy = audioBuffer
+            audioBuffer.removeAll(keepingCapacity: true)
+            return copy
+        }
+    }
+
+    /// Checks whether a hardware input format is safe to pass to AVAudioEngine.
+    /// Invalid or transient formats can cause installTap to raise NSException.
+    private func isValidInputFormat(_ format: AVAudioFormat) -> Bool {
+        format.sampleRate.isFinite && format.sampleRate > 0 && format.channelCount > 0
+    }
+
+    /// Removes the current input tap while converting AVFoundation NSExceptions
+    /// into log messages instead of process aborts.
+    private func removeInputTap(reason: String) {
+        let exception = VocaObjCExceptionCatcher.catchException { [weak self] in
+            self?.engine.inputNode.removeTap(onBus: 0)
+        }
+
+        if let exception {
+            VocaLogger.warning(.audioEngine, "Ignoring AVAudioEngine exception while removing tap during \(reason): \(exception.localizedDescription)")
+        }
+    }
+
+    /// Restores AudioEngine to a clean idle state after any failed start attempt.
+    private func recoverFromStartFailure(notifyAppState: Bool) {
+        _isCurrentlyRecording = false
+        silenceCallbackFired = false
+        maxDurationCallbackFired = false
+        removeInputTap(reason: "start failure")
+        engine.stop()
+        engine.reset()
+        clearAudioBuffer()
+
+        if notifyAppState {
+            DispatchQueue.main.async { [weak self] in
+                self?.onAudioDeviceChanged?()
+            }
         }
     }
 

--- a/Sources/VocaMacObjC/VocaObjCExceptionCatcher.m
+++ b/Sources/VocaMacObjC/VocaObjCExceptionCatcher.m
@@ -1,0 +1,25 @@
+// VocaObjCExceptionCatcher.m
+// VocaMac
+
+#import "VocaMacObjC.h"
+
+@implementation VocaObjCExceptionCatcher
+
++ (NSError * _Nullable)catchException:(NS_NOESCAPE void (^)(void))block {
+    @try {
+        block();
+        return nil;
+    } @catch (NSException *exception) {
+        NSString *name = exception.name ?: @"NSException";
+        NSString *reason = exception.reason ?: @"Objective-C exception raised";
+
+        return [NSError errorWithDomain:@"com.vocamac.objc-exception"
+                                   code:1
+                               userInfo:@{
+                                   NSLocalizedDescriptionKey: reason,
+                                   @"NSExceptionName": name
+                               }];
+    }
+}
+
+@end

--- a/Sources/VocaMacObjC/include/VocaMacObjC.h
+++ b/Sources/VocaMacObjC/include/VocaMacObjC.h
@@ -1,0 +1,22 @@
+// VocaMacObjC.h
+// VocaMac
+//
+// Objective-C helpers used by the Swift app.
+
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface VocaObjCExceptionCatcher : NSObject
+
+/// Executes a block and converts any Objective-C NSException into an NSError.
+///
+/// Some AVFoundation APIs, including AVAudioNode tap installation, report
+/// programmer/precondition failures by raising NSException instead of throwing
+/// Swift/Objective-C NSError values. Swift cannot catch NSException directly,
+/// so this helper prevents those framework exceptions from aborting the app.
++ (NSError * _Nullable)catchException:(NS_NOESCAPE void (^)(void))block;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Tests/VocaMacTests/ObjCExceptionCatcherTests.swift
+++ b/Tests/VocaMacTests/ObjCExceptionCatcherTests.swift
@@ -1,0 +1,32 @@
+// ObjCExceptionCatcherTests.swift
+// VocaMac
+
+import Foundation
+import VocaMacObjC
+import XCTest
+
+final class ObjCExceptionCatcherTests: XCTestCase {
+
+    func testCatchExceptionReturnsNilWhenBlockDoesNotRaise() {
+        let error = VocaObjCExceptionCatcher.catchException {
+            _ = "safe block"
+        }
+
+        XCTAssertNil(error)
+    }
+
+    func testCatchExceptionConvertsNSExceptionToNSError() throws {
+        let error = VocaObjCExceptionCatcher.catchException {
+            NSException(
+                name: NSExceptionName("VocaMacTestException"),
+                reason: "simulated Objective-C exception",
+                userInfo: nil
+            ).raise()
+        }
+
+        let unwrappedError = try XCTUnwrap(error as NSError?)
+        XCTAssertEqual(unwrappedError.domain, "com.vocamac.objc-exception")
+        XCTAssertEqual(unwrappedError.localizedDescription, "simulated Objective-C exception")
+        XCTAssertEqual(unwrappedError.userInfo["NSExceptionName"] as? String, "VocaMacTestException")
+    }
+}


### PR DESCRIPTION
Some users have been hitting a hard crash when starting or stopping recording. The crash report points squarely at AVAudioEngine raising an Objective-C exception from inside `installTap`, which Swift can't catch with `do/catch`, so the whole app aborts.

This PR closes that crash path and tightens up the surrounding lifecycle so we don't get back into the broken state in the first place.

## What was actually going wrong

Two things, working together:

1. `AVAudioNode.installTap` reports precondition failures (bad input format, tap already installed on that bus, no input device, etc.) by raising an `NSException`. Swift can't catch those, and AVFoundation calls them straight from our `lifecycleQueue`, so they tear the process down.
2. The previous `startRecording` could leave a tap installed if `engine.start()` failed *after* `installTap` succeeded. The next recording attempt would then try to install a second tap on the same bus — and AVAudioEngine reacts to that by raising the exception above. Classic self-inflicted wound.

That matches the user reports: things look fine for a while, then a recording gets stuck, and the *next* press of the hotkey crashes the app.

## The fix

- Added a small Objective-C helper (`VocaObjCExceptionCatcher`) that runs a block inside `@try/@catch` and converts any `NSException` into an `NSError` Swift can handle. It's the only ObjC in the codebase and does exactly one thing.
- Wrapped every AVAudioEngine call that can raise — `installTap`, `engine.start()`, `removeTap` — in that catcher. If the framework throws, we log it and recover instead of aborting.
- Validate the input format (`sampleRate > 0`, `channelCount > 0`, finite) before calling `installTap`. Transient bad formats during route changes were one of the easy ways to trip the exception.
- Always remove any existing tap before installing a new one, so a previously failed start can't poison the next attempt.
- On failure, fully reset engine + tap + buffer + recording flags, and notify `AppState` via the existing `onAudioDeviceChanged` callback so the UI exits the stuck "recording" state instead of sitting there red.

No behaviour change on the happy path. Same threading, same protocols, same `AudioRecording` conformance.