### PR TITLE
fix: reset recording state on audio start failure

### DIFF
--- a/Sources/VocaMac/Models/AppState.swift
+++ b/Sources/VocaMac/Models/AppState.swift
@@ -464,11 +464,21 @@ final class AppState: ObservableObject {
         // Start recording immediately for instant responsiveness.
         // The start sound is played concurrently — any brief bleed into the
         // mic buffer is negligible and handled well by WhisperKit's noise model.
-        audioEngine.startRecording(
+        let didStartRecording = audioEngine.startRecording(
             silenceThreshold: Float(silenceThreshold),
             silenceDuration: silenceDuration,
             maxDuration: TimeInterval(maxRecordingDuration)
         )
+
+        guard didStartRecording else {
+            VocaLogger.warning(.appState, "Audio engine failed to start — resetting recording state")
+            isRecording = false
+            audioLevel = 0.0
+            cursorOverlay.hide()
+            hotKeyManager.resetKeyState()
+            appStatus = .idle
+            return
+        }
 
         // Play start sound after mic is active (fire-and-forget)
         if soundEffectsEnabled {

--- a/Sources/VocaMac/Services/AudioEngine.swift
+++ b/Sources/VocaMac/Services/AudioEngine.swift
@@ -183,13 +183,15 @@ final class AudioEngine {
     ///   - silenceThreshold: RMS energy threshold below which audio is considered silence
     ///   - silenceDuration: Seconds of silence before triggering silence detection callback
     ///   - maxDuration: Maximum recording duration in seconds
+    /// - Returns: `true` when the engine is recording, otherwise `false`.
+    @discardableResult
     func startRecording(
         silenceThreshold: Float = 0.01,
         silenceDuration: Double = 2.0,
         maxDuration: TimeInterval = 60.0
-    ) {
+    ) -> Bool {
         lifecycleQueue.sync {
-            guard !self._isCurrentlyRecording else { return }
+            guard !self._isCurrentlyRecording else { return true }
 
             self.silenceThreshold = silenceThreshold
             self.silenceDuration = silenceDuration
@@ -208,7 +210,7 @@ final class AudioEngine {
                     "Invalid input format before recording start: sampleRate=\(inputFormat.sampleRate), channels=\(inputFormat.channelCount)"
                 )
                 recoverFromStartFailure(notifyAppState: true)
-                return
+                return false
             }
 
             // A previous failed start can leave a tap installed even when our
@@ -234,14 +236,15 @@ final class AudioEngine {
             if let exception {
                 VocaLogger.error(.audioEngine, "AVAudioEngine exception while starting recording: \(exception.localizedDescription)")
                 recoverFromStartFailure(notifyAppState: true)
-                return
+                return false
             }
 
             if let startError {
                 VocaLogger.error(.audioEngine, "Failed to start audio engine: \(startError.localizedDescription)")
                 recoverFromStartFailure(notifyAppState: true)
-                return
+                return false
             }
+            return true
         }
     }
 

--- a/Sources/VocaMac/Services/ServiceProtocols.swift
+++ b/Sources/VocaMac/Services/ServiceProtocols.swift
@@ -16,7 +16,8 @@ protocol AudioRecording: AnyObject {
     var onMaxDurationReached: (() -> Void)? { get set }
     var onAudioDeviceChanged: (() -> Void)? { get set }
 
-    func startRecording(silenceThreshold: Float, silenceDuration: Double, maxDuration: TimeInterval)
+    @discardableResult
+    func startRecording(silenceThreshold: Float, silenceDuration: Double, maxDuration: TimeInterval) -> Bool
     @discardableResult func stopRecording() -> [Float]
     func forceReset()
     func checkPermissionStatus() -> PermissionStatus

--- a/Tests/VocaMacTests/AppStateRecordingTests.swift
+++ b/Tests/VocaMacTests/AppStateRecordingTests.swift
@@ -362,6 +362,27 @@ final class AppStateRecordingGuardTests: XCTestCase {
     }
 
     @MainActor
+    func testStartRecordingFailureResetsRecordingState() async {
+        let (appState, mocks) = AppState.makeTestState()
+        mocks.audioEngine.startRecordingResult = false
+
+        await appState.startRecording()
+
+        XCTAssertEqual(appState.appStatus, .idle,
+            "failed audio start should return app state to idle")
+        XCTAssertFalse(appState.isRecording,
+            "failed audio start should clear recording state")
+        XCTAssertEqual(appState.audioLevel, 0.0,
+            "failed audio start should reset audio level")
+        XCTAssertEqual(mocks.cursorOverlay.hideCallCount, 1,
+            "failed audio start should hide the cursor overlay")
+        XCTAssertEqual(mocks.hotKeyManager.resetKeyStateCallCount, 1,
+            "failed audio start should reset hotkey state")
+        XCTAssertEqual(mocks.soundManager.startSoundCallCount, 0,
+            "failed audio start should not play the start sound")
+    }
+
+    @MainActor
     func testInitialStateIsIdle() {
         let (appState, _) = AppState.makeTestState()
         XCTAssertEqual(appState.appStatus, .idle)

--- a/Tests/VocaMacTests/Mocks/MockServices.swift
+++ b/Tests/VocaMacTests/Mocks/MockServices.swift
@@ -22,14 +22,17 @@ final class MockAudioEngine: AudioRecording {
     var lastMaxDuration: TimeInterval?
     var stopRecordingResult: [Float] = []
     var forceResetCallCount = 0
+    var startRecordingResult = true
 
     private var permissionStatus: PermissionStatus = .granted
 
-    func startRecording(silenceThreshold: Float, silenceDuration: Double, maxDuration: TimeInterval) {
-        isCurrentlyRecording = true
+    @discardableResult
+    func startRecording(silenceThreshold: Float, silenceDuration: Double, maxDuration: TimeInterval) -> Bool {
+        isCurrentlyRecording = startRecordingResult
         lastSilenceThreshold = silenceThreshold
         lastSilenceDuration = silenceDuration
         lastMaxDuration = maxDuration
+        return startRecordingResult
     }
 
     @discardableResult


### PR DESCRIPTION
## Summary
- Make `AudioRecording.startRecording` return whether audio capture actually started
- Reset `AppState`, cursor overlay, and hotkey state immediately when `AVAudioEngine` start fails
- Extend `MockAudioEngine` and add an AppState regression test for the failure path

## Context
Follow-up to #136. That PR fixed idle `AVAudioEngine` ownership; this closes the small UI-state gap noted during review.

## Tests
- `swift test --filter AppStateRecordingGuardTests/testStartRecordingFailureResetsRecordingState`
- `swift test`
