### PR TITLE
feat: add hotkey presets and custom recording

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@
 - **⚡ Native Apple Acceleration** - CoreML + Metal + Neural Engine acceleration on Apple Silicon. No manual setup.
 - **📊 Visual Feedback** - Menu bar icon changes color during recording and processing. Audio level indicator shows input.
 - **🔄 Auto-Updates** - Built-in update checker queries GitHub Releases on launch and lets you download and install the latest version in one click from within the app.
-- **⚙️ Configurable** - Choose hotkey presets or record a custom activation key, models, languages, silence detection thresholds, and more.
+- **⚙️ Configurable** - Choose hotkey presets or record a custom activation key reserved by VocaMac while it runs, models, languages, silence detection thresholds, and more.
 
 ---
 
@@ -251,7 +251,7 @@ Open Settings from the menu bar popover or with **⌘,**
 
 ### General
 - **Activation mode** - Push-to-Talk or Double-Tap Toggle
-- **Hotkey** - Choose from common presets or record a custom activation key directly from your keyboard
+- **Hotkey** - Choose from common presets or record a custom activation key directly from your keyboard. The selected key is consumed by VocaMac while the app is running.
 - **Language** - Auto-detect or specify (English, Spanish, French, German, Chinese, Japanese, and more)
 - **Launch at login**
 

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@
 - **⚡ Native Apple Acceleration** - CoreML + Metal + Neural Engine acceleration on Apple Silicon. No manual setup.
 - **📊 Visual Feedback** - Menu bar icon changes color during recording and processing. Audio level indicator shows input.
 - **🔄 Auto-Updates** - Built-in update checker queries GitHub Releases on launch and lets you download and install the latest version in one click from within the app.
-- **⚙️ Configurable** - Choose hotkeys, models, languages, silence detection thresholds, and more.
+- **⚙️ Configurable** - Choose hotkey presets or record a custom activation key, models, languages, silence detection thresholds, and more.
 
 ---
 
@@ -251,7 +251,7 @@ Open Settings from the menu bar popover or with **⌘,**
 
 ### General
 - **Activation mode** - Push-to-Talk or Double-Tap Toggle
-- **Hotkey** - Choose from Right Option, Right Command, Fn, function keys, etc.
+- **Hotkey** - Choose from common presets or record a custom activation key directly from your keyboard
 - **Language** - Auto-detect or specify (English, Spanish, French, German, Chinese, Japanese, and more)
 - **Launch at login**
 

--- a/Sources/VocaMac/Services/HotKeyManager.swift
+++ b/Sources/VocaMac/Services/HotKeyManager.swift
@@ -6,6 +6,7 @@
 
 import Foundation
 import AppKit
+import Carbon.HIToolbox
 
 final class HotKeyManager {
 
@@ -37,6 +38,12 @@ final class HotKeyManager {
 
     /// Whether we are currently in a "recording" toggle state (for double-tap mode)
     private var isToggled = false
+
+    /// Whether the configured modifier key is physically held.
+    /// This is tracked separately from recording state so modifier double-tap
+    /// mode can distinguish press/release even when another same-group modifier
+    /// keeps the shared modifier flag set.
+    private var isModifierKeyHeld = false
 
     /// Safety timer that auto-fires key-up if a real key-up event is missed.
     /// macOS can drop flagsChanged events when multiple modifiers interact,
@@ -97,6 +104,7 @@ final class HotKeyManager {
         self.lastKeyDownTime = 0
         self.isKeyHeld = false
         self.isToggled = false
+        self.isModifierKeyHeld = false
 
         // Create event tap for key events and flags changed (modifier keys)
         let eventMask: CGEventMask = (
@@ -109,9 +117,9 @@ final class HotKeyManager {
         let userInfo = Unmanaged.passUnretained(self).toOpaque()
 
         guard let tap = CGEvent.tapCreate(
-            tap: .cghidEventTap,
+            tap: .cgSessionEventTap,
             place: .headInsertEventTap,
-            options: .listenOnly,  // Listen only — don't suppress events
+            options: .defaultTap,
             eventsOfInterest: eventMask,
             callback: HotKeyManager.eventTapCallback,
             userInfo: userInfo
@@ -149,7 +157,7 @@ final class HotKeyManager {
         isListening = false
         isKeyHeld = false
         isToggled = false
-        previousFlags = []
+        isModifierKeyHeld = false
         cancelSafetyTimer()
 
         VocaLogger.info(.hotKeyManager, "Stopped listening")
@@ -162,6 +170,7 @@ final class HotKeyManager {
     func resetKeyState() {
         isKeyHeld = false
         isToggled = false
+        isModifierKeyHeld = false
         cancelSafetyTimer()
         VocaLogger.debug(.hotKeyManager, "Key state reset")
     }
@@ -202,7 +211,10 @@ final class HotKeyManager {
             return Unmanaged.passUnretained(event)
         }
 
-        manager.handleEvent(type: type, event: event)
+        let shouldConsumeEvent = manager.handleEvent(type: type, event: event)
+        if shouldConsumeEvent {
+            return nil
+        }
 
         return Unmanaged.passUnretained(event)
     }
@@ -210,7 +222,11 @@ final class HotKeyManager {
     // MARK: - Event Handling
 
     /// Handle an incoming key event
-    private func handleEvent(type: CGEventType, event: CGEvent) {
+    /// - Returns: `true` when the event belongs to the configured hotkey and
+    ///   should be consumed so it doesn't also affect the frontmost app.
+    private func handleEvent(type: CGEventType, event: CGEvent) -> Bool {
+        guard !isSelfGeneratedEvent(event) else { return false }
+
         let keyCode = Int(event.getIntegerValueField(.keyboardEventKeycode))
 
         // For modifier keys (like Option), we use flagsChanged events
@@ -219,10 +235,17 @@ final class HotKeyManager {
             if keyCode == targetKeyCode {
                 VocaLogger.debug(.hotKeyManager, "flagsChanged event for target keyCode \(keyCode)")
             }
-            handleModifierKeyEvent(keyCode: keyCode, event: event)
+            return handleModifierKeyEvent(keyCode: keyCode, event: event)
         } else if type == .keyDown || type == .keyUp {
-            handleRegularKeyEvent(keyCode: keyCode, isKeyDown: type == .keyDown, event: event)
+            return handleRegularKeyEvent(keyCode: keyCode, isKeyDown: type == .keyDown, event: event)
         }
+
+        return false
+    }
+
+    private func isSelfGeneratedEvent(_ event: CGEvent) -> Bool {
+        let eventPID = event.getIntegerValueField(.eventSourceUnixProcessID)
+        return eventPID == Int64(ProcessInfo.processInfo.processIdentifier)
     }
 
     /// Handle modifier key events (Option, Command, Control, Shift, Fn)
@@ -236,14 +259,13 @@ final class HotKeyManager {
     /// and releasing Right Option while Left Option is held would *not* clear
     /// the flag, causing the key-up to be missed.
     ///
-    /// **Fix:** We track the raw flags value and detect transitions. When the
-    /// target key code fires a `flagsChanged` event, we compare the current
-    /// flags with the previous snapshot to determine if the *specific* key
-    /// was pressed or released.
-    private var previousFlags: CGEventFlags = []
+    /// **Fix:** We track the target modifier's physical held state. When a
+    /// `flagsChanged` event arrives for the target key code, a transition from
+    /// not-held to set flags is a press; any later target-key event while held
+    /// is a release, even if another same-group modifier keeps the shared flag set.
 
-    private func handleModifierKeyEvent(keyCode: Int, event: CGEvent) {
-        guard keyCode == targetKeyCode else { return }
+    private func handleModifierKeyEvent(keyCode: Int, event: CGEvent) -> Bool {
+        guard keyCode == targetKeyCode else { return false }
 
         let flags = event.flags
 
@@ -261,54 +283,40 @@ final class HotKeyManager {
         case 63:      // Fn key
             relevantMask = .maskSecondaryFn
         default:
-            return
+            return false
         }
 
         // A flagsChanged event for this keyCode means the key was either
-        // pressed or released. We determine which by comparing the flag
-        // state with our expectation:
-        //
-        // • If the modifier flag is set AND we weren't already tracking
-        //   this key as held → key was pressed.
-        // • If the modifier flag is cleared → key was definitely released.
-        // • If the modifier flag is still set BUT macOS sent a flagsChanged
-        //   event specifically for our keyCode → the *specific* physical key
-        //   changed state. Since a flagsChanged for keyCode X only fires when
-        //   key X changes, if we were already holding it, this means it was
-        //   released (the flag may still be set because the *other* key in
-        //   the pair, e.g. Left Option, is still down).
+        // pressed or released. Modifier flags are shared by left/right pairs,
+        // so we cannot rely on the flag being cleared to detect release.
         let flagIsSet = flags.contains(relevantMask)
 
         let isPressed: Bool
-        if !flagIsSet {
-            // Flag is clear — the key is definitely released
-            isPressed = false
-        } else if !isKeyHeld {
-            // Flag is set and we weren't tracking this key — it was pressed
+        if flagIsSet && !isModifierKeyHeld {
             isPressed = true
-        } else {
-            // Flag is still set but we're already tracking the key as held,
-            // and macOS sent a flagsChanged event for this exact keyCode.
-            // This means the physical key was released (the flag persists
-            // because another key in the same modifier group is still held).
+            isModifierKeyHeld = true
+        } else if isModifierKeyHeld {
             isPressed = false
+            isModifierKeyHeld = false
+        } else {
+            return true
         }
-
-        previousFlags = flags
 
         if isPressed {
             handleKeyDown()
         } else {
             handleKeyUp()
         }
+
+        return true
     }
 
     /// Handle regular (non-modifier) key events
-    private func handleRegularKeyEvent(keyCode: Int, isKeyDown: Bool, event: CGEvent) {
-        guard keyCode == targetKeyCode else { return }
+    private func handleRegularKeyEvent(keyCode: Int, isKeyDown: Bool, event: CGEvent) -> Bool {
+        guard keyCode == targetKeyCode else { return false }
 
         if isKeyDown && event.getIntegerValueField(.keyboardEventAutorepeat) != 0 {
-            return
+            return true
         }
 
         if isKeyDown {
@@ -316,6 +324,8 @@ final class HotKeyManager {
         } else {
             handleKeyUp()
         }
+
+        return true
     }
 
     /// Process a key-down event for the target hotkey
@@ -445,7 +455,7 @@ extension HotKeyManager: HotKeyMonitoring {
 
 extension HotKeyManager {
     /// Exercise event handling without installing a process-wide event tap.
-    func _handleTestEvent(type: CGEventType, event: CGEvent) {
+    func _handleTestEvent(type: CGEventType, event: CGEvent) -> Bool {
         handleEvent(type: type, event: event)
     }
 }
@@ -455,6 +465,8 @@ extension HotKeyManager {
 /// Reference for common macOS virtual key codes
 /// Used for hotkey configuration UI
 enum KeyCodeReference {
+    static let escapeKeyCode = 53
+
     static let commonHotKeys: [(name: String, keyCode: Int)] = [
         ("Right Option (⌥)", 61),
         ("Left Option (⌥)", 58),
@@ -473,56 +485,9 @@ enum KeyCodeReference {
     ]
 
     private static let namedKeyCodes: [Int: String] = [
-        0: "A",
-        1: "S",
-        2: "D",
-        3: "F",
-        4: "H",
-        5: "G",
-        6: "Z",
-        7: "X",
-        8: "C",
-        9: "V",
-        11: "B",
-        12: "Q",
-        13: "W",
-        14: "E",
-        15: "R",
-        16: "Y",
-        17: "T",
-        18: "1",
-        19: "2",
-        20: "3",
-        21: "4",
-        22: "6",
-        23: "5",
-        24: "=",
-        25: "9",
-        26: "7",
-        27: "-",
-        28: "8",
-        29: "0",
-        30: "]",
-        31: "O",
-        32: "U",
-        33: "[",
-        34: "I",
-        35: "P",
         36: "Return",
-        37: "L",
-        38: "J",
-        39: "'",
-        40: "K",
-        41: ";",
-        42: "\\",
-        43: ",",
-        44: "/",
-        45: "N",
-        46: "M",
-        47: ".",
         48: "Tab",
         49: "Space",
-        50: "`",
         51: "Delete",
         53: "Escape",
         54: "Right Command (⌘)",
@@ -589,6 +554,7 @@ enum KeyCodeReference {
     static func displayName(for keyCode: Int) -> String {
         commonHotKeys.first(where: { $0.keyCode == keyCode })?.name
             ?? namedKeyCodes[keyCode]
+            ?? displayCharacter(for: keyCode)
             ?? "Key \(keyCode)"
     }
 
@@ -605,5 +571,73 @@ enum KeyCodeReference {
         default:
             return false
         }
+    }
+
+    private static func displayCharacter(for keyCode: Int) -> String? {
+        let inputSource: TISInputSource? = {
+            if let asciiSource = TISCopyCurrentASCIICapableKeyboardLayoutInputSource()?.takeRetainedValue() {
+                return asciiSource
+            }
+            return TISCopyCurrentKeyboardLayoutInputSource()?.takeRetainedValue()
+        }()
+
+        guard let source = inputSource,
+              let layoutDataPointer = TISGetInputSourceProperty(source, kTISPropertyUnicodeKeyLayoutData)
+        else {
+            return fallbackDisplayCharacter(for: keyCode)
+        }
+
+        let layoutData = Unmanaged<CFData>.fromOpaque(layoutDataPointer).takeUnretainedValue() as Data
+
+        return layoutData.withUnsafeBytes { (rawBuffer: UnsafeRawBufferPointer) -> String? in
+            guard let baseAddress = rawBuffer.baseAddress else {
+                return fallbackDisplayCharacter(for: keyCode)
+            }
+
+            let keyboardLayout = baseAddress.assumingMemoryBound(to: UCKeyboardLayout.self)
+            var deadKeyState: UInt32 = 0
+            let maxStringLength = 4
+            var actualStringLength = 0
+            var unicodeString = [UniChar](repeating: 0, count: maxStringLength)
+
+            let status = UCKeyTranslate(
+                keyboardLayout,
+                UInt16(keyCode),
+                UInt16(kUCKeyActionDisplay),
+                0,
+                UInt32(LMGetKbdType()),
+                OptionBits(kUCKeyTranslateNoDeadKeysBit),
+                &deadKeyState,
+                maxStringLength,
+                &actualStringLength,
+                &unicodeString
+            )
+
+            guard status == noErr, actualStringLength > 0 else {
+                return fallbackDisplayCharacter(for: keyCode)
+            }
+
+            let produced = String(utf16CodeUnits: unicodeString, count: actualStringLength)
+            guard produced.rangeOfCharacter(from: .controlCharacters) == nil else {
+                return fallbackDisplayCharacter(for: keyCode)
+            }
+
+            return produced.count == 1 ? produced.uppercased() : produced
+        }
+    }
+
+    private static func fallbackDisplayCharacter(for keyCode: Int) -> String? {
+        let qwertyNames: [Int: String] = [
+            0: "A", 1: "S", 2: "D", 3: "F", 4: "H", 5: "G",
+            6: "Z", 7: "X", 8: "C", 9: "V", 11: "B",
+            12: "Q", 13: "W", 14: "E", 15: "R", 16: "Y", 17: "T",
+            18: "1", 19: "2", 20: "3", 21: "4", 22: "6", 23: "5",
+            24: "=", 25: "9", 26: "7", 27: "-", 28: "8", 29: "0",
+            30: "]", 31: "O", 32: "U", 33: "[", 34: "I", 35: "P",
+            37: "L", 38: "J", 39: "'", 40: "K", 41: ";", 42: "\\",
+            43: ",", 44: "/", 45: "N", 46: "M", 47: ".", 50: "`",
+        ]
+
+        return qwertyNames[keyCode]
     }
 }

--- a/Sources/VocaMac/Services/HotKeyManager.swift
+++ b/Sources/VocaMac/Services/HotKeyManager.swift
@@ -221,7 +221,7 @@ final class HotKeyManager {
             }
             handleModifierKeyEvent(keyCode: keyCode, event: event)
         } else if type == .keyDown || type == .keyUp {
-            handleRegularKeyEvent(keyCode: keyCode, isKeyDown: type == .keyDown)
+            handleRegularKeyEvent(keyCode: keyCode, isKeyDown: type == .keyDown, event: event)
         }
     }
 
@@ -304,8 +304,12 @@ final class HotKeyManager {
     }
 
     /// Handle regular (non-modifier) key events
-    private func handleRegularKeyEvent(keyCode: Int, isKeyDown: Bool) {
+    private func handleRegularKeyEvent(keyCode: Int, isKeyDown: Bool, event: CGEvent) {
         guard keyCode == targetKeyCode else { return }
+
+        if isKeyDown && event.getIntegerValueField(.keyboardEventAutorepeat) != 0 {
+            return
+        }
 
         if isKeyDown {
             handleKeyDown()
@@ -437,6 +441,15 @@ extension HotKeyManager: HotKeyMonitoring {
     }
 }
 
+// MARK: - Test Support
+
+extension HotKeyManager {
+    /// Exercise event handling without installing a process-wide event tap.
+    func _handleTestEvent(type: CGEventType, event: CGEvent) {
+        handleEvent(type: type, event: event)
+    }
+}
+
 // MARK: - Common Key Codes Reference
 
 /// Reference for common macOS virtual key codes
@@ -459,8 +472,138 @@ enum KeyCodeReference {
         ("F12", 111),
     ]
 
+    private static let namedKeyCodes: [Int: String] = [
+        0: "A",
+        1: "S",
+        2: "D",
+        3: "F",
+        4: "H",
+        5: "G",
+        6: "Z",
+        7: "X",
+        8: "C",
+        9: "V",
+        11: "B",
+        12: "Q",
+        13: "W",
+        14: "E",
+        15: "R",
+        16: "Y",
+        17: "T",
+        18: "1",
+        19: "2",
+        20: "3",
+        21: "4",
+        22: "6",
+        23: "5",
+        24: "=",
+        25: "9",
+        26: "7",
+        27: "-",
+        28: "8",
+        29: "0",
+        30: "]",
+        31: "O",
+        32: "U",
+        33: "[",
+        34: "I",
+        35: "P",
+        36: "Return",
+        37: "L",
+        38: "J",
+        39: "'",
+        40: "K",
+        41: ";",
+        42: "\\",
+        43: ",",
+        44: "/",
+        45: "N",
+        46: "M",
+        47: ".",
+        48: "Tab",
+        49: "Space",
+        50: "`",
+        51: "Delete",
+        53: "Escape",
+        54: "Right Command (⌘)",
+        55: "Left Command (⌘)",
+        56: "Left Shift (⇧)",
+        57: "Caps Lock",
+        58: "Left Option (⌥)",
+        59: "Left Control (⌃)",
+        60: "Right Shift (⇧)",
+        61: "Right Option (⌥)",
+        62: "Right Control (⌃)",
+        63: "Fn",
+        64: "F17",
+        65: "Keypad .",
+        67: "Keypad *",
+        69: "Keypad +",
+        71: "Clear",
+        75: "Keypad /",
+        76: "Keypad Enter",
+        78: "Keypad -",
+        79: "F18",
+        80: "F19",
+        81: "Keypad =",
+        82: "Keypad 0",
+        83: "Keypad 1",
+        84: "Keypad 2",
+        85: "Keypad 3",
+        86: "Keypad 4",
+        87: "Keypad 5",
+        88: "Keypad 6",
+        89: "Keypad 7",
+        90: "F20",
+        91: "Keypad 8",
+        92: "Keypad 9",
+        96: "F5",
+        97: "F6",
+        98: "F7",
+        99: "F3",
+        100: "F8",
+        101: "F9",
+        103: "F11",
+        105: "F13",
+        106: "F16",
+        107: "F14",
+        109: "F10",
+        111: "F12",
+        113: "F15",
+        114: "Help",
+        115: "Home",
+        116: "Page Up",
+        117: "Forward Delete",
+        118: "F4",
+        119: "End",
+        120: "F2",
+        121: "Page Down",
+        122: "F1",
+        123: "Left Arrow",
+        124: "Right Arrow",
+        125: "Down Arrow",
+        126: "Up Arrow",
+    ]
+
     /// Get the display name for a key code
     static func displayName(for keyCode: Int) -> String {
-        commonHotKeys.first(where: { $0.keyCode == keyCode })?.name ?? "Key \(keyCode)"
+        commonHotKeys.first(where: { $0.keyCode == keyCode })?.name
+            ?? namedKeyCodes[keyCode]
+            ?? "Key \(keyCode)"
+    }
+
+    /// Whether this key code is included in the curated preset list.
+    static func isCommonHotKey(_ keyCode: Int) -> Bool {
+        commonHotKeys.contains(where: { $0.keyCode == keyCode })
+    }
+
+    /// Whether this key code represents a modifier key that emits flagsChanged events.
+    static func isModifierKeyCode(_ keyCode: Int) -> Bool {
+        switch keyCode {
+        case 54, 55, 56, 58, 59, 60, 61, 62, 63:
+            return true
+        default:
+            return false
+        }
     }
 }

--- a/Sources/VocaMac/Services/PermissionManager.swift
+++ b/Sources/VocaMac/Services/PermissionManager.swift
@@ -67,16 +67,16 @@ final class PermissionManager: ObservableObject {
     /// Check Input Monitoring permission using multiple strategies since no
     /// single approach is 100% reliable:
     /// 1. If HotKeyManager created a tap, check if macOS has disabled it (revocation)
-    /// 2. Try creating a fresh `.cghidEventTap` (same type HotKeyManager uses)
+    /// 2. Try creating a fresh `.cghidEventTap` to trigger/check Input Monitoring
     private func checkInputMonitoringPermission() -> Bool {
         // Strategy 1: If HotKeyManager has an active tap, check if macOS disabled it.
         if hotKeyManager.isListening, let tap = hotKeyManager.eventTap {
             return CGEvent.tapIsEnabled(tap: tap)
         }
 
-        // Strategy 2: Try creating a fresh .cghidEventTap — the same type
-        // HotKeyManager uses. More accurate than .cgSessionEventTap which
-        // may inherit Terminal's permissions when launched from CLI.
+        // Strategy 2: Try creating a fresh .cghidEventTap. This probes Input
+        // Monitoring more accurately than .cgSessionEventTap, which may inherit
+        // Terminal's permissions when launched from CLI.
         let tap = CGEvent.tapCreate(
             tap: .cghidEventTap,
             place: .headInsertEventTap,

--- a/Sources/VocaMac/Views/HotKeySelectionControl.swift
+++ b/Sources/VocaMac/Views/HotKeySelectionControl.swift
@@ -1,0 +1,245 @@
+// HotKeySelectionControl.swift
+// VocaMac
+//
+// Reusable hotkey picker with direct key recording for settings and onboarding.
+
+import AppKit
+import SwiftUI
+
+struct HotKeySelectionControl: View {
+    @EnvironmentObject private var appState: AppState
+    @State private var isRecording = false
+    @State private var wasListeningBeforeRecording = false
+
+    let pickerLabel: String
+    let footerText: String?
+
+    init(pickerLabel: String = "Preset", footerText: String? = nil) {
+        self.pickerLabel = pickerLabel
+        self.footerText = footerText
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            HStack(spacing: 8) {
+                Picker(pickerLabel, selection: $appState.hotKeyCode) {
+                    ForEach(KeyCodeReference.commonHotKeys, id: \.keyCode) { hotKey in
+                        Text(hotKey.name).tag(hotKey.keyCode)
+                    }
+
+                    if !KeyCodeReference.isCommonHotKey(appState.hotKeyCode) {
+                        Divider()
+                        Text("Custom: \(KeyCodeReference.displayName(for: appState.hotKeyCode))")
+                            .tag(appState.hotKeyCode)
+                    }
+                }
+                .disabled(isRecording)
+                .onChange(of: appState.hotKeyCode) { newCode in
+                    guard !isRecording else { return }
+                    appState.hotKeyManager.updateConfiguration(keyCode: newCode)
+                }
+
+                HotKeyRecorderButton(
+                    isRecording: $isRecording,
+                    onStart: beginRecording,
+                    onCancel: finishRecording,
+                    onKeyRecorded: recordKey
+                )
+            }
+
+            if isRecording {
+                Label("Press any single key", systemImage: "keyboard")
+                    .font(.caption)
+                    .foregroundStyle(Color.accentColor)
+            } else if let footerText {
+                Text(footerText)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+        }
+        .onDisappear {
+            guard isRecording else { return }
+            isRecording = false
+            finishRecording()
+        }
+    }
+
+    private func beginRecording() {
+        wasListeningBeforeRecording = appState.hotKeyManager.isListening
+        if wasListeningBeforeRecording {
+            appState.hotKeyManager.stopListening()
+        }
+    }
+
+    private func finishRecording() {
+        if wasListeningBeforeRecording {
+            restartHotKeyListener()
+        }
+        wasListeningBeforeRecording = false
+    }
+
+    private func recordKey(_ keyCode: Int) {
+        appState.hotKeyCode = keyCode
+        appState.hotKeyManager.updateConfiguration(keyCode: keyCode)
+        finishRecording()
+    }
+
+    private func restartHotKeyListener() {
+        appState.hotKeyManager.startListening(
+            keyCode: appState.hotKeyCode,
+            mode: appState.activationMode,
+            doubleTapThreshold: appState.doubleTapThreshold,
+            safetyTimeout: Double(appState.maxRecordingDuration) + 5.0
+        )
+    }
+}
+
+private struct HotKeyRecorderButton: View {
+    @Binding var isRecording: Bool
+
+    let onStart: () -> Void
+    let onCancel: () -> Void
+    let onKeyRecorded: (Int) -> Void
+
+    var body: some View {
+        ZStack {
+            Button {
+                if isRecording {
+                    isRecording = false
+                    onCancel()
+                } else {
+                    onStart()
+                    isRecording = true
+                }
+            } label: {
+                Label(isRecording ? "Cancel" : "Record", systemImage: isRecording ? "xmark.circle" : "record.circle")
+            }
+            .controlSize(.small)
+
+            if isRecording {
+                HotKeyCaptureView { keyCode in
+                    isRecording = false
+                    onKeyRecorded(keyCode)
+                }
+                .frame(width: 1, height: 1)
+                .opacity(0)
+                .accessibilityHidden(true)
+            }
+        }
+    }
+}
+
+private struct HotKeyCaptureView: NSViewRepresentable {
+    let onCapture: (Int) -> Void
+
+    func makeNSView(context: Context) -> HotKeyCaptureNSView {
+        let view = HotKeyCaptureNSView()
+        view.onCapture = onCapture
+        return view
+    }
+
+    func updateNSView(_ nsView: HotKeyCaptureNSView, context: Context) {
+        nsView.onCapture = onCapture
+        nsView.focus()
+    }
+
+    static func dismantleNSView(_ nsView: HotKeyCaptureNSView, coordinator: ()) {
+        nsView.stopMonitoring()
+    }
+}
+
+private final class HotKeyCaptureNSView: NSView {
+    var onCapture: ((Int) -> Void)?
+
+    private var localMonitor: Any?
+    private var didCapture = false
+
+    override var acceptsFirstResponder: Bool { true }
+
+    override func viewDidMoveToWindow() {
+        super.viewDidMoveToWindow()
+        installMonitor()
+        focus()
+    }
+
+    override func keyDown(with event: NSEvent) {
+        _ = capture(event)
+    }
+
+    override func flagsChanged(with event: NSEvent) {
+        _ = capture(event)
+    }
+
+    func focus() {
+        DispatchQueue.main.async { [weak self] in
+            guard let self else { return }
+            self.window?.makeFirstResponder(self)
+        }
+    }
+
+    func stopMonitoring() {
+        if let localMonitor {
+            NSEvent.removeMonitor(localMonitor)
+            self.localMonitor = nil
+        }
+    }
+
+    private func installMonitor() {
+        guard localMonitor == nil else { return }
+        localMonitor = NSEvent.addLocalMonitorForEvents(matching: [.keyDown, .flagsChanged]) { [weak self] event in
+            guard let self, self.window?.isKeyWindow == true else { return event }
+            return self.capture(event) ? nil : event
+        }
+    }
+
+    private func capture(_ event: NSEvent) -> Bool {
+        guard !didCapture, shouldCapture(event) else { return false }
+
+        didCapture = true
+        stopMonitoring()
+
+        let keyCode = Int(event.keyCode)
+        DispatchQueue.main.async { [weak self] in
+            self?.onCapture?(keyCode)
+        }
+        return true
+    }
+
+    private func shouldCapture(_ event: NSEvent) -> Bool {
+        switch event.type {
+        case .keyDown:
+            return !event.isARepeat
+        case .flagsChanged:
+            let keyCode = Int(event.keyCode)
+            guard KeyCodeReference.isModifierKeyCode(keyCode),
+                  let modifierFlag = modifierFlag(for: keyCode)
+            else {
+                return false
+            }
+            return event.modifierFlags.contains(modifierFlag)
+        default:
+            return false
+        }
+    }
+
+    private func modifierFlag(for keyCode: Int) -> NSEvent.ModifierFlags? {
+        switch keyCode {
+        case 54, 55:
+            return .command
+        case 56, 60:
+            return .shift
+        case 58, 61:
+            return .option
+        case 59, 62:
+            return .control
+        case 63:
+            return .function
+        default:
+            return nil
+        }
+    }
+
+    deinit {
+        stopMonitoring()
+    }
+}

--- a/Sources/VocaMac/Views/HotKeySelectionControl.swift
+++ b/Sources/VocaMac/Views/HotKeySelectionControl.swift
@@ -34,9 +34,9 @@ struct HotKeySelectionControl: View {
                     }
                 }
                 .disabled(isRecording)
-                .onChange(of: appState.hotKeyCode) { newCode in
+                .onChange(of: appState.hotKeyCode) { _ in
                     guard !isRecording else { return }
-                    appState.hotKeyManager.updateConfiguration(keyCode: newCode)
+                    appState.syncHotKeyConfiguration()
                 }
 
                 HotKeyRecorderButton(
@@ -48,7 +48,7 @@ struct HotKeySelectionControl: View {
             }
 
             if isRecording {
-                Label("Press any single key", systemImage: "keyboard")
+                Label("Press a key, or press Escape to cancel", systemImage: "keyboard")
                     .font(.caption)
                     .foregroundStyle(Color.accentColor)
             } else if let footerText {
@@ -80,7 +80,7 @@ struct HotKeySelectionControl: View {
 
     private func recordKey(_ keyCode: Int) {
         appState.hotKeyCode = keyCode
-        appState.hotKeyManager.updateConfiguration(keyCode: keyCode)
+        appState.syncHotKeyConfiguration()
         finishRecording()
     }
 
@@ -117,10 +117,16 @@ private struct HotKeyRecorderButton: View {
             .controlSize(.small)
 
             if isRecording {
-                HotKeyCaptureView { keyCode in
-                    isRecording = false
-                    onKeyRecorded(keyCode)
-                }
+                HotKeyCaptureView(
+                    onCapture: { keyCode in
+                        isRecording = false
+                        onKeyRecorded(keyCode)
+                    },
+                    onCancel: {
+                        isRecording = false
+                        onCancel()
+                    }
+                )
                 .frame(width: 1, height: 1)
                 .opacity(0)
                 .accessibilityHidden(true)
@@ -131,15 +137,18 @@ private struct HotKeyRecorderButton: View {
 
 private struct HotKeyCaptureView: NSViewRepresentable {
     let onCapture: (Int) -> Void
+    let onCancel: () -> Void
 
     func makeNSView(context: Context) -> HotKeyCaptureNSView {
         let view = HotKeyCaptureNSView()
         view.onCapture = onCapture
+        view.onCancel = onCancel
         return view
     }
 
     func updateNSView(_ nsView: HotKeyCaptureNSView, context: Context) {
         nsView.onCapture = onCapture
+        nsView.onCancel = onCancel
         nsView.focus()
     }
 
@@ -150,8 +159,10 @@ private struct HotKeyCaptureView: NSViewRepresentable {
 
 private final class HotKeyCaptureNSView: NSView {
     var onCapture: ((Int) -> Void)?
+    var onCancel: (() -> Void)?
 
     private var localMonitor: Any?
+    private var windowResignObserver: NSObjectProtocol?
     private var didCapture = false
 
     override var acceptsFirstResponder: Bool { true }
@@ -159,6 +170,7 @@ private final class HotKeyCaptureNSView: NSView {
     override func viewDidMoveToWindow() {
         super.viewDidMoveToWindow()
         installMonitor()
+        installWindowObserver()
         focus()
     }
 
@@ -182,6 +194,11 @@ private final class HotKeyCaptureNSView: NSView {
             NSEvent.removeMonitor(localMonitor)
             self.localMonitor = nil
         }
+
+        if let windowResignObserver {
+            NotificationCenter.default.removeObserver(windowResignObserver)
+            self.windowResignObserver = nil
+        }
     }
 
     private func installMonitor() {
@@ -192,8 +209,26 @@ private final class HotKeyCaptureNSView: NSView {
         }
     }
 
+    private func installWindowObserver() {
+        guard windowResignObserver == nil, let window else { return }
+        windowResignObserver = NotificationCenter.default.addObserver(
+            forName: NSWindow.didResignKeyNotification,
+            object: window,
+            queue: .main
+        ) { [weak self] _ in
+            self?.cancelCapture()
+        }
+    }
+
     private func capture(_ event: NSEvent) -> Bool {
-        guard !didCapture, shouldCapture(event) else { return false }
+        guard !didCapture else { return false }
+
+        if shouldCancel(event) {
+            cancelCapture()
+            return true
+        }
+
+        guard shouldCapture(event) else { return false }
 
         didCapture = true
         stopMonitoring()
@@ -203,6 +238,15 @@ private final class HotKeyCaptureNSView: NSView {
             self?.onCapture?(keyCode)
         }
         return true
+    }
+
+    private func cancelCapture() {
+        guard !didCapture else { return }
+        didCapture = true
+        stopMonitoring()
+        DispatchQueue.main.async { [weak self] in
+            self?.onCancel?()
+        }
     }
 
     private func shouldCapture(_ event: NSEvent) -> Bool {
@@ -220,6 +264,10 @@ private final class HotKeyCaptureNSView: NSView {
         default:
             return false
         }
+    }
+
+    private func shouldCancel(_ event: NSEvent) -> Bool {
+        event.type == .keyDown && Int(event.keyCode) == KeyCodeReference.escapeKeyCode
     }
 
     private func modifierFlag(for keyCode: Int) -> NSEvent.ModifierFlags? {

--- a/Sources/VocaMac/Views/OnboardingView.swift
+++ b/Sources/VocaMac/Views/OnboardingView.swift
@@ -641,15 +641,10 @@ struct HotkeyConfigStep: View {
                         .fontWeight(.semibold)
                         .foregroundStyle(.secondary)
 
-                    Picker("Key", selection: $appState.hotKeyCode) {
-                        ForEach(KeyCodeReference.commonHotKeys, id: \.keyCode) { hotKey in
-                            Text(hotKey.name).tag(hotKey.keyCode)
-                        }
-                    }
-
-                    Text("Press this key to start recording.")
-                        .font(.caption)
-                        .foregroundStyle(.secondary)
+                    HotKeySelectionControl(
+                        pickerLabel: "Key",
+                        footerText: "Press this key to start recording."
+                    )
                 }
 
                 if appState.activationMode == .doubleTapToggle {

--- a/Sources/VocaMac/Views/OnboardingView.swift
+++ b/Sources/VocaMac/Views/OnboardingView.swift
@@ -643,7 +643,7 @@ struct HotkeyConfigStep: View {
 
                     HotKeySelectionControl(
                         pickerLabel: "Key",
-                        footerText: "Press this key to start recording."
+                        footerText: "VocaMac reserves this key while running."
                     )
                 }
 

--- a/Sources/VocaMac/Views/SettingsView.swift
+++ b/Sources/VocaMac/Views/SettingsView.swift
@@ -73,7 +73,7 @@ struct GeneralSettingsTab: View {
             Section("Hotkey") {
                 HotKeySelectionControl(
                     pickerLabel: "Activation Key",
-                    footerText: "Choose a preset or record a custom activation key."
+                    footerText: "Choose a preset or record a key. VocaMac reserves this key while running."
                 )
 
                 if appState.activationMode == .doubleTapToggle {

--- a/Sources/VocaMac/Views/SettingsView.swift
+++ b/Sources/VocaMac/Views/SettingsView.swift
@@ -71,14 +71,10 @@ struct GeneralSettingsTab: View {
 
             // Hotkey
             Section("Hotkey") {
-                Picker("Activation Key", selection: $appState.hotKeyCode) {
-                    ForEach(KeyCodeReference.commonHotKeys, id: \.keyCode) { hotKey in
-                        Text(hotKey.name).tag(hotKey.keyCode)
-                    }
-                }
-                .onChange(of: appState.hotKeyCode) { _ in
-                    appState.syncHotKeyConfiguration()
-                }
+                HotKeySelectionControl(
+                    pickerLabel: "Activation Key",
+                    footerText: "Choose a preset or record a custom activation key."
+                )
 
                 if appState.activationMode == .doubleTapToggle {
                     HStack {

--- a/Tests/VocaMacTests/HotKeyManagerTests.swift
+++ b/Tests/VocaMacTests/HotKeyManagerTests.swift
@@ -106,6 +106,39 @@ final class HotKeyManagerConfigurationTests: XCTestCase {
         manager.stopListening()
         XCTAssertFalse(manager.isListening)
     }
+
+    func testRegularKeyAutoRepeatDoesNotStopPushToTalk() throws {
+        let manager = HotKeyManager()
+        manager.updateConfiguration(keyCode: 0, mode: .pushToTalk, safetyTimeout: 5.0)
+
+        let startExpectation = expectation(description: "Recording starts once")
+        let stopExpectation = expectation(description: "Auto-repeat should not stop recording")
+        stopExpectation.isInverted = true
+
+        var startCount = 0
+        manager.onRecordingStart = {
+            startCount += 1
+            startExpectation.fulfill()
+        }
+        manager.onRecordingStop = {
+            stopExpectation.fulfill()
+        }
+
+        guard let keyDown = CGEvent(keyboardEventSource: nil, virtualKey: 0, keyDown: true),
+              let repeatedKeyDown = CGEvent(keyboardEventSource: nil, virtualKey: 0, keyDown: true)
+        else {
+            throw XCTSkip("Could not create keyboard events")
+        }
+        repeatedKeyDown.setIntegerValueField(.keyboardEventAutorepeat, value: 1)
+
+        manager._handleTestEvent(type: .keyDown, event: keyDown)
+        wait(for: [startExpectation], timeout: 1.0)
+
+        manager._handleTestEvent(type: .keyDown, event: repeatedKeyDown)
+        wait(for: [stopExpectation], timeout: 0.1)
+        XCTAssertEqual(startCount, 1)
+        manager.resetKeyState()
+    }
 }
 
 // MARK: - HotKeyManager Reset State Tests

--- a/Tests/VocaMacTests/HotKeyManagerTests.swift
+++ b/Tests/VocaMacTests/HotKeyManagerTests.swift
@@ -129,15 +129,140 @@ final class HotKeyManagerConfigurationTests: XCTestCase {
         else {
             throw XCTSkip("Could not create keyboard events")
         }
+        markAsExternal(keyDown)
+        markAsExternal(repeatedKeyDown)
         repeatedKeyDown.setIntegerValueField(.keyboardEventAutorepeat, value: 1)
 
-        manager._handleTestEvent(type: .keyDown, event: keyDown)
+        XCTAssertTrue(manager._handleTestEvent(type: .keyDown, event: keyDown))
         wait(for: [startExpectation], timeout: 1.0)
 
-        manager._handleTestEvent(type: .keyDown, event: repeatedKeyDown)
+        XCTAssertTrue(manager._handleTestEvent(type: .keyDown, event: repeatedKeyDown))
         wait(for: [stopExpectation], timeout: 0.1)
         XCTAssertEqual(startCount, 1)
         manager.resetKeyState()
+    }
+
+    func testTargetRegularKeyEventsAreConsumed() throws {
+        let manager = HotKeyManager()
+        manager.updateConfiguration(keyCode: 0, mode: .pushToTalk, safetyTimeout: 5.0)
+
+        guard let keyDown = CGEvent(keyboardEventSource: nil, virtualKey: 0, keyDown: true),
+              let keyUp = CGEvent(keyboardEventSource: nil, virtualKey: 0, keyDown: false)
+        else {
+            throw XCTSkip("Could not create keyboard events")
+        }
+        markAsExternal(keyDown)
+        markAsExternal(keyUp)
+
+        XCTAssertTrue(manager._handleTestEvent(type: .keyDown, event: keyDown))
+        XCTAssertTrue(manager._handleTestEvent(type: .keyUp, event: keyUp))
+        manager.resetKeyState()
+    }
+
+    func testNonTargetRegularKeyEventsPassThrough() throws {
+        let manager = HotKeyManager()
+        manager.updateConfiguration(keyCode: 0, mode: .pushToTalk)
+
+        guard let keyDown = CGEvent(keyboardEventSource: nil, virtualKey: 1, keyDown: true) else {
+            throw XCTSkip("Could not create keyboard event")
+        }
+        markAsExternal(keyDown)
+
+        XCTAssertFalse(manager._handleTestEvent(type: .keyDown, event: keyDown))
+    }
+
+    func testTargetModifierEventIsConsumed() throws {
+        let manager = HotKeyManager()
+        manager.updateConfiguration(keyCode: 61, mode: .pushToTalk, safetyTimeout: 5.0)
+
+        guard let event = CGEvent(keyboardEventSource: nil, virtualKey: 61, keyDown: true) else {
+            throw XCTSkip("Could not create keyboard event")
+        }
+        markAsExternal(event)
+        event.flags = .maskAlternate
+
+        XCTAssertTrue(manager._handleTestEvent(type: .flagsChanged, event: event))
+        manager.resetKeyState()
+    }
+
+    func testModifierReleaseStopsWhenSiblingModifierStillHeld() throws {
+        let manager = HotKeyManager()
+        manager.updateConfiguration(keyCode: 61, mode: .pushToTalk, safetyTimeout: 5.0)
+
+        let startExpectation = expectation(description: "Recording starts")
+        let stopExpectation = expectation(description: "Recording stops")
+
+        manager.onRecordingStart = {
+            startExpectation.fulfill()
+        }
+        manager.onRecordingStop = {
+            stopExpectation.fulfill()
+        }
+
+        guard let keyDown = CGEvent(keyboardEventSource: nil, virtualKey: 61, keyDown: true),
+              let keyUp = CGEvent(keyboardEventSource: nil, virtualKey: 61, keyDown: false)
+        else {
+            throw XCTSkip("Could not create modifier events")
+        }
+        markAsExternal(keyDown)
+        markAsExternal(keyUp)
+        keyDown.flags = .maskAlternate
+        keyUp.flags = .maskAlternate
+
+        XCTAssertTrue(manager._handleTestEvent(type: .flagsChanged, event: keyDown))
+        wait(for: [startExpectation], timeout: 1.0)
+
+        XCTAssertTrue(manager._handleTestEvent(type: .flagsChanged, event: keyUp))
+        wait(for: [stopExpectation], timeout: 1.0)
+        manager.resetKeyState()
+    }
+
+    func testModifierReleaseWithSiblingModifierHeldDoesNotCountAsDoubleTap() throws {
+        let manager = HotKeyManager()
+        manager.updateConfiguration(keyCode: 61, mode: .doubleTapToggle, doubleTapThreshold: 1.0)
+
+        let startExpectation = expectation(description: "Modifier release should not start recording")
+        startExpectation.isInverted = true
+        manager.onRecordingStart = {
+            startExpectation.fulfill()
+        }
+
+        guard let keyDown = CGEvent(keyboardEventSource: nil, virtualKey: 61, keyDown: true),
+              let keyUp = CGEvent(keyboardEventSource: nil, virtualKey: 61, keyDown: false)
+        else {
+            throw XCTSkip("Could not create modifier events")
+        }
+        markAsExternal(keyDown)
+        markAsExternal(keyUp)
+        keyDown.flags = .maskAlternate
+        keyUp.flags = .maskAlternate
+
+        XCTAssertTrue(manager._handleTestEvent(type: .flagsChanged, event: keyDown))
+
+        let releaseDelay = expectation(description: "Release after double-tap minimum interval")
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.06) {
+            releaseDelay.fulfill()
+        }
+        wait(for: [releaseDelay], timeout: 1.0)
+
+        XCTAssertTrue(manager._handleTestEvent(type: .flagsChanged, event: keyUp))
+        wait(for: [startExpectation], timeout: 0.15)
+        manager.resetKeyState()
+    }
+
+    func testSelfGeneratedEventsPassThrough() throws {
+        let manager = HotKeyManager()
+        manager.updateConfiguration(keyCode: 9, mode: .pushToTalk)
+
+        guard let event = CGEvent(keyboardEventSource: nil, virtualKey: 9, keyDown: true) else {
+            throw XCTSkip("Could not create keyboard event")
+        }
+
+        XCTAssertFalse(manager._handleTestEvent(type: .keyDown, event: event))
+    }
+
+    private func markAsExternal(_ event: CGEvent) {
+        event.setIntegerValueField(.eventSourceUnixProcessID, value: 0)
     }
 }
 

--- a/Tests/VocaMacTests/ServiceTests.swift
+++ b/Tests/VocaMacTests/ServiceTests.swift
@@ -18,8 +18,12 @@ final class KeyCodeReferenceTests: XCTestCase {
         XCTAssertEqual(KeyCodeReference.displayName(for: 61), "Right Option (⌥)")
     }
 
-    func testDisplayNameForRecordedCharacterKeyCode() {
-        XCTAssertEqual(KeyCodeReference.displayName(for: 0), "A")
+    func testDisplayNameForRecordedCharacterKeyCodeUsesActiveLayout() throws {
+        guard let keyCode = TextInjector.keyCode(forCharacter: "a") else {
+            throw XCTSkip("Could not inspect active keyboard layout")
+        }
+
+        XCTAssertEqual(KeyCodeReference.displayName(for: Int(keyCode)), "A")
     }
 
     func testDisplayNameForRecordedFunctionKeyCode() {
@@ -38,6 +42,15 @@ final class KeyCodeReferenceTests: XCTestCase {
         XCTAssertTrue(KeyCodeReference.isModifierKeyCode(61))
         XCTAssertTrue(KeyCodeReference.isModifierKeyCode(55))
         XCTAssertFalse(KeyCodeReference.isModifierKeyCode(105))
+    }
+
+    func testEscapeKeyCodeConstant() {
+        XCTAssertEqual(KeyCodeReference.escapeKeyCode, 53)
+        XCTAssertEqual(KeyCodeReference.displayName(for: KeyCodeReference.escapeKeyCode), "Escape")
+    }
+
+    func testDisplayNameForSpaceUsesReadableName() {
+        XCTAssertEqual(KeyCodeReference.displayName(for: 49), "Space")
     }
 
     func testCommonHotKeysValid() {

--- a/Tests/VocaMacTests/ServiceTests.swift
+++ b/Tests/VocaMacTests/ServiceTests.swift
@@ -18,8 +18,26 @@ final class KeyCodeReferenceTests: XCTestCase {
         XCTAssertEqual(KeyCodeReference.displayName(for: 61), "Right Option (⌥)")
     }
 
+    func testDisplayNameForRecordedCharacterKeyCode() {
+        XCTAssertEqual(KeyCodeReference.displayName(for: 0), "A")
+    }
+
+    func testDisplayNameForRecordedFunctionKeyCode() {
+        XCTAssertEqual(KeyCodeReference.displayName(for: 105), "F13")
+    }
+
     func testDisplayNameForUnknownKeyCode() {
         XCTAssertEqual(KeyCodeReference.displayName(for: 999), "Key 999")
+    }
+
+    func testCustomKeyCodeIsNotCommonPreset() {
+        XCTAssertFalse(KeyCodeReference.isCommonHotKey(105))
+    }
+
+    func testModifierKeyCodeDetection() {
+        XCTAssertTrue(KeyCodeReference.isModifierKeyCode(61))
+        XCTAssertTrue(KeyCodeReference.isModifierKeyCode(55))
+        XCTAssertFalse(KeyCodeReference.isModifierKeyCode(105))
     }
 
     func testCommonHotKeysValid() {

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -152,7 +152,8 @@ HotKey Triggered (stop)
 
 **Implementation Approach:**
 - Uses `CGEvent.tapCreate()` to create a Mach port event tap
-- Tap is inserted at `.cghidEventTap` level for system-wide coverage
+- Tap is inserted at `.cgSessionEventTap` level for user-session coverage
+- The tap acts as an event filter and consumes only the configured hotkey events so they don't leak into the frontmost app
 - Callback processes `keyDown`/`keyUp` events for regular keys and `flagsChanged` events for modifier keys
 
 **Activation Modes:**
@@ -176,9 +177,9 @@ On keyUp:
   (Used only for push-to-talk mode)
 ```
 
-**Default Hotkey:** Right Option (keyCode 61). Users can choose a preset or record any single activation key from Settings.
+**Default Hotkey:** Right Option (keyCode 61). Users can choose a preset or record any single activation key from Settings; the selected key is reserved by VocaMac while the app is running.
 
-**Required Permission:** Accessibility (System Settings → Privacy & Security → Accessibility)
+**Required Permissions:** Accessibility and Input Monitoring (System Settings → Privacy & Security)
 
 #### 3.2.4 `AudioEngine` - Microphone Capture
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -153,7 +153,7 @@ HotKey Triggered (stop)
 **Implementation Approach:**
 - Uses `CGEvent.tapCreate()` to create a Mach port event tap
 - Tap is inserted at `.cghidEventTap` level for system-wide coverage
-- Callback processes `keyDown` and `keyUp` events for the configured hotkey
+- Callback processes `keyDown`/`keyUp` events for regular keys and `flagsChanged` events for modifier keys
 
 **Activation Modes:**
 
@@ -176,7 +176,7 @@ On keyUp:
   (Used only for push-to-talk mode)
 ```
 
-**Default Hotkey:** Right Option (keyCode 61)
+**Default Hotkey:** Right Option (keyCode 61). Users can choose a preset or record any single activation key from Settings.
 
 **Required Permission:** Accessibility (System Settings → Privacy & Security → Accessibility)
 

--- a/docs/DATA_MODEL.md
+++ b/docs/DATA_MODEL.md
@@ -284,7 +284,7 @@ struct TranscriptionResult: Identifiable {
 struct UserSettings {
     // Activation
     var activationMode: ActivationMode = .pushToTalk
-    var hotKeyCode: Int = 61                    // Right Option key
+    var hotKeyCode: Int = 61                    // Right Option by default; user may record any single key
     var doubleTapThreshold: Double = 0.4        // seconds
 
     // Audio

--- a/docs/DATA_MODEL.md
+++ b/docs/DATA_MODEL.md
@@ -284,7 +284,7 @@ struct TranscriptionResult: Identifiable {
 struct UserSettings {
     // Activation
     var activationMode: ActivationMode = .pushToTalk
-    var hotKeyCode: Int = 61                    // Right Option by default; user may record any single key
+    var hotKeyCode: Int = 61                    // Right Option by default; selected key is reserved while running
     var doubleTapThreshold: Double = 0.4        // seconds
 
     // Audio


### PR DESCRIPTION
## Summary
- Add a reusable hotkey selector for Settings and onboarding that keeps curated presets and supports recording any single activation key.
- Reserve the selected key while VocaMac is running by using an active session `CGEvent` tap that consumes only configured hotkey events.
- Preserve text injection by letting VocaMac self-generated keyboard events pass through, so printable bindings do not intercept the app’s own Cmd+V fallback.
- Support Escape and popover focus loss cancellation while recording a custom key.
- Display recorded printable keys using the active keyboard layout while keeping readable names for Space, Escape, F-keys, arrows, keypad keys, and modifiers.
- Update user-facing copy and docs to explain the reserved-key behavior.

## Demo
<img width="3180" height="1628" alt="Screen Recording 2026-06-02 at 12 37 11" src="https://github.com/user-attachments/assets/d610bed5-021c-4cab-9b13-e9412e284bf6" />



## Review Focus
- `HotKeyManager` now filters matching hotkey events instead of passively observing them; non-matching and self-generated events pass through.
- `HotKeySelectionControl` pauses the global listener during recording, then syncs through `AppState.syncHotKeyConfiguration()` when selection changes.
- Modifier key state is tracked separately from recording state so same-modifier-group edge cases work in both push-to-talk and double-tap modes.

## Tests
- `swift test` (190 tests, 1 accessibility-permission-dependent skip)
- `xcodebuild build -scheme VocaMac -configuration Release -derivedDataPath .xcode-build -destination platform=macOS,arch=arm64 ONLY_ACTIVE_ARCH=YES -quiet`
- `git diff --check`

Closes #48