### PR TITLE
ui: rename Unoptimized badge to Experimental with clearer copy

### DIFF
--- a/Sources/VocaMac/Models/AppState.swift
+++ b/Sources/VocaMac/Models/AppState.swift
@@ -253,6 +253,7 @@ final class AppState: ObservableObject {
         // WhisperKit's `.default` may not be in the supported list for some
         // devices. If so, fall back to the best supported model instead.
         let recommendation = modelManager.deviceRecommendation()
+        VocaLogger.info(.appState, "WhisperKit recommendation — default: \(recommendation.defaultModel), supported: [\(recommendation.supported.joined(separator: ", "))], disabled: [\(recommendation.disabled.joined(separator: ", "))]")
         let defaultIsSupported = recommendation.supported.contains(recommendation.defaultModel)
         if !defaultIsSupported, let bestSupported = recommendation.supported.last {
             deviceRecommendedModel = bestSupported

--- a/Sources/VocaMac/Views/OnboardingView.swift
+++ b/Sources/VocaMac/Views/OnboardingView.swift
@@ -548,7 +548,7 @@ struct ModelSelectionCard: View {
                         showForceDownloadAlert = true
                     } label: {
                         HStack(spacing: 4) {
-                            Image(systemName: "exclamationmark.triangle")
+                            Image(systemName: "sparkles")
                             Text("Try Anyway")
                         }
                         .font(.caption)

--- a/Sources/VocaMac/Views/OnboardingView.swift
+++ b/Sources/VocaMac/Views/OnboardingView.swift
@@ -585,13 +585,13 @@ struct ModelSelectionCard: View {
             RoundedRectangle(cornerRadius: 8)
                 .stroke(isRecommended ? Color.orange : Color.clear, lineWidth: 1.5)
         )
-        .alert("Use Unoptimized Model?", isPresented: $showForceDownloadAlert) {
+        .alert("Use Experimental Model?", isPresented: $showForceDownloadAlert) {
             Button("Cancel", role: .cancel) {}
             Button("Download Anyway", role: .destructive) {
                 onDownload()
             }
         } message: {
-            Text("This model may exceed your device's capabilities. It could cause slow performance, high memory usage, or crashes. Are you sure you want to continue?")
+            Text("WhisperKit hasn't verified this model on your chip family. It will likely work but may be slower than tuned models.")
         }
     }
 }

--- a/Sources/VocaMac/Views/SettingsView.swift
+++ b/Sources/VocaMac/Views/SettingsView.swift
@@ -341,8 +341,13 @@ struct ModelSettingsTab: View {
                     HStack {
                         Image(systemName: "sparkles")
                             .foregroundStyle(.blue)
-                        Text("Recommended for your device: **\(recommendedSize.displayName)**")
-                            .font(.callout)
+                        VStack(alignment: .leading, spacing: 2) {
+                            Text("Recommended for your device: **\(recommendedSize.displayName)**")
+                                .font(.callout)
+                            Text("Based on WhisperKit's tuned variants for your chip — not your RAM.")
+                                .font(.caption2)
+                                .foregroundStyle(.tertiary)
+                        }
                     }
                 }
 
@@ -418,13 +423,14 @@ struct ModelRow: View {
                     }
 
                     if !model.isSupported {
-                        Text("Unoptimized")
+                        Text("Experimental")
                             .font(.caption2)
                             .padding(.horizontal, 6)
                             .padding(.vertical, 1)
                             .background(.orange.opacity(0.2))
                             .foregroundStyle(.orange)
                             .cornerRadius(4)
+                            .help("WhisperKit hasn't verified this model on your chip family. Your hardware can likely run it — use Load Anyway to try.")
                     }
                 }
 
@@ -508,7 +514,7 @@ struct ModelRow: View {
         }
         .padding(.vertical, 8)
         .padding(.horizontal, 4)
-        .alert("Use Unoptimized Model?", isPresented: $showForceDownloadAlert) {
+        .alert("Use Experimental Model?", isPresented: $showForceDownloadAlert) {
             Button("Cancel", role: .cancel) {}
             Button(model.isDownloaded ? "Load Anyway" : "Download & Load", role: .destructive) {
                 Task { @MainActor in
@@ -521,7 +527,7 @@ struct ModelRow: View {
                 }
             }
         } message: {
-            Text("This model may exceed your device's capabilities. It could cause slow performance, high memory usage, or crashes. Are you sure you want to continue?")
+            Text("WhisperKit hasn't verified this model on your chip family. It will likely work but may be slower than tuned models.")
         }
     }
 }


### PR DESCRIPTION
The "Unoptimized" badge on the Models tab was misleading — it implies the model is broken or won't work, when it actually just means WhisperKit hasn't shipped a tuned CoreML variant for your specific chip family yet. On a 48 GB M4 Pro, Medium and Large v3 run fine.

## Changes

**Badge renamed:** "Unoptimized" → "Experimental" (Settings and Onboarding)

**Tooltip added** (hover over the Experimental badge):
> "WhisperKit hasn't verified this model on your chip family. Your hardware can likely run it — use Load Anyway to try."

**Alert title + body softened** (both Settings and Onboarding):
- Before: "Use Unoptimized Model?" / "This model may exceed your device's capabilities. It could cause slow performance, high memory usage, or crashes."
- After: "Use Experimental Model?" / "WhisperKit hasn't verified this model on your chip family. It will likely work but may be slower than tuned models."

**Subtitle added** under "Recommended for your device" (Settings):
> "Based on WhisperKit's tuned variants for your chip — not your RAM."

**Startup log added** (AppState):
Logs the full `default / supported / disabled` triple from `WhisperKit.recommendedModels()` so future "why is X marked Experimental?" questions are answerable from the log file without asking users for anything.

No model-loading behaviour changed. No new state, no migrations.