### PR TITLE
ci: add SwiftLint, coverage reporting, and dev loop improvements

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,8 +35,27 @@ jobs:
               - 'scripts/**'
               - 'Makefile'
               - 'VocaMac.entitlements'
+              - '.swiftlint.yml'
             web:
               - 'web/**'
+
+  # Lint Swift sources (only when app source or lint config changes)
+  lint:
+    name: Lint
+    needs: changes
+    if: needs.changes.outputs.app == 'true'
+    runs-on: macos-15
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Install SwiftLint
+        run: brew install swiftlint
+
+      - name: Run SwiftLint
+        run: swiftlint lint --config .swiftlint.yml
 
   # Build and test Swift app (only when app source changes)
   build-and-test:
@@ -45,6 +64,8 @@ jobs:
     if: needs.changes.outputs.app == 'true'
     runs-on: macos-15
     timeout-minutes: 30
+    permissions:
+      pull-requests: write
 
     steps:
       - name: Checkout
@@ -61,8 +82,80 @@ jobs:
       - name: Build (Debug)
         run: swift build
 
-      - name: Test
-        run: swift test
+      - name: Test with coverage
+        run: swift test --enable-code-coverage
+
+      - name: Generate coverage report
+        id: coverage
+        run: |
+          PROFDATA=".build/debug/codecov/default.profdata"
+          BINARY=".build/debug/VocaMacTests.xctest/Contents/MacOS/VocaMacTests"
+
+          if [ -f "$PROFDATA" ] && [ -f "$BINARY" ]; then
+            xcrun llvm-cov report "$BINARY" \
+              --instr-profile="$PROFDATA" \
+              --ignore-filename-regex="\.build|Tests|VocaMacObjC" \
+              > /tmp/coverage-raw.txt 2>&1
+            echo "coverage_available=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "coverage_available=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Post coverage comment
+        if: github.event_name == 'pull_request'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const available = '${{ steps.coverage.outputs.coverage_available }}' === 'true';
+
+            let body;
+            if (available) {
+              const raw = fs.readFileSync('/tmp/coverage-raw.txt', 'utf8');
+              const lines = raw.trim().split('\n');
+              const total = lines[lines.length - 1];
+              body = [
+                '## 📊 Test Coverage',
+                '',
+                `**Total:** \`${total}\``,
+                '',
+                '<details><summary>Full report</summary>',
+                '',
+                '```',
+                raw,
+                '```',
+                '',
+                '</details>',
+              ].join('\n');
+            } else {
+              body = '## 📊 Test Coverage\n\nCoverage data unavailable.';
+            }
+
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+            });
+
+            const existing = comments.find(
+              c => c.user.login === 'github-actions[bot]' && c.body.includes('📊 Test Coverage')
+            );
+
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body,
+              });
+            }
 
       - name: Build (Release)
         run: swift build -c release
@@ -93,7 +186,7 @@ jobs:
       - name: Setup Hugo
         uses: peaceiris/actions-hugo@v3
         with:
-          hugo-version: 'latest'
+          hugo-version: "latest"
           extended: true
 
       - name: Build Hugo site

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,6 +66,7 @@ jobs:
     timeout-minutes: 30
     permissions:
       pull-requests: write
+      issues: write
 
     steps:
       - name: Checkout

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -1,0 +1,86 @@
+# VocaMac — SwiftLint configuration
+# Docs: https://github.com/realm/SwiftLint
+
+# ─── Scope ────────────────────────────────────────────────────────────────────
+
+included:
+  - Sources/VocaMac
+  - Tests/VocaMacTests
+
+excluded:
+  - .build
+  - Sources/VocaMacObjC # Objective-C bridge; not linted
+
+# ─── Disabled rules ───────────────────────────────────────────────────────────
+
+disabled_rules:
+  - todo # TODOs are fine during active development
+  - multiple_closures_with_trailing_closure # Too restrictive with SwiftUI modifiers
+
+# ─── Opt-in rules ─────────────────────────────────────────────────────────────
+# These are not on by default; we explicitly enable the ones that match our conventions.
+
+opt_in_rules:
+  - force_unwrapping # AGENTS.md: "Never force-unwrap"
+  - empty_count # prefer .isEmpty over count == 0
+  - empty_string # prefer .isEmpty over == ""
+  - closure_spacing # { x } not {x}
+  - first_where # prefer first(where:) over filter().first
+  - last_where # prefer last(where:) over filter().last
+  - toggle_bool # prefer .toggle() over = !flag
+  - prefer_self_type_over_type_of_self # use Self instead of type(of: self)
+  - redundant_nil_coalescing # avoid ?? nil
+  - fatal_error_message # fatalError() must carry a message
+  - sorted_imports # keep import groups sorted alphabetically
+
+# ─── Rule configuration ───────────────────────────────────────────────────────
+
+force_cast: error
+force_try: error
+
+line_length:
+  warning: 140
+  error: 200
+  ignores_comments: true
+  ignores_urls: true
+
+file_length:
+  warning: 600
+  error: 1000
+  ignore_comment_only_lines: true
+
+function_body_length:
+  warning: 100
+  error: 150
+
+type_body_length:
+  warning: 500
+  error: 700
+
+cyclomatic_complexity:
+  warning: 15
+  error: 25
+
+nesting:
+  type_level:
+    warning: 2
+  function_level:
+    warning: 4
+
+type_name:
+  min_length: 3
+  max_length: 50
+
+identifier_name:
+  min_length: 2
+  max_length: 50
+  excluded:
+    - id
+    - x
+    - y
+    - i
+    - j
+    - k
+    - db
+    - ok
+    - on

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # VocaMac — Makefile
 # Run `make help` for available commands.
 
-.PHONY: build install install-cli dmg release test clean reset run help
+.PHONY: build install install-cli dmg release test lint lint-fix clean reset run dev help
 
 .DEFAULT_GOAL := help
 
@@ -28,6 +28,23 @@ release:
 ## Run tests
 test:
 	@swift test
+
+## Lint Swift sources (requires SwiftLint: brew install swiftlint)
+lint:
+	@command -v swiftlint >/dev/null 2>&1 || \
+		(echo "❌ SwiftLint not found. Install with: brew install swiftlint" && exit 1)
+	@xcode-select -p | grep -q Xcode || \
+		(echo "❌ SwiftLint requires full Xcode, not just Command Line Tools." && \
+		 echo "   Fix: sudo xcode-select --switch /Applications/Xcode.app/Contents/Developer" && \
+		 exit 1)
+	@echo "🔍 Running SwiftLint..."
+	@swiftlint lint --config .swiftlint.yml
+
+## Auto-fix SwiftLint violations where possible (requires SwiftLint: brew install swiftlint)
+lint-fix:
+	@command -v swiftlint >/dev/null 2>&1 || (echo "❌ SwiftLint not found. Install with: brew install swiftlint" && exit 1)
+	@echo "🔧 Auto-correcting SwiftLint violations..."
+	@swiftlint lint --fix --config .swiftlint.yml
 
 ## Remove build artifacts
 clean:
@@ -61,6 +78,12 @@ reset:
 run:
 	@open VocaMac.app 2>/dev/null || (echo "❌ VocaMac.app not found. Run 'make build' first." && exit 1)
 
+## Kill any running instance, rebuild, and relaunch in one shot (fast dev loop)
+dev:
+	@pkill -x VocaMac 2>/dev/null && echo "⏹  Stopped VocaMac" && sleep 0.5 || true
+	@$(MAKE) --no-print-directory build
+	@$(MAKE) --no-print-directory run
+
 ## Show this help
 help:
 	@echo "VocaMac — Available Commands"
@@ -71,7 +94,10 @@ help:
 	@echo "  make dmg          Build DMG for distribution (output in dist/)"
 	@echo "  make release VERSION=X.Y.Z  Tag and release (triggers CI signing + notarization)"
 	@echo "  make test         Run tests"
+	@echo "  make lint         Lint Swift sources (requires: brew install swiftlint)"
+	@echo "  make lint-fix     Auto-fix SwiftLint violations where possible"
 	@echo "  make run          Launch the locally built .app"
+	@echo "  make dev          Kill, rebuild, and relaunch (one-shot dev loop)"
 	@echo "  make clean        Remove build artifacts"
 	@echo "  make reset        Delete all local app data (models, cache, prefs)"
 	@echo "  make help         Show this help"

--- a/Sources/VocaMac/Models/AppState.swift
+++ b/Sources/VocaMac/Models/AppState.swift
@@ -4,10 +4,10 @@
 // Central observable state for the entire application.
 // All UI and services react to changes in AppState.
 
-import Foundation
-import SwiftUI
 import Combine
+import Foundation
 import ServiceManagement
+import SwiftUI
 
 // MARK: - Enums
 
@@ -253,7 +253,11 @@ final class AppState: ObservableObject {
         // WhisperKit's `.default` may not be in the supported list for some
         // devices. If so, fall back to the best supported model instead.
         let recommendation = modelManager.deviceRecommendation()
-        VocaLogger.info(.appState, "WhisperKit recommendation — default: \(recommendation.defaultModel), supported: [\(recommendation.supported.joined(separator: ", "))], disabled: [\(recommendation.disabled.joined(separator: ", "))]")
+        let supportedModels = recommendation.supported.joined(separator: ", ")
+        let disabledModels = recommendation.disabled.joined(separator: ", ")
+        VocaLogger.info(.appState,
+            "WhisperKit recommendation — default: \(recommendation.defaultModel), " +
+            "supported: [\(supportedModels)], disabled: [\(disabledModels)]")
         let defaultIsSupported = recommendation.supported.contains(recommendation.defaultModel)
         if !defaultIsSupported, let bestSupported = recommendation.supported.last {
             deviceRecommendedModel = bestSupported

--- a/Sources/VocaMac/Services/AudioEngine.swift
+++ b/Sources/VocaMac/Services/AudioEngine.swift
@@ -4,8 +4,8 @@
 // Real-time microphone audio capture using AVAudioEngine.
 // Captures audio in the format required by whisper.cpp (16kHz, mono, Float32 PCM).
 
-import Foundation
 import AVFoundation
+import Foundation
 import VocaMacObjC
 
 final class AudioEngine {
@@ -33,13 +33,10 @@ final class AudioEngine {
     private var lastLevelReportTime: Date = Date()
     private let levelReportInterval: TimeInterval = 1.0 / 15.0  // ~15 Hz
 
+    // swiftlint:disable force_unwrapping
     /// Target audio format for whisper.cpp
-    static let whisperFormat = AVAudioFormat(
-        commonFormat: .pcmFormatFloat32,
-        sampleRate: 16000.0,
-        channels: 1,
-        interleaved: false
-    )!
+    static let whisperFormat = AVAudioFormat(commonFormat: .pcmFormatFloat32, sampleRate: 16000.0, channels: 1, interleaved: false)!
+    // swiftlint:enable force_unwrapping
 
     // MARK: - Callbacks
 

--- a/Sources/VocaMac/Services/CursorOverlayManager.swift
+++ b/Sources/VocaMac/Services/CursorOverlayManager.swift
@@ -113,11 +113,13 @@ final class CursorOverlayManager {
         guard AXUIElementCopyAttributeValue(systemWide, kAXFocusedApplicationAttribute as CFString, &focusedApp) == .success else {
             return mousePosition()
         }
+        // swiftlint:disable:next force_cast
         let app = focusedApp as! AXUIElement
 
         var focusedElement: AnyObject?
         if AXUIElementCopyAttributeValue(app, kAXFocusedUIElementAttribute as CFString, &focusedElement) == .success,
            focusedElement != nil {
+            // swiftlint:disable:next force_cast
             let element = focusedElement as! AXUIElement
 
             if let caretRect = getCaretRectFromElement(element) {
@@ -146,9 +148,15 @@ final class CursorOverlayManager {
         guard rangeResult == .success, let range = selectedRange else { return nil }
 
         var bounds: AnyObject?
-        guard AXUIElementCopyParameterizedAttributeValue(element, kAXBoundsForRangeParameterizedAttribute as CFString, range, &bounds) == .success else { return nil }
+        guard AXUIElementCopyParameterizedAttributeValue(
+            element,
+            kAXBoundsForRangeParameterizedAttribute as CFString,
+            range,
+            &bounds
+        ) == .success else { return nil }
 
         var rect = CGRect.zero
+        // swiftlint:disable:next force_cast
         guard AXValueGetValue(bounds as! AXValue, .cgRect, &rect) else { return nil }
 
         return convertAXRectToAppKit(rect)
@@ -163,8 +171,10 @@ final class CursorOverlayManager {
 
         var position = CGPoint.zero
         var size = CGSize.zero
+        // swiftlint:disable force_cast
         guard AXValueGetValue(positionValue as! AXValue, .cgPoint, &position),
               AXValueGetValue(sizeValue as! AXValue, .cgSize, &size) else { return nil }
+        // swiftlint:enable force_cast
 
         return CGRect(origin: position, size: size)
     }
@@ -178,6 +188,7 @@ final class CursorOverlayManager {
         }
 
         guard result == .success, window != nil else { return nil }
+        // swiftlint:disable:next force_cast
         return getElementRect(window as! AXUIElement)
     }
 
@@ -197,14 +208,12 @@ final class CursorOverlayManager {
 
     private func clamped(_ point: NSPoint) -> NSPoint {
         let panelSize = CGSize(width: 36, height: 36)
-        for screen in NSScreen.screens {
-            if screen.frame.contains(point) {
-                let visible = screen.visibleFrame
-                return NSPoint(
-                    x: min(max(point.x, visible.minX), visible.maxX - panelSize.width),
-                    y: min(max(point.y, visible.minY), visible.maxY - panelSize.height)
-                )
-            }
+        for screen in NSScreen.screens where screen.frame.contains(point) {
+            let visible = screen.visibleFrame
+            return NSPoint(
+                x: min(max(point.x, visible.minX), visible.maxX - panelSize.width),
+                y: min(max(point.y, visible.minY), visible.maxY - panelSize.height)
+            )
         }
         return point
     }

--- a/Sources/VocaMac/Services/HotKeyManager.swift
+++ b/Sources/VocaMac/Services/HotKeyManager.swift
@@ -4,8 +4,8 @@
 // Listens for global hotkey events using CGEventTap.
 // Supports push-to-talk (hold key) and double-tap toggle modes.
 
-import Foundation
 import AppKit
+import Foundation
 
 final class HotKeyManager {
 
@@ -189,7 +189,7 @@ final class HotKeyManager {
     // MARK: - Event Tap Callback
 
     /// Static C callback for CGEventTap — dispatches to the instance method
-    private static let eventTapCallback: CGEventTapCallBack = { proxy, type, event, userInfo in
+    private static let eventTapCallback: CGEventTapCallBack = { _, type, event, userInfo in
         guard let userInfo = userInfo else { return Unmanaged.passUnretained(event) }
 
         let manager = Unmanaged<HotKeyManager>.fromOpaque(userInfo).takeUnretainedValue()
@@ -432,6 +432,7 @@ extension HotKeyManager: HotKeyMonitoring {
         Self.checkAccessibilityPermission(prompt: prompt)
     }
 
+    // swiftlint:disable:next identifier_name
     func _updateConfiguration(keyCode: Int?, mode: ActivationMode?, doubleTapThreshold: Double?, safetyTimeout: Double?) {
         updateConfiguration(keyCode: keyCode, mode: mode, doubleTapThreshold: doubleTapThreshold, safetyTimeout: safetyTimeout)
     }
@@ -456,7 +457,7 @@ enum KeyCodeReference {
         ("F9", 101),
         ("F10", 109),
         ("F11", 103),
-        ("F12", 111),
+        ("F12", 111)
     ]
 
     /// Get the display name for a key code

--- a/Sources/VocaMac/Services/Logger.swift
+++ b/Sources/VocaMac/Services/Logger.swift
@@ -291,10 +291,8 @@ final class VocaLogger {
         result += "================================\n\n"
 
         let lines = getLastLines(lastLines)
-        for line in lines {
-            if !line.isEmpty {
-                result += line + "\n"
-            }
+        for line in lines where !line.isEmpty {
+            result += line + "\n"
         }
 
         return result

--- a/Sources/VocaMac/Services/ModelManager.swift
+++ b/Sources/VocaMac/Services/ModelManager.swift
@@ -98,19 +98,17 @@ final class ModelManager {
 
         // Search all known tokenizer locations (snapshots, openai cache, etc.)
         let candidates = tokenizerSearchDirectories(for: size)
-        for candidateDir in candidates {
-            if hasRequiredTokenizerAssets(at: candidateDir) {
-                for fileName in requiredTokenizerFiles {
-                    let sourceURL = candidateDir.appendingPathComponent(fileName)
-                    let destinationURL = modelDirectory.appendingPathComponent(fileName)
-                    if fileManager.fileExists(atPath: destinationURL.path) {
-                        try fileManager.removeItem(at: destinationURL)
-                    }
-                    try fileManager.copyItem(at: sourceURL, to: destinationURL)
+        for candidateDir in candidates where hasRequiredTokenizerAssets(at: candidateDir) {
+            for fileName in requiredTokenizerFiles {
+                let sourceURL = candidateDir.appendingPathComponent(fileName)
+                let destinationURL = modelDirectory.appendingPathComponent(fileName)
+                if fileManager.fileExists(atPath: destinationURL.path) {
+                    try fileManager.removeItem(at: destinationURL)
                 }
-                VocaLogger.info(.modelManager, "Repaired tokenizer assets for \(modelName) from \(candidateDir.path)")
-                return
+                try fileManager.copyItem(at: sourceURL, to: destinationURL)
             }
+            VocaLogger.info(.modelManager, "Repaired tokenizer assets for \(modelName) from \(candidateDir.path)")
+            return
         }
 
         throw ModelManagerError.tokenizerAssetsUnavailable(modelName)
@@ -167,14 +165,12 @@ final class ModelManager {
         try ensureInstalledModelReady(for: size)
     }
 
-
     /// Local base directory passed to WhisperKit's downloadBase config.
     /// WhisperKit creates its own subdirectory structure under this path.
     private var downloadBase: URL {
-        let appSupport = FileManager.default.urls(
-            for: .applicationSupportDirectory,
-            in: .userDomainMask
-        ).first!
+        let urls = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask)
+        // swiftlint:disable:next force_unwrapping
+        let appSupport = urls.first!
         return appSupport
             .appendingPathComponent("VocaMac")
             .appendingPathComponent("models")
@@ -190,6 +186,7 @@ final class ModelManager {
 
     // MARK: - Model Discovery
 
+    // swiftlint:disable large_tuple
     /// Get WhisperKit's recommendation for the current device
     func deviceRecommendation() -> (defaultModel: String, supported: [String], disabled: [String]) {
         let rec = WhisperKit.recommendedModels()
@@ -199,6 +196,7 @@ final class ModelManager {
             disabled: rec.disabled
         )
     }
+    // swiftlint:enable large_tuple
 
     /// Map a ModelSize enum to WhisperKit model variant name
     func whisperKitModelName(for size: ModelSize) -> String {
@@ -307,19 +305,17 @@ final class ModelManager {
         // 3. The model directory's own snapshots/ subdirectory
         let candidateDirectories = tokenizerSearchDirectories(for: size)
 
-        for candidateDir in candidateDirectories {
-            if hasRequiredTokenizerAssets(at: candidateDir) {
-                for file in requiredTokenizerFiles {
-                    let src = candidateDir.appendingPathComponent(file)
-                    let dst = destination.appendingPathComponent(file)
-                    if fileManager.fileExists(atPath: dst.path) {
-                        try? fileManager.removeItem(at: dst)
-                    }
-                    try fileManager.copyItem(at: src, to: dst)
+        for candidateDir in candidateDirectories where hasRequiredTokenizerAssets(at: candidateDir) {
+            for file in requiredTokenizerFiles {
+                let src = candidateDir.appendingPathComponent(file)
+                let dst = destination.appendingPathComponent(file)
+                if fileManager.fileExists(atPath: dst.path) {
+                    try? fileManager.removeItem(at: dst)
                 }
-                VocaLogger.info(.modelManager, "Consolidated tokenizer assets for \(modelName) from \(candidateDir.path)")
-                return
+                try fileManager.copyItem(at: src, to: dst)
             }
+            VocaLogger.info(.modelManager, "Consolidated tokenizer assets for \(modelName) from \(candidateDir.path)")
+            return
         }
 
         VocaLogger.warning(.modelManager, "Could not find tokenizer assets for \(modelName) in any known location")
@@ -399,7 +395,7 @@ final class ModelManager {
                 }
             }
 
-            let _ = try await WhisperKit(config)
+            _ = try await WhisperKit(config)
 
             // Stop the simulated progress and report completion
             progressTask.cancel()

--- a/Sources/VocaMac/Services/PermissionManager.swift
+++ b/Sources/VocaMac/Services/PermissionManager.swift
@@ -4,9 +4,9 @@
 // Manages system permission checking, requesting, and polling.
 // Extracts permission logic from AppState for focused responsibility.
 
-import Foundation
 import AppKit
 import Combine
+import Foundation
 
 /// Manages system permissions: microphone, accessibility, and input monitoring.
 ///
@@ -120,7 +120,7 @@ final class PermissionManager: ObservableObject {
 
     /// Prompt the user to grant Accessibility permission.
     func requestAccessibilityPermission() {
-        let _ = HotKeyManager.checkAccessibilityPermission(prompt: true)
+        _ = HotKeyManager.checkAccessibilityPermission(prompt: true)
         startPermissionPolling()
     }
 

--- a/Sources/VocaMac/Services/ServiceProtocols.swift
+++ b/Sources/VocaMac/Services/ServiceProtocols.swift
@@ -4,8 +4,8 @@
 // Protocol abstractions for all services that AppState depends on.
 // Enables dependency injection and test mocking.
 
-import Foundation
 import Combine
+import Foundation
 
 // MARK: - AudioRecording
 
@@ -45,6 +45,7 @@ protocol HotKeyMonitoring: AnyObject {
     func startListening(keyCode: Int, mode: ActivationMode, doubleTapThreshold: Double, safetyTimeout: Double)
     func stopListening()
     func resetKeyState()
+    // swiftlint:disable:next identifier_name
     func _updateConfiguration(keyCode: Int?, mode: ActivationMode?, doubleTapThreshold: Double?, safetyTimeout: Double?)
 }
 
@@ -88,6 +89,7 @@ protocol CursorOverlayManaging: AnyObject {
 // MARK: - ModelManaging
 
 protocol ModelManaging: AnyObject {
+    // swiftlint:disable:next large_tuple
     func deviceRecommendation() -> (defaultModel: String, supported: [String], disabled: [String])
     func modelFolder(for size: ModelSize) -> URL?
     func bundledModelFolder(for size: ModelSize) -> URL?
@@ -124,6 +126,7 @@ protocol SpeechTranscribing: AnyObject {
     var loadedModelName: String? { get }
     var isModelLoaded: Bool { get }
     func transcribe(audioData: [Float], language: String?, translate: Bool) async throws -> VocaTranscription
+    // swiftlint:disable:next identifier_name
     func _loadModel(name: String?, folder: URL?, onPhaseChange: ((String) -> Void)?) async throws
 }
 

--- a/Sources/VocaMac/Services/SoundManager.swift
+++ b/Sources/VocaMac/Services/SoundManager.swift
@@ -4,8 +4,8 @@
 // Plays audio feedback sounds for recording start/stop events.
 // Uses macOS system sounds for soft, pleasing audio cues.
 
-import Foundation
 import AppKit
+import Foundation
 
 final class SoundManager: NSObject, NSSoundDelegate, @unchecked Sendable {
 
@@ -105,7 +105,7 @@ final class SoundManager: NSObject, NSSoundDelegate, @unchecked Sendable {
     // MARK: - NSSoundDelegate
 
     /// Called when sound finishes playing
-    nonisolated func sound(_ sound: NSSound, didFinishPlaying FinishedPlaying: Bool) {
+    nonisolated func sound(_ sound: NSSound, didFinishPlaying finishedPlaying: Bool) {
         DispatchQueue.main.async { [weak self] in
             guard let self = self else { return }
             self.continuationLock.lock()

--- a/Sources/VocaMac/Services/TextInjector.swift
+++ b/Sources/VocaMac/Services/TextInjector.swift
@@ -4,9 +4,9 @@
 // Injects transcribed text at the cursor position in any application
 // using the clipboard (NSPasteboard) + simulated Cmd+V keystroke approach.
 
-import Foundation
 import AppKit
 import Carbon.HIToolbox
+import Foundation
 
 final class TextInjector {
 
@@ -23,9 +23,11 @@ final class TextInjector {
     /// pasteboard a moment to settle after we write to it.
     private let prePasteDelay: Double = 0.05
 
+    // swiftlint:disable identifier_name
     /// Default virtual key code for the V key on a US-QWERTY layout.
     /// Used as a fallback when the active layout cannot be inspected.
     private let kVK_ANSI_V_Fallback: CGKeyCode = 9
+    // swiftlint:enable identifier_name
 
     // MARK: - Types
 

--- a/Sources/VocaMac/Services/UpdateChecker.swift
+++ b/Sources/VocaMac/Services/UpdateChecker.swift
@@ -3,10 +3,10 @@
 //
 // Checks GitHub Releases for new versions and downloads DMG updates.
 
-import Foundation
-import SwiftUI
 import AppKit
 import CryptoKit
+import Foundation
+import SwiftUI
 
 enum UpdateCheckerError: LocalizedError {
     case invalidResponse
@@ -158,6 +158,7 @@ final class UpdateChecker: ObservableObject {
     }
 
     func isNewerVersion(remote: String, current: String) -> Bool {
+        // swiftlint:disable:next large_tuple
         func parse(_ version: String) -> (Int, Int, Int) {
             let values = version.split(separator: ".").compactMap { Int($0) }
             let major = values.indices.contains(0) ? values[0] : 0

--- a/Sources/VocaMac/Services/WhisperService.swift
+++ b/Sources/VocaMac/Services/WhisperService.swift
@@ -82,10 +82,9 @@ final class WhisperService: @unchecked Sendable {
 
             // Store models in Application Support, not the default ~/Documents
             // path, to avoid triggering a Documents folder permission prompt.
-            let appSupport = FileManager.default.urls(
-                for: .applicationSupportDirectory,
-                in: .userDomainMask
-            ).first!
+            let appSupportURLs = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask)
+            // swiftlint:disable:next force_unwrapping
+            let appSupport = appSupportURLs.first!
             config.downloadBase = appSupport
                 .appendingPathComponent("VocaMac")
                 .appendingPathComponent("models")
@@ -236,7 +235,7 @@ final class WhisperService: @unchecked Sendable {
         "[Music]",
         "(music)",
         "[Applause]",
-        "(applause)",
+        "(applause)"
     ]
 
     /// Remove hallucination tokens from transcribed text.
@@ -274,6 +273,7 @@ final class WhisperService: @unchecked Sendable {
 // MARK: - SpeechTranscribing Conformance
 
 extension WhisperService: SpeechTranscribing {
+    // swiftlint:disable:next identifier_name
     func _loadModel(name: String?, folder: URL?, onPhaseChange: ((String) -> Void)?) async throws {
         try await loadModel(name: name, folder: folder, onPhaseChange: onPhaseChange)
     }

--- a/Sources/VocaMac/Views/MenuBarView.swift
+++ b/Sources/VocaMac/Views/MenuBarView.swift
@@ -173,7 +173,7 @@ struct MenuBarView: View {
                     details: [
                         ("CPU Usage", String(format: "%.1f%%", processMonitor.cpuUsage)),
                         ("Threads", "\(processMonitor.threadCount)"),
-                        ("Cores", "\(ProcessInfo.processInfo.activeProcessorCount)"),
+                        ("Cores", "\(ProcessInfo.processInfo.activeProcessorCount)")
                     ]
                 )
 
@@ -183,7 +183,7 @@ struct MenuBarView: View {
                     details: [
                         ("Resident", String(format: "%.1f MB", processMonitor.memoryMB)),
                         ("Peak", String(format: "%.1f MB", processMonitor.memoryPeakMB)),
-                        ("System", "\(ProcessInfo.processInfo.physicalMemory / (1024 * 1024 * 1024)) GB"),
+                        ("System", "\(ProcessInfo.processInfo.physicalMemory / (1024 * 1024 * 1024)) GB")
                     ]
                 )
             }

--- a/Sources/VocaMac/Views/SettingsView.swift
+++ b/Sources/VocaMac/Views/SettingsView.swift
@@ -944,7 +944,10 @@ struct DebugTab: View {
     private func resetPermissions() {
         let alert = NSAlert()
         alert.messageText = "Reset All Permissions?"
-        alert.informativeText = "This will clear all permission grants (Microphone, Accessibility, Input Monitoring) for VocaMac. The app will quit and you'll need to re-grant permissions on next launch.\n\nThis is useful when permissions appear stuck or aren't being recognized after an update."
+        alert.informativeText =
+            "This will clear all permission grants (Microphone, Accessibility, Input Monitoring)" +
+            " for VocaMac. The app will quit and you'll need to re-grant permissions on next launch.\n\n" +
+            "This is useful when permissions appear stuck or aren't being recognized after an update."
         alert.alertStyle = .warning
         alert.addButton(withTitle: "Reset & Quit")
         alert.addButton(withTitle: "Cancel")

--- a/Tests/VocaMacTests/AppStateRecordingTests.swift
+++ b/Tests/VocaMacTests/AppStateRecordingTests.swift
@@ -3,8 +3,8 @@
 //
 // Tests for AppState recording flow and state transitions.
 
-import XCTest
 @testable import VocaMac
+import XCTest
 
 // MARK: - AppState Recording State Transition Tests
 

--- a/Tests/VocaMacTests/AppStateTests.swift
+++ b/Tests/VocaMacTests/AppStateTests.swift
@@ -3,9 +3,9 @@
 //
 // Tests for AppState: translation toggle, onboarding, launch at login.
 
-import XCTest
 import ServiceManagement
 @testable import VocaMac
+import XCTest
 
 // MARK: - Translation Toggle Tests
 
@@ -29,7 +29,6 @@ final class TranslationToggleTests: XCTestCase {
         XCTAssertFalse(appState.translationEnabled)
     }
 }
-
 
 // MARK: - OnboardingStep Tests
 
@@ -64,7 +63,6 @@ final class OnboardingStepTests: XCTestCase {
         XCTAssertEqual(ids.count, uniqueIds.count)
     }
 }
-
 
 // MARK: - Launch at Login Tests
 

--- a/Tests/VocaMacTests/CursorOverlayTests.swift
+++ b/Tests/VocaMacTests/CursorOverlayTests.swift
@@ -3,8 +3,8 @@
 //
 // Tests for CursorOverlayManager, IndicatorPhase, and MicIndicatorViewModel.
 
-import XCTest
 @testable import VocaMac
+import XCTest
 
 // MARK: - IndicatorPhase Tests
 

--- a/Tests/VocaMacTests/HotKeyManagerTests.swift
+++ b/Tests/VocaMacTests/HotKeyManagerTests.swift
@@ -3,8 +3,8 @@
 //
 // Tests for HotKeyManager configuration and state logic.
 
-import XCTest
 @testable import VocaMac
+import XCTest
 
 // MARK: - HotKeyManager Configuration Tests
 

--- a/Tests/VocaMacTests/LoggerTests.swift
+++ b/Tests/VocaMacTests/LoggerTests.swift
@@ -3,8 +3,8 @@
 //
 // Tests for VocaLogger, LogCategory, and LogLevel.
 
-import XCTest
 @testable import VocaMac
+import XCTest
 
 // MARK: - LogCategory Tests
 
@@ -32,6 +32,7 @@ final class LogCategoryTests: XCTestCase {
         ]
 
         for category in categories {
+            // swiftlint:disable:next force_unwrapping
             let first = category.rawValue.first!
             XCTAssertTrue(first.isUppercase,
                          "LogCategory.\(category) raw value '\(category.rawValue)' should start with uppercase")

--- a/Tests/VocaMacTests/Mocks/MockServices.swift
+++ b/Tests/VocaMacTests/Mocks/MockServices.swift
@@ -4,8 +4,8 @@
 // Mock implementations of service protocols for unit testing.
 // These avoid triggering real system side effects (sounds, permissions, mic, etc.).
 
-import Foundation
 import Combine
+import Foundation
 @testable import VocaMac
 
 // MARK: - MockAudioEngine
@@ -86,7 +86,7 @@ final class MockSoundManager: SoundPlaying {
 
 final class MockHotKeyManager: HotKeyMonitoring {
     var isListening = false
-    var eventTap: CFMachPort? = nil
+    var eventTap: CFMachPort?
     var onRecordingStart: (() -> Void)?
     var onRecordingStop: (() -> Void)?
 
@@ -124,6 +124,7 @@ final class MockHotKeyManager: HotKeyMonitoring {
         resetKeyStateCallCount += 1
     }
 
+    // swiftlint:disable:next identifier_name
     func _updateConfiguration(keyCode: Int?, mode: ActivationMode?, doubleTapThreshold: Double?, safetyTimeout: Double?) {
     }
 }
@@ -294,7 +295,13 @@ final class MockWhisperService: SpeechTranscribing {
     var lastTranscribedAudioData: [Float]?
     var lastLanguage: String?
     var lastTranslate: Bool?
-    var mockTranscriptionResult: VocaTranscription = VocaTranscription(text: "mock transcription", duration: 1.0, detectedLanguage: "en", audioLengthSeconds: 1.0, modelUsed: .tiny)
+    var mockTranscriptionResult: VocaTranscription = VocaTranscription(
+        text: "mock transcription",
+        duration: 1.0,
+        detectedLanguage: "en",
+        audioLengthSeconds: 1.0,
+        modelUsed: .tiny
+    )
     var shouldThrow = false
 
     func transcribe(audioData: [Float], language: String?, translate: Bool) async throws -> VocaTranscription {
@@ -307,6 +314,7 @@ final class MockWhisperService: SpeechTranscribing {
         return mockTranscriptionResult
     }
 
+    // swiftlint:disable:next identifier_name
     func _loadModel(name: String?, folder: URL?, onPhaseChange: ((String) -> Void)?) async throws {
         loadedModelName = name ?? "mock-model"
         isModelLoaded = true

--- a/Tests/VocaMacTests/ModelTests.swift
+++ b/Tests/VocaMacTests/ModelTests.swift
@@ -4,9 +4,9 @@
 // Tests for data models: SystemInfo, ModelSize, ModelManager,
 // WhisperModelInfo, TranscriptionResult, AppStatus, ActivationMode.
 
-import XCTest
 import ServiceManagement
 @testable import VocaMac
+import XCTest
 
 // MARK: - SystemInfo Tests
 
@@ -274,4 +274,3 @@ final class ActivationModeTests: XCTestCase {
         XCTAssertEqual(ActivationMode.doubleTapToggle.rawValue, "doubleTapToggle")
     }
 }
-

--- a/Tests/VocaMacTests/PermissionManagerTests.swift
+++ b/Tests/VocaMacTests/PermissionManagerTests.swift
@@ -3,8 +3,8 @@
 //
 // Tests for the PermissionManager service.
 
-import XCTest
 @testable import VocaMac
+import XCTest
 
 // MARK: - PermissionStatus Tests
 

--- a/Tests/VocaMacTests/ServiceTests.swift
+++ b/Tests/VocaMacTests/ServiceTests.swift
@@ -3,8 +3,8 @@
 //
 // Tests for services: KeyCodeReference, TextInjector, SoundManager, AudioEngine.
 
-import XCTest
 @testable import VocaMac
+import XCTest
 
 // MARK: - KeyCodeReference Tests
 
@@ -181,8 +181,6 @@ final class SoundManagerTests: XCTestCase {
     }
 }
 
-
-
 // MARK: - AudioEngine Tests
 
 final class AudioEngineTests: XCTestCase {
@@ -217,7 +215,7 @@ final class AudioEngineTests: XCTestCase {
         }
         wait(for: [expectation], timeout: 2.0)
 
-        let _ = engine.stopRecording()
+        _ = engine.stopRecording()
 
         // The callback should have fired at most once due to the silenceCallbackFired guard
         XCTAssertLessThanOrEqual(silenceCallCount, 1,
@@ -246,7 +244,7 @@ final class AudioEngineTests: XCTestCase {
         }
         wait(for: [expectation], timeout: 2.0)
 
-        let _ = engine.stopRecording()
+        _ = engine.stopRecording()
 
         // The callback should have fired at most once
         XCTAssertLessThanOrEqual(maxDurationCallCount, 1,
@@ -354,7 +352,6 @@ final class AudioEngineTests: XCTestCase {
     }
 }
 
-
 // MARK: - AudioEngine Force Reset Tests
 
 final class AudioEngineForceResetTests: XCTestCase {
@@ -459,7 +456,7 @@ final class AudioEngineForceResetTests: XCTestCase {
         XCTAssertTrue(engine.isCurrentlyRecording,
             "Engine should be recording after startRecording")
 
-        let _ = engine.stopRecording()
+        _ = engine.stopRecording()
 
         XCTAssertFalse(engine.isCurrentlyRecording,
             "Engine should not be recording after stopRecording")
@@ -522,7 +519,7 @@ final class AudioEngineDeviceChangeTests: XCTestCase {
 
         XCTAssertTrue(engine.isCurrentlyRecording,
             "Should be able to record again after device change recovery")
-        let _ = engine.stopRecording()
+        _ = engine.stopRecording()
     }
 
     func testDeviceChangeCallbackNotFiredWhenNotRecording() {

--- a/Tests/VocaMacTests/UpdateCheckerTests.swift
+++ b/Tests/VocaMacTests/UpdateCheckerTests.swift
@@ -1,8 +1,8 @@
 // UpdateCheckerTests.swift
 // VocaMac Tests
 
-import XCTest
 @testable import VocaMac
+import XCTest
 
 final class UpdateCheckerTests: XCTestCase {
     @MainActor
@@ -26,6 +26,7 @@ final class UpdateCheckerTests: XCTestCase {
     }
 
     func testGitHubReleaseDecoding() throws {
+        // swiftlint:disable:next line_length
         let json = #"{"tag_name":"v0.4.0","name":"v0.4.0-beta","body":"Release notes","html_url":"https://github.com/jatinkrmalik/vocamac/releases/tag/v0.4.0","prerelease":false,"draft":false,"published_at":"2026-04-10T18:46:58Z","assets":[{"name":"VocaMac-0.4.0-arm64.dmg","size":1234,"browser_download_url":"https://github.com/jatinkrmalik/vocamac/releases/download/v0.4.0/VocaMac-0.4.0-arm64.dmg","content_type":"application/x-apple-diskimage","digest":"sha256:abc123"}]}"#
 
         let release = try JSONDecoder().decode(GitHubRelease.self, from: Data(json.utf8))

--- a/Tests/VocaMacTests/WhisperServiceTests.swift
+++ b/Tests/VocaMacTests/WhisperServiceTests.swift
@@ -3,8 +3,8 @@
 //
 // Tests for WhisperService: translation and hallucination filtering.
 
-import XCTest
 @testable import VocaMac
+import XCTest
 
 // MARK: - WhisperService Translation Tests
 
@@ -18,7 +18,6 @@ final class WhisperServiceTranslationTests: XCTestCase {
         XCTAssertNotNil(service)
     }
 }
-
 
 // MARK: - WhisperService Hallucination Filtering Tests
 


### PR DESCRIPTION
Issue: #108

- make dev now kills any running instance before rebuilding and
  relaunching, replacing the old build + run two-step
- Add make lint (SwiftLint) and make lint-fix (autocorrect);
  both check that xcode-select points at Xcode.app and give an
  actionable error if not
- Add .swiftlint.yml scoped to Sources/VocaMac and Tests/;
  thresholds tuned for a SwiftUI codebase (file_length ≤ 1000,
  line_length warn at 140 / error at 200, etc.)
- CI: new lint job (macos-15, brew install swiftlint) runs on
  every app-source change
- CI: swift test --enable-code-coverage; generates an llvm-cov
  report and posts/updates a coverage summary comment on PRs