### PR TITLE
docs: clarify VocaMac is Apple Silicon only

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@
 - **⌨️ System-Wide Text Injection** - Transcribed text is typed wherever your cursor is: browsers, Slack, VS Code, spreadsheets, terminals - everywhere.
 - **🎯 Push-to-Talk** - Hold a hotkey (default: Right Option) to record. Release to transcribe.
 - **👆 Double-Tap Toggle** - Double-tap the hotkey to start/stop recording.
-- **🧠 Smart Model Selection** - Auto-detects your hardware (Apple Silicon/Intel, RAM) and recommends the best whisper model via WhisperKit.
+- **🧠 Smart Model Selection** - Auto-detects your Apple Silicon chip and RAM, then recommends the best whisper model via WhisperKit.
 - **⚡ Native Apple Acceleration** - CoreML + Metal + Neural Engine acceleration on Apple Silicon. No manual setup.
 - **📊 Visual Feedback** - Menu bar icon changes color during recording and processing. Audio level indicator shows input.
 - **🔄 Auto-Updates** - Built-in update checker queries GitHub Releases on launch and lets you download and install the latest version in one click from within the app.
@@ -106,7 +106,7 @@ Same accuracy, dramatically better Apple platform integration.
 ## 📋 Requirements
 
 - **macOS 13 (Ventura)** or later
-- **Apple Silicon** (M1/M2/M3/M4)
+- **Apple Silicon Mac** (M1/M2/M3/M4) — **Intel Macs are not supported.** The released DMG is built for `arm64` only.
 - **Xcode 15+** or Swift 5.9+ (only for building from source)
 
 ### Permissions

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -246,7 +246,7 @@ audioData: [Float]
 **Metal Acceleration:**
 - Enabled by default on Apple Silicon when WhisperKit is compiled with Metal support
 - Compile flag: `WHISPER_METAL=1` or `CoreML_METAL=1`
-- Falls back to CPU on Intel Macs
+- VocaMac targets Apple Silicon only; Intel Macs are not a supported runtime
 
 #### 3.2.6 `ModelManager` - Model Lifecycle Management
 
@@ -286,7 +286,7 @@ audioData: [Float]
 **Responsibility:** Detect system hardware capabilities and recommend optimal model size.
 
 **Detection Points:**
-- CPU architecture: `uname()` → arm64 (Apple Silicon) or x86_64 (Intel)
+- CPU architecture: `uname()` → arm64 (Apple Silicon) — the only supported runtime target
 - Physical RAM: `ProcessInfo.processInfo.physicalMemory`
 - Processor name: `sysctlbyname("machdep.cpu.brand_string")`
 - Core count: `ProcessInfo.processInfo.activeProcessorCount`
@@ -297,12 +297,12 @@ Apple Silicon:
   RAM ≤ 8 GB  → tiny  (safe default)
   RAM = 16 GB → small (good balance)
   RAM ≥ 24 GB → medium (high quality)
-
-Intel:
-  RAM ≤ 8 GB  → tiny
-  RAM = 16 GB → base
-  RAM ≥ 32 GB → small
 ```
+
+> The `recommendModel` function in `SystemInfo.swift` retains a defensive
+> Intel branch (smaller models, no Metal). It exists only to keep the
+> code valid if someone compiles from source on Intel; the released DMG
+> is `arm64`-only and Intel Macs are not a supported configuration.
 
 #### 3.2.8 `TextInjector` - System-Wide Text Insertion
 

--- a/web/content/features/apple-silicon-native.md
+++ b/web/content/features/apple-silicon-native.md
@@ -32,7 +32,7 @@ WhisperKit, the framework powering VocaMac, was specifically engineered to take 
 
 ## Unmatched Performance
 
-Benchmark after benchmark shows the same pattern. On an M1 Mac, medium-sized Whisper models transcribe audio roughly 3 to 5 times faster than real time. A 30-second audio clip finishes transcribing in 6 to 10 seconds. Intel-based Macs using CPU-only processing take 90 seconds or more for the same task.
+Benchmark after benchmark shows the same pattern. On an M1 Mac, medium-sized Whisper models transcribe audio roughly 3 to 5 times faster than real time. A 30-second audio clip finishes transcribing in 6 to 10 seconds. CPU-only inference on machines without a Neural Engine can take 90 seconds or more for the same task — which is exactly why VocaMac ships for Apple Silicon only.
 
 This performance gap only widens with larger, more accurate Whisper models. The base model runs instantly. The small model takes a few seconds. The medium model, which offers near-human accuracy, completes in under a minute on Apple Silicon. Cloud-based services may offer similar speed, but they require internet, demand subscription fees, and raise privacy concerns.
 

--- a/web/content/features/smart-model-selection.md
+++ b/web/content/features/smart-model-selection.md
@@ -1,6 +1,6 @@
 ---
 title: "Smart Model Selection"
-subtitle: "Auto-detects your hardware (Apple Silicon, Intel, RAM) and recommends the optimal Whisper model."
+subtitle: "Auto-detects your Apple Silicon hardware and RAM, then recommends the optimal Whisper model."
 description: "VocaMac automatically detects your Mac hardware and recommends the best Whisper model for your system. Choose from Tiny to Large v3 based on your needs."
 keywords: "whisper model selection, auto detect hardware macOS, apple silicon whisper, coreml speech model, best whisper model mac, RAM based model recommendation"
 icon: "🧠"
@@ -8,9 +8,11 @@ icon: "🧠"
 
 ## Intelligent Hardware Detection
 
-Every Mac is different. A MacBook Air with Apple Silicon has different capabilities than an Intel Mac mini with 8GB RAM. VocaMac detects your exact hardware configuration and recommends the Whisper model that delivers the best balance of accuracy and speed on your specific machine.
+Every Apple Silicon Mac is different. An 8 GB MacBook Air has very different headroom than a 32 GB Mac Studio. VocaMac detects your exact hardware configuration and recommends the Whisper model that delivers the best balance of accuracy and speed on your specific machine.
 
-On first launch, VocaMac analyzes your processor type (Apple Silicon or Intel), CPU core count, GPU availability, and installed RAM. It then suggests the optimal model tier. You remain free to choose any model, but the recommendation gets you great results immediately without guesswork.
+On first launch, VocaMac analyzes your chip generation, CPU core count, Neural Engine availability, and installed RAM. It then suggests the optimal model tier. You remain free to choose any model, but the recommendation gets you great results immediately without guesswork.
+
+> **Note:** VocaMac is Apple Silicon only. The released DMG does not run on Intel Macs.
 
 ## Five Model Tiers
 
@@ -37,10 +39,10 @@ The most accurate model available. Peak performance on Apple Silicon Macs with 3
 
 VocaMac provides tailored suggestions:
 
-- **MacBook Air with Apple Silicon (8GB)**: Base or Small model recommended
-- **MacBook Pro with Apple Silicon (16GB)**: Small or Medium model recommended
-- **Mac mini with Intel (8GB RAM)**: Tiny or Base model recommended
-- **Mac Studio with Apple Silicon (32GB)**: Medium or Large v3 model recommended
+- **MacBook Air (M1/M2, 8 GB)**: Base or Small model recommended
+- **MacBook Pro (M1/M2/M3, 16 GB)**: Small or Medium model recommended
+- **Mac mini (M2, 16 GB)**: Small or Medium model recommended
+- **Mac Studio (M2/M3 Max, 32 GB+)**: Medium or Large v3 model recommended
 
 These recommendations balance your hardware capabilities with practical transcription speeds. Your actual choice depends on your accuracy requirements and tolerance for processing time.
 
@@ -56,8 +58,8 @@ Model storage uses your local disk space. VocaMac shows disk usage for each mode
 
 All Whisper models in VocaMac are converted to Apple's CoreML format. This optimization ensures:
 
-- Native execution on Apple Silicon using Neural Engine
-- Efficient Intel compatibility through Intel AMX (Apple Mac compatible) instructions
+- Native execution on Apple Silicon using the Neural Engine
+- GPU offload through Metal Performance Shaders for compute-heavy ops
 - Minimal energy consumption (important for battery life on laptops)
 - No cloud dependencies or external API calls
 - Complete privacy (all processing happens locally)

--- a/web/layouts/index.html
+++ b/web/layouts/index.html
@@ -521,7 +521,7 @@
                 </details>
                 <details class="faq__item">
                     <summary>Which Macs are supported?</summary>
-                    <p>VocaMac works on any Mac running macOS 13 (Ventura) or later. It runs on both Apple Silicon (M1/M2/M3/M4) and Intel Macs, though Apple Silicon provides significantly better performance thanks to CoreML and Neural Engine acceleration.</p>
+                    <p>VocaMac requires an <strong>Apple Silicon Mac</strong> (M1, M2, M3, or M4) running macOS 13 (Ventura) or later. The released DMG is built for <code>arm64</code> only and will not install on Intel Macs. WhisperKit relies on the Apple Neural Engine and CoreML for hardware-accelerated transcription, so Intel Macs are not supported.</p>
                 </details>
                 <details class="faq__item">
                     <summary>How does it inject text into other apps?</summary>

--- a/web/layouts/index.html
+++ b/web/layouts/index.html
@@ -176,7 +176,7 @@
                 <a href="/features/smart-model-selection/" class="feature-card">
                     <div class="feature-card__icon">🧠</div>
                     <h3>Smart Model Selection</h3>
-                    <p>Auto-detects your hardware (Apple Silicon, Intel, RAM) and recommends the optimal Whisper model.</p>
+                    <p>Auto-detects your Apple Silicon chip and RAM, then recommends the optimal Whisper model.</p>
                 </a>
                 <a href="/features/apple-silicon-native/" class="feature-card">
                     <div class="feature-card__icon">⚡</div>


### PR DESCRIPTION
## Why

A user reported (#98) that the website FAQ said VocaMac runs on Intel Macs, but the released DMG refused to install on their Intel Mac. The DMG is built `arm64`-only (see `docs/RELEASE.md`), so the FAQ was misleading.

## What changed

- **`web/layouts/index.html`** — rewrite the "Which Macs are supported?" FAQ entry to state Apple Silicon only and explain the released DMG is `arm64`-only.
- **`web/content/features/smart-model-selection.md`** — drop Intel framing in the subtitle, intro narrative, hardware example list, and CoreML bullet list. Replaced the Intel example with another Apple Silicon configuration. Added an explicit Apple-Silicon-only note.
- **`README.md`** — tightened the Requirements section to call out that Intel Macs are not supported and that the released DMG is `arm64`-only. Also updated the Smart Model Selection feature bullet.

## Out of scope (intentionally)

- No code changes — `SystemInfo.swift` still has Intel branches, which is harmless defensive code if anyone compiles from source.
- Not switching the build to a universal binary. WhisperKit's perf story leans heavily on the Neural Engine, so an Intel build wouldn't be a good user experience even if it compiled.

## Verification

- `grep` for stale Intel mentions across `README.md` and `web/` shows only the corrected/contextual references remain.
- No code paths touched, so CI `swift build` + `swift test` should pass unchanged.

Closes the doc-side concern raised in https://github.com/jatinkrmalik/vocamac/discussions/98.