### PR TITLE
feat: allow fixed audio input device

### DIFF
--- a/Sources/VocaMac/Models/AppState.swift
+++ b/Sources/VocaMac/Models/AppState.swift
@@ -99,6 +99,8 @@ final class AppState: ObservableObject {
     @AppStorage("vocamac.silenceThreshold") var silenceThreshold: Double = 0.01
     @AppStorage("vocamac.silenceDuration") var silenceDuration: Double = 2.0
     @AppStorage("vocamac.maxRecordingDuration") var maxRecordingDuration: Int = 60
+    @AppStorage("vocamac.selectedAudioDeviceID") var selectedAudioDeviceID: String = ""
+    @AppStorage("vocamac.selectedAudioDeviceName") var selectedAudioDeviceName: String = ""
     @AppStorage("vocamac.selectedModelSize") var selectedModelSize: String = ModelSize.tiny.rawValue
     @AppStorage("vocamac.selectedLanguage") var selectedLanguage: String = "auto"
     @AppStorage("vocamac.launchAtLogin") var launchAtLogin: Bool = false
@@ -486,7 +488,8 @@ final class AppState: ObservableObject {
         let didStartRecording = audioEngine.startRecording(
             silenceThreshold: Float(silenceThreshold),
             silenceDuration: silenceDuration,
-            maxDuration: TimeInterval(maxRecordingDuration)
+            maxDuration: TimeInterval(maxRecordingDuration),
+            preferredInputDeviceID: selectedAudioDeviceID.isEmpty ? nil : selectedAudioDeviceID
         )
 
         guard didStartRecording else {

--- a/Sources/VocaMac/Services/AudioEngine.swift
+++ b/Sources/VocaMac/Services/AudioEngine.swift
@@ -6,6 +6,8 @@
 
 import Foundation
 import AVFoundation
+import AudioToolbox
+import CoreAudio
 import VocaMacObjC
 
 final class AudioEngine {
@@ -188,7 +190,8 @@ final class AudioEngine {
     func startRecording(
         silenceThreshold: Float = 0.01,
         silenceDuration: Double = 2.0,
-        maxDuration: TimeInterval = 60.0
+        maxDuration: TimeInterval = 60.0,
+        preferredInputDeviceID: String? = nil
     ) -> Bool {
         lifecycleQueue.sync {
             guard !self._isCurrentlyRecording else { return true }
@@ -202,6 +205,7 @@ final class AudioEngine {
 
             let engine = acquireEngine()
             let inputNode = engine.inputNode
+            configurePreferredInputDevice(preferredInputDeviceID, on: inputNode)
             let inputFormat = inputNode.outputFormat(forBus: 0)
 
             guard isValidInputFormat(inputFormat) else {
@@ -490,22 +494,183 @@ final class AudioEngine {
 
     // MARK: - Audio Device Enumeration
 
-    /// List available audio input devices
+    /// List available audio input devices.
     static func availableInputDevices() -> [AudioDevice] {
-        let devices = AVCaptureDevice.DiscoverySession(
-            deviceTypes: [.builtInMicrophone, .externalUnknown],
-            mediaType: .audio,
-            position: .unspecified
-        ).devices
+        let defaultDeviceID = defaultInputAudioDeviceID()
 
-        let defaultDevice = AVCaptureDevice.default(for: .audio)
+        return inputAudioDeviceIDs().compactMap { deviceID in
+            guard let uid = audioDeviceUID(for: deviceID),
+                  let name = audioDeviceName(for: deviceID) else {
+                return nil
+            }
 
-        return devices.map { device in
-            AudioDevice(
-                id: device.uniqueID,
-                name: device.localizedName,
-                isDefault: device.uniqueID == defaultDevice?.uniqueID
+            return AudioDevice(
+                id: uid,
+                name: name,
+                isDefault: deviceID == defaultDeviceID,
+                sampleRate: audioDeviceSampleRate(for: deviceID),
+                channelCount: inputChannelCount(for: deviceID)
             )
+        }
+        .sorted { lhs, rhs in
+            if lhs.isDefault != rhs.isDefault { return lhs.isDefault }
+            return lhs.name.localizedCaseInsensitiveCompare(rhs.name) == .orderedAscending
+        }
+    }
+
+    /// Configure this engine's input unit to use a specific Core Audio device.
+    /// This is scoped to VocaMac's AudioUnit and does not change macOS' global default input.
+    private func configurePreferredInputDevice(_ preferredInputDeviceID: String?, on inputNode: AVAudioInputNode) {
+        guard let preferredInputDeviceID,
+              !preferredInputDeviceID.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+            VocaLogger.debug(.audioEngine, "Using system default input device")
+            return
+        }
+
+        guard let deviceID = Self.inputAudioDeviceID(forUID: preferredInputDeviceID) else {
+            VocaLogger.warning(.audioEngine, "Preferred input device unavailable, falling back to system default: \(preferredInputDeviceID)")
+            return
+        }
+
+        guard let audioUnit = inputNode.audioUnit else {
+            VocaLogger.warning(.audioEngine, "Input node has no AudioUnit; falling back to system default input")
+            return
+        }
+
+        var mutableDeviceID = deviceID
+        let status = AudioUnitSetProperty(
+            audioUnit,
+            kAudioOutputUnitProperty_CurrentDevice,
+            kAudioUnitScope_Global,
+            0,
+            &mutableDeviceID,
+            UInt32(MemoryLayout<AudioDeviceID>.size)
+        )
+
+        guard status == noErr else {
+            VocaLogger.warning(.audioEngine, "Failed to set preferred input device \(preferredInputDeviceID): OSStatus \(status)")
+            return
+        }
+
+        let deviceName = Self.audioDeviceName(for: deviceID) ?? preferredInputDeviceID
+        VocaLogger.info(.audioEngine, "Using preferred input device: \(deviceName)")
+    }
+
+    private static func inputAudioDeviceID(forUID uid: String) -> AudioDeviceID? {
+        inputAudioDeviceIDs().first { audioDeviceUID(for: $0) == uid }
+    }
+
+    private static func inputAudioDeviceIDs() -> [AudioDeviceID] {
+        var address = AudioObjectPropertyAddress(
+            mSelector: kAudioHardwarePropertyDevices,
+            mScope: kAudioObjectPropertyScopeGlobal,
+            mElement: kAudioObjectPropertyElementMain
+        )
+        var dataSize: UInt32 = 0
+        let systemObjectID = AudioObjectID(kAudioObjectSystemObject)
+
+        guard AudioObjectGetPropertyDataSize(systemObjectID, &address, 0, nil, &dataSize) == noErr else {
+            VocaLogger.warning(.audioEngine, "Failed to read Core Audio device list size")
+            return []
+        }
+
+        let deviceCount = Int(dataSize) / MemoryLayout<AudioDeviceID>.size
+        guard deviceCount > 0 else { return [] }
+
+        var deviceIDs = [AudioDeviceID](repeating: AudioDeviceID(kAudioObjectUnknown), count: deviceCount)
+        let status = AudioObjectGetPropertyData(systemObjectID, &address, 0, nil, &dataSize, &deviceIDs)
+        guard status == noErr else {
+            VocaLogger.warning(.audioEngine, "Failed to read Core Audio device list: OSStatus \(status)")
+            return []
+        }
+
+        return deviceIDs.filter { inputChannelCount(for: $0) > 0 }
+    }
+
+    private static func defaultInputAudioDeviceID() -> AudioDeviceID? {
+        var address = AudioObjectPropertyAddress(
+            mSelector: kAudioHardwarePropertyDefaultInputDevice,
+            mScope: kAudioObjectPropertyScopeGlobal,
+            mElement: kAudioObjectPropertyElementMain
+        )
+        var deviceID = AudioDeviceID(kAudioObjectUnknown)
+        var dataSize = UInt32(MemoryLayout<AudioDeviceID>.size)
+        let status = AudioObjectGetPropertyData(
+            AudioObjectID(kAudioObjectSystemObject),
+            &address,
+            0,
+            nil,
+            &dataSize,
+            &deviceID
+        )
+
+        guard status == noErr, deviceID != AudioDeviceID(kAudioObjectUnknown) else {
+            return nil
+        }
+        return deviceID
+    }
+
+    private static func audioDeviceUID(for deviceID: AudioDeviceID) -> String? {
+        stringProperty(kAudioDevicePropertyDeviceUID, for: deviceID)
+    }
+
+    private static func audioDeviceName(for deviceID: AudioDeviceID) -> String? {
+        stringProperty(kAudioObjectPropertyName, for: deviceID)
+    }
+
+    private static func stringProperty(_ selector: AudioObjectPropertySelector, for deviceID: AudioDeviceID) -> String? {
+        var address = AudioObjectPropertyAddress(
+            mSelector: selector,
+            mScope: kAudioObjectPropertyScopeGlobal,
+            mElement: kAudioObjectPropertyElementMain
+        )
+        var value: Unmanaged<CFString>?
+        var dataSize = UInt32(MemoryLayout<Unmanaged<CFString>?>.size)
+        let status = AudioObjectGetPropertyData(deviceID, &address, 0, nil, &dataSize, &value)
+
+        guard status == noErr, let value else { return nil }
+        return value.takeRetainedValue() as String
+    }
+
+    private static func audioDeviceSampleRate(for deviceID: AudioDeviceID) -> Double {
+        var address = AudioObjectPropertyAddress(
+            mSelector: kAudioDevicePropertyNominalSampleRate,
+            mScope: kAudioObjectPropertyScopeGlobal,
+            mElement: kAudioObjectPropertyElementMain
+        )
+        var sampleRate = Float64(0)
+        var dataSize = UInt32(MemoryLayout<Float64>.size)
+        let status = AudioObjectGetPropertyData(deviceID, &address, 0, nil, &dataSize, &sampleRate)
+
+        guard status == noErr else { return 0 }
+        return sampleRate
+    }
+
+    private static func inputChannelCount(for deviceID: AudioDeviceID) -> Int {
+        var address = AudioObjectPropertyAddress(
+            mSelector: kAudioDevicePropertyStreamConfiguration,
+            mScope: kAudioObjectPropertyScopeInput,
+            mElement: kAudioObjectPropertyElementMain
+        )
+        var dataSize: UInt32 = 0
+
+        guard AudioObjectGetPropertyDataSize(deviceID, &address, 0, nil, &dataSize) == noErr,
+              dataSize > 0 else {
+            return 0
+        }
+
+        let rawPointer = UnsafeMutableRawPointer.allocate(
+            byteCount: Int(dataSize),
+            alignment: MemoryLayout<AudioBufferList>.alignment
+        )
+        defer { rawPointer.deallocate() }
+
+        let bufferList = rawPointer.bindMemory(to: AudioBufferList.self, capacity: 1)
+        let status = AudioObjectGetPropertyData(deviceID, &address, 0, nil, &dataSize, bufferList)
+        guard status == noErr else { return 0 }
+
+        return UnsafeMutableAudioBufferListPointer(bufferList).reduce(0) { total, buffer in
+            total + Int(buffer.mNumberChannels)
         }
     }
 }
@@ -517,6 +682,8 @@ struct AudioDevice: Identifiable, Hashable {
     let id: String
     let name: String
     let isDefault: Bool
+    let sampleRate: Double
+    let channelCount: Int
 }
 
 // MARK: - AudioRecording Conformance

--- a/Sources/VocaMac/Services/ServiceProtocols.swift
+++ b/Sources/VocaMac/Services/ServiceProtocols.swift
@@ -17,7 +17,12 @@ protocol AudioRecording: AnyObject {
     var onAudioDeviceChanged: (() -> Void)? { get set }
 
     @discardableResult
-    func startRecording(silenceThreshold: Float, silenceDuration: Double, maxDuration: TimeInterval) -> Bool
+    func startRecording(
+        silenceThreshold: Float,
+        silenceDuration: Double,
+        maxDuration: TimeInterval,
+        preferredInputDeviceID: String?
+    ) -> Bool
     @discardableResult func stopRecording() -> [Float]
     func forceReset()
     func checkPermissionStatus() -> PermissionStatus

--- a/Sources/VocaMac/Views/SettingsView.swift
+++ b/Sources/VocaMac/Views/SettingsView.swift
@@ -595,6 +595,19 @@ struct AudioSettingsTab: View {
             }
 
             Section("Input Device") {
+                Picker("Microphone", selection: $appState.selectedAudioDeviceID) {
+                    Text("System Default").tag("")
+                    if selectedAudioDeviceIsUnavailable {
+                        Text("\(selectedAudioDeviceDisplayName) (Unavailable)").tag(appState.selectedAudioDeviceID)
+                    }
+                    ForEach(audioDevices) { device in
+                        Text(audioDeviceLabel(for: device)).tag(device.id)
+                    }
+                }
+                .onChange(of: appState.selectedAudioDeviceID) { _ in
+                    syncSelectedAudioDeviceName()
+                }
+
                 if audioDevices.isEmpty {
                     HStack {
                         Image(systemName: "exclamationmark.triangle")
@@ -602,42 +615,78 @@ struct AudioSettingsTab: View {
                         Text("No audio input devices found")
                             .foregroundStyle(.secondary)
                     }
-                } else {
-                    ForEach(audioDevices) { device in
-                        HStack {
-                            Image(systemName: device.isDefault ? "mic.circle.fill" : "mic.circle")
-                                .foregroundStyle(device.isDefault ? .blue : .secondary)
-                            VStack(alignment: .leading) {
-                                Text(device.name)
-                                    .font(.callout)
-                                if device.isDefault {
-                                    Text("System Default")
-                                        .font(.caption2)
-                                        .foregroundStyle(.blue)
-                                }
-                            }
-                            Spacer()
-                            if device.isDefault {
-                                Image(systemName: "checkmark")
-                                    .foregroundStyle(.blue)
-                            }
-                        }
+                } else if selectedAudioDeviceIsUnavailable {
+                    HStack(alignment: .top) {
+                        Image(systemName: "exclamationmark.triangle")
+                            .foregroundStyle(.orange)
+                        Text("\(selectedAudioDeviceDisplayName) is unavailable. VocaMac will use System Default until it reconnects.")
+                            .foregroundStyle(.secondary)
                     }
+                } else if let selectedAudioDevice {
+                    HStack {
+                        Image(systemName: "mic.circle.fill")
+                            .foregroundStyle(.blue)
+                        Text("VocaMac will record from \(selectedAudioDevice.name) without changing macOS' system default input.")
+                            .foregroundStyle(.secondary)
+                    }
+                } else {
+                    Text(systemDefaultInputDescription)
+                        .foregroundStyle(.secondary)
                 }
 
                 Button("Refresh Devices") {
-                    audioDevices = AudioEngine.availableInputDevices()
+                    refreshAudioDevices()
                 }
                 .controlSize(.small)
 
-                Text("VocaMac uses your system default input device. Change it in System Settings → Sound → Input.")
+                Text("Choose System Default to follow macOS, or pin VocaMac to a specific microphone.")
                     .font(.caption)
                     .foregroundStyle(.secondary)
             }
         }
         .formStyle(.grouped)
         .onAppear {
-            audioDevices = AudioEngine.availableInputDevices()
+            refreshAudioDevices()
+        }
+    }
+
+    private var selectedAudioDevice: AudioDevice? {
+        guard !appState.selectedAudioDeviceID.isEmpty else { return nil }
+        return audioDevices.first { $0.id == appState.selectedAudioDeviceID }
+    }
+
+    private var selectedAudioDeviceIsUnavailable: Bool {
+        !appState.selectedAudioDeviceID.isEmpty && selectedAudioDevice == nil
+    }
+
+    private var selectedAudioDeviceDisplayName: String {
+        appState.selectedAudioDeviceName.isEmpty ? "Selected microphone" : appState.selectedAudioDeviceName
+    }
+
+    private var systemDefaultInputDescription: String {
+        if let defaultDevice = audioDevices.first(where: { $0.isDefault }) {
+            return "VocaMac will follow macOS' system default input: \(defaultDevice.name)."
+        }
+        return "VocaMac will follow macOS' system default input."
+    }
+
+    private func audioDeviceLabel(for device: AudioDevice) -> String {
+        device.isDefault ? "\(device.name) (System Default)" : device.name
+    }
+
+    private func refreshAudioDevices() {
+        audioDevices = AudioEngine.availableInputDevices()
+        syncSelectedAudioDeviceName()
+    }
+
+    private func syncSelectedAudioDeviceName() {
+        guard !appState.selectedAudioDeviceID.isEmpty else {
+            appState.selectedAudioDeviceName = ""
+            return
+        }
+
+        if let selectedAudioDevice {
+            appState.selectedAudioDeviceName = selectedAudioDevice.name
         }
     }
 

--- a/Tests/VocaMacTests/AppStateRecordingTests.swift
+++ b/Tests/VocaMacTests/AppStateRecordingTests.swift
@@ -123,6 +123,15 @@ final class AppStateRecordingTests: XCTestCase {
                       "Default language should be 'auto'")
     }
 
+    func testSelectedAudioDeviceDefaultsToSystemDefault() {
+        let (appState, _) = AppState.makeTestState()
+
+        XCTAssertEqual(appState.selectedAudioDeviceID, "",
+                      "Default audio input should follow the system default")
+        XCTAssertEqual(appState.selectedAudioDeviceName, "",
+                      "No device name should be persisted for system default")
+    }
+
     func testActivationModeDefault() {
         let (appState, _) = AppState.makeTestState()
 
@@ -189,6 +198,26 @@ final class AppStateRecordingTests: XCTestCase {
         appState.triggerStartupIfNeeded()
         appState.triggerStartupIfNeeded()
         appState.triggerStartupIfNeeded()
+    }
+
+    func testStartRecordingPassesNilDeviceForSystemDefault() async {
+        let (appState, mocks) = AppState.makeTestState()
+        appState.selectedAudioDeviceID = ""
+
+        await appState.startRecording()
+
+        XCTAssertNil(mocks.audioEngine.lastPreferredInputDeviceID,
+                     "System Default should not pass a preferred input device")
+    }
+
+    func testStartRecordingPassesSelectedAudioDeviceID() async {
+        let (appState, mocks) = AppState.makeTestState()
+        appState.selectedAudioDeviceID = "coreaudio-device-uid"
+
+        await appState.startRecording()
+
+        XCTAssertEqual(mocks.audioEngine.lastPreferredInputDeviceID, "coreaudio-device-uid",
+                       "Selected audio device ID should be forwarded to AudioEngine")
     }
 }
 

--- a/Tests/VocaMacTests/Mocks/MockServices.swift
+++ b/Tests/VocaMacTests/Mocks/MockServices.swift
@@ -20,6 +20,7 @@ final class MockAudioEngine: AudioRecording {
     var lastSilenceThreshold: Float?
     var lastSilenceDuration: Double?
     var lastMaxDuration: TimeInterval?
+    var lastPreferredInputDeviceID: String?
     var stopRecordingResult: [Float] = []
     var forceResetCallCount = 0
     var startRecordingResult = true
@@ -27,11 +28,17 @@ final class MockAudioEngine: AudioRecording {
     private var permissionStatus: PermissionStatus = .granted
 
     @discardableResult
-    func startRecording(silenceThreshold: Float, silenceDuration: Double, maxDuration: TimeInterval) -> Bool {
+    func startRecording(
+        silenceThreshold: Float,
+        silenceDuration: Double,
+        maxDuration: TimeInterval,
+        preferredInputDeviceID: String?
+    ) -> Bool {
         isCurrentlyRecording = startRecordingResult
         lastSilenceThreshold = silenceThreshold
         lastSilenceDuration = silenceDuration
         lastMaxDuration = maxDuration
+        lastPreferredInputDeviceID = preferredInputDeviceID
         return startRecordingResult
     }
 
@@ -349,6 +356,9 @@ final class MockTextInjector: TextInjecting {
 extension AppState {
     @MainActor
     static func makeTestState() -> (appState: AppState, mocks: TestMocks) {
+        UserDefaults.standard.removeObject(forKey: "vocamac.selectedAudioDeviceID")
+        UserDefaults.standard.removeObject(forKey: "vocamac.selectedAudioDeviceName")
+
         let audioEngine = MockAudioEngine()
         let soundManager = MockSoundManager()
         let hotKeyManager = MockHotKeyManager()

--- a/docs/DATA_MODEL.md
+++ b/docs/DATA_MODEL.md
@@ -292,6 +292,7 @@ struct UserSettings {
     var silenceDuration: Double = 2.0           // seconds of silence to auto-stop
     var maxRecordingDuration: Int = 60          // seconds
     var selectedAudioDeviceID: String?          // nil = system default
+    var selectedAudioDeviceName: String?        // last known display name for unavailable-device messaging
 
     // Model
     var selectedModelSize: ModelSize = .tiny


### PR DESCRIPTION
## Summary

- Add a persisted VocaMac input-device preference with System Default as the existing default behavior.
- Enumerate input devices through Core Audio and bind the recording engine's input AudioUnit to the selected device without changing macOS' global default input.
- Replace the read-only Settings → Audio device list with a microphone picker, including unavailable-device fallback messaging.
- Update mocks/tests for the new audio-device contract and document the stored display name.

Fixes #154.

## Verification

- `swift test` — 193 tests passed, 1 skipped due to missing Accessibility permission.
- `swift build`
