### PR TITLE
docs: add star history chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -458,3 +458,13 @@ AGPL-3.0 License - see [LICENSE](LICENSE) for details.
 Made with ❤️ for the macOS community!
 
 </div>
+
+## Star History
+
+<a href="https://www.star-history.com/?repos=jatinkrmalik%2Fvocamac&type=date&legend=top-left">
+ <picture>
+   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/chart?repos=jatinkrmalik/vocamac&type=date&theme=dark&legend=top-left" />
+   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/chart?repos=jatinkrmalik/vocamac&type=date&legend=top-left" />
+   <img alt="Star History Chart" src="https://api.star-history.com/chart?repos=jatinkrmalik/vocamac&type=date&legend=top-left" />
+ </picture>
+</a>

--- a/README.md
+++ b/README.md
@@ -451,14 +451,6 @@ Release builds of VocaMac are **Developer ID signed and notarized** by Apple. Ac
 
 AGPL-3.0 License - see [LICENSE](LICENSE) for details.
 
----
-
-<div align="center">
-  
-Made with ❤️ for the macOS community!
-
-</div>
-
 ## Star History
 
 <a href="https://www.star-history.com/?repos=jatinkrmalik%2Fvocamac&type=date&legend=top-left">
@@ -468,3 +460,11 @@ Made with ❤️ for the macOS community!
    <img alt="Star History Chart" src="https://api.star-history.com/chart?repos=jatinkrmalik/vocamac&type=date&legend=top-left" />
  </picture>
 </a>
+
+---
+
+<div align="center">
+  
+Made with ❤️ for the macOS community!
+
+</div>


### PR DESCRIPTION
Summary: Adds the Star History chart to the end of README. Testing: Not run (docs-only change).