### PR TITLE
chore: bump version to 0.6.2

### DIFF
--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -26,8 +26,8 @@ Pre-release versions use suffixes: `v0.1.0-alpha`, `v0.1.0-beta.1`
 2. **Verify CI passes** on the latest `main` commit
 3. **Update version number** in all locations:
    - `scripts/build.sh` — both `CFBundleVersion` and `CFBundleShortVersionString` in the Info.plist template
-   - `Sources/VocaMac/Views/SettingsView.swift` — version label in the About tab
    - `web/layouts/index.html` — `softwareVersion` in JSON-LD schema and hero version badge (two occurrences)
+   - _(No Swift change needed — the About tab reads the version from `Info.plist` via `appVersionDisplay` in `SettingsView.swift`.)_
    - **Do NOT** create a `docs/RELEASE_NOTES_vX.Y.Z.md` file — release notes live out-of-tree (see [Release Notes (out-of-tree)](#release-notes-out-of-tree) below)
 4. **Test locally**:
    ```bash
@@ -98,7 +98,7 @@ Pre-release versions use suffixes: `v0.1.0-alpha`, `v0.1.0-beta.1`
 
 ### What goes in the version-bump PR
 
-The version-bump PR should only touch *code* files that carry the version string (`scripts/build.sh`, `Sources/VocaMac/Views/SettingsView.swift`, `web/layouts/index.html`). The **PR description** is where the changelog table lives — that gives reviewers the context they need without polluting the tree.
+The version-bump PR should only touch *code* files that carry the version string (`scripts/build.sh`, `web/layouts/index.html`). The **PR description** is where the changelog table lives — that gives reviewers the context they need without polluting the tree.
 
 ### Suggested PR-description template
 
@@ -114,7 +114,6 @@ Prepares the **vX.Y.Z** patch/minor release.
 
 ### Files updated
 - `scripts/build.sh`
-- `Sources/VocaMac/Views/SettingsView.swift`
 - `web/layouts/index.html`
 
 ### Release plan after merge

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -8,8 +8,8 @@
 # 3. Code signs — Developer ID if CODE_SIGN_IDENTITY is set, ad-hoc otherwise
 #
 # Environment variables:
-#   APP_VERSION         — Version string to embed in Info.plist. Defaults to 0.6.1.
-#                         Set by CI for nightly builds (e.g., 0.6.1-nightly.20260424+abc1234).
+#   APP_VERSION         — Version string to embed in Info.plist. Defaults to 0.6.2.
+#                         Set by CI for nightly builds (e.g., 0.6.2-nightly.20260512+abc1234).
 #   CODE_SIGN_IDENTITY  — Signing identity to use. Defaults to auto-detect
 #                         Developer ID Application in the login keychain.
 #                         Set to "-" to force ad-hoc signing.
@@ -29,7 +29,7 @@ BUNDLE_ID="com.vocamac.app"
 APP_NAME="VocaMac"
 APP_DIR="${APP_NAME}.app"
 ENTITLEMENTS="VocaMac.entitlements"
-APP_VERSION="${APP_VERSION:-0.6.1}"
+APP_VERSION="${APP_VERSION:-0.6.2}"
 
 # Resolve signing identity:
 # 1. Use CODE_SIGN_IDENTITY env var if set

--- a/web/layouts/index.html
+++ b/web/layouts/index.html
@@ -36,7 +36,7 @@
             "Open source (AGPL-3.0 license)"
         ],
         "screenshot": "https://vocamac.com/og-image.png",
-        "softwareVersion": "0.6.1",
+        "softwareVersion": "0.6.2",
         "softwareRequirements": "macOS 13 (Ventura) or later, Apple Silicon (M1 or later), 8 GB RAM minimum"
     }
     </script>
@@ -49,7 +49,7 @@
             <div class="hero__content">
                 <div class="hero__badges">
                     <span class="badge badge--beta">BETA RELEASE</span>
-                    <span class="badge badge--outline" id="version-badge">v0.6.1</span>
+                    <span class="badge badge--outline" id="version-badge">v0.6.2</span>
                 </div>
                 <h1 class="hero__headline">
                     Your Voice,<br>


### PR DESCRIPTION
## Summary
Prepares the **v0.6.2** patch release.

### Changes since v0.6.1
| PR | Type | Summary |
|---|---|---|
| #134 | fix | Harden audio engine tap lifecycle. Wraps `installTap`, `engine.start`, and `removeTap` in an Objective-C exception bridge so AVFoundation NSExceptions become recoverable Swift errors instead of SIGABRTs. Affected users have confirmed the crash is gone on the latest nightly. |
| #130 | fix | Stabilize app state and audio engine lifecycle. |
| #137 | ui  | Rename the "Unoptimized" model badge to "Experimental", soften the confirmation alert wording, add a tooltip plus a "Recommended for your device" subtitle clarifying that the badge reflects WhisperKit's per-chip tuning (not RAM), and log the WhisperKit recommendation triple at startup for easier triage. Also swaps the Onboarding "Try Anyway" button icon from a warning triangle to sparkles. |
| #128 | ui  | Clean up website footer links (no app code change). |

No new features, no API or behaviour changes on the happy path, so this is a patch bump.

### Files updated
- `scripts/build.sh`: default `APP_VERSION` set to `0.6.2`.
- `web/layouts/index.html`: `softwareVersion` (JSON-LD) and hero `version-badge` set to `0.6.2`.
- `docs/RELEASE.md`: drop the stale instruction to bump `Sources/VocaMac/Views/SettingsView.swift`. The About tab reads the version from `Info.plist` via `appVersionDisplay`, so there is nothing to change there.

### Release plan after merge
- Tag `v0.6.2` and push the tag, which triggers `release.yml` to build, sign, notarize, and draft the release.
- Paste finalized notes from the local scratch file into the draft, then publish.
- `deploy-website.yml` auto publishes the website on release publish.
- Delete the local scratch notes file.