### PR TITLE
fix: recover audio engine after route changes

### DIFF
--- a/Sources/VocaMac/Models/AppState.swift
+++ b/Sources/VocaMac/Models/AppState.swift
@@ -464,11 +464,21 @@ final class AppState: ObservableObject {
         // Start recording immediately for instant responsiveness.
         // The start sound is played concurrently — any brief bleed into the
         // mic buffer is negligible and handled well by WhisperKit's noise model.
-        audioEngine.startRecording(
+        let didStartRecording = audioEngine.startRecording(
             silenceThreshold: Float(silenceThreshold),
             silenceDuration: silenceDuration,
             maxDuration: TimeInterval(maxRecordingDuration)
         )
+
+        guard didStartRecording else {
+            VocaLogger.warning(.appState, "Audio engine failed to start — resetting recording state")
+            isRecording = false
+            audioLevel = 0.0
+            cursorOverlay.hide()
+            hotKeyManager.resetKeyState()
+            appStatus = .idle
+            return
+        }
 
         // Play start sound after mic is active (fire-and-forget)
         if soundEffectsEnabled {

--- a/Sources/VocaMac/Services/AudioEngine.swift
+++ b/Sources/VocaMac/Services/AudioEngine.swift
@@ -12,7 +12,8 @@ final class AudioEngine {
 
     // MARK: - Properties
 
-    private let engine = AVAudioEngine()
+    private var engine = AVAudioEngine()
+    private var audioConfigurationObserver: NSObjectProtocol?
     private var audioBuffer: [Float] = []
     private var _isCurrentlyRecording = false
     private let bufferQueue = DispatchQueue(label: "com.vocamac.audio-buffer", qos: .userInteractive)
@@ -60,23 +61,34 @@ final class AudioEngine {
     // MARK: - Initialization
 
     init() {
-        // Listen for audio configuration changes (device plug/unplug, route changes,
-        // Bluetooth disconnects, display sleep changing audio routing, etc.).
-        // AVAudioEngine posts this notification when the underlying hardware changes
-        // and the engine needs to be reconfigured.
-        NotificationCenter.default.addObserver(
-            self,
-            selector: #selector(handleAudioConfigurationChange),
-            name: .AVAudioEngineConfigurationChange,
-            object: engine
-        )
+        registerForAudioConfigurationChanges()
     }
 
     deinit {
-        NotificationCenter.default.removeObserver(self)
+        unregisterFromAudioConfigurationChanges()
     }
 
     // MARK: - Audio Configuration Change
+
+    /// Register for configuration changes from the current AVAudioEngine instance.
+    private func registerForAudioConfigurationChanges() {
+        unregisterFromAudioConfigurationChanges()
+        audioConfigurationObserver = NotificationCenter.default.addObserver(
+            forName: .AVAudioEngineConfigurationChange,
+            object: engine,
+            queue: nil
+        ) { [weak self] notification in
+            self?.handleAudioConfigurationChange(notification)
+        }
+    }
+
+    /// Remove the configuration-change observer for the current engine.
+    private func unregisterFromAudioConfigurationChanges() {
+        if let audioConfigurationObserver {
+            NotificationCenter.default.removeObserver(audioConfigurationObserver)
+            self.audioConfigurationObserver = nil
+        }
+    }
 
     /// Called when macOS detects an audio hardware configuration change.
     /// This happens when a microphone is unplugged/replugged, Bluetooth audio
@@ -85,7 +97,7 @@ final class AudioEngine {
     /// When this fires during an active recording, the engine's internal state
     /// is invalidated — the installed tap references a stale format and no audio
     /// flows. We must stop, reset, and notify AppState so it can recover.
-    @objc private func handleAudioConfigurationChange(_ notification: Notification) {
+    private func handleAudioConfigurationChange(_ notification: Notification) {
         lifecycleQueue.async { [weak self] in
             guard let self = self else { return }
             VocaLogger.info(.audioEngine, "Audio configuration changed (device plug/unplug or route change)")
@@ -102,9 +114,11 @@ final class AudioEngine {
                 self.engine.stop()
             }
 
-            // Reset the engine so it picks up the new audio device/format
-            self.engine.reset()
-            VocaLogger.info(.audioEngine, "Audio engine reset after configuration change")
+            // Recreate the engine so it drops any stale hardware format/tap state.
+            // A plain reset can leave AVAudioEngine stuck with a pre-route-change
+            // input format, causing repeated "Input HW format and tap format not matching" exceptions.
+            self.recreateEngine(reason: "audio configuration change")
+            VocaLogger.info(.audioEngine, "Audio engine recreated after configuration change")
 
             if wasRecording {
                 // Notify AppState on the main queue so it can handle the interrupted recording
@@ -147,13 +161,14 @@ final class AudioEngine {
     ///   - silenceThreshold: RMS energy threshold below which audio is considered silence
     ///   - silenceDuration: Seconds of silence before triggering silence detection callback
     ///   - maxDuration: Maximum recording duration in seconds
+    @discardableResult
     func startRecording(
         silenceThreshold: Float = 0.01,
         silenceDuration: Double = 2.0,
         maxDuration: TimeInterval = 60.0
-    ) {
+    ) -> Bool {
         lifecycleQueue.sync {
-            guard !self._isCurrentlyRecording else { return }
+            guard !self._isCurrentlyRecording else { return true }
 
             self.silenceThreshold = silenceThreshold
             self.silenceDuration = silenceDuration
@@ -171,7 +186,7 @@ final class AudioEngine {
                     "Invalid input format before recording start: sampleRate=\(inputFormat.sampleRate), channels=\(inputFormat.channelCount)"
                 )
                 recoverFromStartFailure(notifyAppState: true)
-                return
+                return false
             }
 
             // A previous failed start can leave a tap installed even when our
@@ -197,14 +212,15 @@ final class AudioEngine {
             if let exception {
                 VocaLogger.error(.audioEngine, "AVAudioEngine exception while starting recording: \(exception.localizedDescription)")
                 recoverFromStartFailure(notifyAppState: true)
-                return
+                return false
             }
 
             if let startError {
                 VocaLogger.error(.audioEngine, "Failed to start audio engine: \(startError.localizedDescription)")
                 recoverFromStartFailure(notifyAppState: true)
-                return
+                return false
             }
+            return true
         }
     }
 
@@ -237,7 +253,7 @@ final class AudioEngine {
 
             removeInputTap(reason: "force reset")
             engine.stop()
-            engine.reset()
+            recreateEngine(reason: "force reset")
             clearAudioBuffer()
 
             VocaLogger.info(.audioEngine, "Force reset complete — engine is clean")
@@ -277,6 +293,17 @@ final class AudioEngine {
         format.sampleRate.isFinite && format.sampleRate > 0 && format.channelCount > 0
     }
 
+    /// Replaces the underlying AVAudioEngine with a fresh instance.
+    ///
+    /// Hardware route changes can leave an existing engine with stale input-node
+    /// format state even after `reset()`. Recreating the engine forces AVFoundation
+    /// to bind a fresh input node to the current hardware format.
+    private func recreateEngine(reason: String) {
+        engine = AVAudioEngine()
+        registerForAudioConfigurationChanges()
+        VocaLogger.info(.audioEngine, "Created fresh AVAudioEngine during \(reason)")
+    }
+
     /// Removes the current input tap while converting AVFoundation NSExceptions
     /// into log messages instead of process aborts.
     private func removeInputTap(reason: String) {
@@ -296,7 +323,7 @@ final class AudioEngine {
         maxDurationCallbackFired = false
         removeInputTap(reason: "start failure")
         engine.stop()
-        engine.reset()
+        recreateEngine(reason: "start failure")
         clearAudioBuffer()
 
         if notifyAppState {

--- a/Sources/VocaMac/Services/ServiceProtocols.swift
+++ b/Sources/VocaMac/Services/ServiceProtocols.swift
@@ -16,7 +16,7 @@ protocol AudioRecording: AnyObject {
     var onMaxDurationReached: (() -> Void)? { get set }
     var onAudioDeviceChanged: (() -> Void)? { get set }
 
-    func startRecording(silenceThreshold: Float, silenceDuration: Double, maxDuration: TimeInterval)
+    @discardableResult func startRecording(silenceThreshold: Float, silenceDuration: Double, maxDuration: TimeInterval) -> Bool
     @discardableResult func stopRecording() -> [Float]
     func forceReset()
     func checkPermissionStatus() -> PermissionStatus

--- a/Tests/VocaMacTests/AppStateRecordingTests.swift
+++ b/Tests/VocaMacTests/AppStateRecordingTests.swift
@@ -362,6 +362,25 @@ final class AppStateRecordingGuardTests: XCTestCase {
     }
 
     @MainActor
+    func testFailedAudioStartResetsRecordingAndHotkeyState() async {
+        let (appState, mocks) = AppState.makeTestState()
+        mocks.audioEngine.shouldStartRecordingSucceed = false
+
+        await appState.startRecording()
+
+        XCTAssertEqual(appState.appStatus, .idle,
+            "A failed audio-engine start should immediately return the app to idle")
+        XCTAssertFalse(appState.isRecording,
+            "AppState should not stay recording if AudioEngine failed to start")
+        XCTAssertFalse(mocks.audioEngine.isCurrentlyRecording,
+            "AudioEngine mock should report idle after a failed start")
+        XCTAssertEqual(mocks.hotKeyManager.resetKeyStateCallCount, 1,
+            "Hotkey state should reset so the next shortcut press is handled")
+        XCTAssertEqual(mocks.soundManager.startSoundCallCount, 0,
+            "Start sound should not play when the microphone did not start")
+    }
+
+    @MainActor
     func testInitialStateIsIdle() {
         let (appState, _) = AppState.makeTestState()
         XCTAssertEqual(appState.appStatus, .idle)

--- a/Tests/VocaMacTests/Mocks/MockServices.swift
+++ b/Tests/VocaMacTests/Mocks/MockServices.swift
@@ -22,14 +22,23 @@ final class MockAudioEngine: AudioRecording {
     var lastMaxDuration: TimeInterval?
     var stopRecordingResult: [Float] = []
     var forceResetCallCount = 0
+    var shouldStartRecordingSucceed = true
 
     private var permissionStatus: PermissionStatus = .granted
 
-    func startRecording(silenceThreshold: Float, silenceDuration: Double, maxDuration: TimeInterval) {
-        isCurrentlyRecording = true
+    @discardableResult
+    func startRecording(silenceThreshold: Float, silenceDuration: Double, maxDuration: TimeInterval) -> Bool {
         lastSilenceThreshold = silenceThreshold
         lastSilenceDuration = silenceDuration
         lastMaxDuration = maxDuration
+
+        guard shouldStartRecordingSucceed else {
+            isCurrentlyRecording = false
+            return false
+        }
+
+        isCurrentlyRecording = true
+        return true
     }
 
     @discardableResult


### PR DESCRIPTION
## Summary

Fix recovery from macOS audio route/input format churn by making the recording start path report failure and rebuilding the AVAudioEngine when the current instance may hold stale hardware format state.

This is aimed at failures like:

```text
AVAudioEngine exception while starting recording: Input HW format and tap format not matching
```

which can happen after Bluetooth headset connect/disconnect, default input changes, Zoom/Loom microphone activity, or other AVAudioEngine configuration changes.

## Changes

- Return a success/failure result from `AudioRecording.startRecording(...)`.
- Reset `AppState` and hotkey state immediately if `AudioEngine` fails to start.
- Recreate the underlying `AVAudioEngine` after:
  - audio configuration changes
  - failed start attempts
  - force reset
- Keep `AVAudioEngineConfigurationChange` scoped to the current engine and re-register the observer when the engine is recreated.
- Add a regression test for failed audio start resetting recording and hotkey state.

## Validation

- `swift test --filter AppStateRecordingGuardTests/testFailedAudioStartResetsRecordingAndHotkeyState`
- `swift build`
- `swift test` — 169 tests passed

## Test notes

Please try this build with Bluetooth headphones connect/disconnect and during/after Zoom or Loom microphone usage to verify VocaMac no longer needs an app restart after input route changes.
