### PR TITLE
fix: set vocamac cask sha256 for v0.6.2

### DIFF
--- a/homebrew/Casks/vocamac-nightly.rb
+++ b/homebrew/Casks/vocamac-nightly.rb
@@ -5,13 +5,12 @@ cask "vocamac-nightly" do
   url "https://github.com/jatinkrmalik/vocamac/releases/download/nightly/VocaMac-nightly-arm64.dmg",
       verified: "github.com/jatinkrmalik/vocamac/"
   name "VocaMac Nightly"
-  desc "Nightly build of VocaMac — local voice-to-text dictation for macOS"
-  homepage "https://vocamac.com"
+  desc "Nightly build of VocaMac — local voice-to-text dictation"
+  homepage "https://vocamac.com/"
 
   conflicts_with cask: "vocamac"
-
   depends_on arch: :arm64
-  depends_on macos: ">= :ventura"
+  depends_on macos: :ventura
 
   app "VocaMac.app"
 

--- a/homebrew/Casks/vocamac.rb
+++ b/homebrew/Casks/vocamac.rb
@@ -1,25 +1,21 @@
 cask "vocamac" do
   version "0.6.2"
+  sha256 "9de43a316ac885deb7b84ead8fe292d16432cce9968d53941c855cc8ff3bed28"
 
   url "https://github.com/jatinkrmalik/vocamac/releases/download/v#{version}/VocaMac-#{version}-arm64.dmg",
-      verified: "github.com/jatinkrmalik/vocamac"
+      verified: "github.com/jatinkrmalik/vocamac/"
   name "VocaMac"
-  desc "Local voice-to-text dictation for macOS, powered by WhisperKit"
-  homepage "https://vocamac.com"
-
-  sha256 "9de43a316ac885deb7b84ead8fe292d16432cce9968d53941c855cc8ff3bed28"
+  desc "Local voice-to-text dictation powered by WhisperKit"
+  homepage "https://vocamac.com/"
 
   livecheck do
     url :url
     strategy :github_latest
   end
 
-  license "AGPL-3.0-only"
-
-  depends_on arch: :arm64
-  depends_on macos: ">= :ventura"
-
   conflicts_with cask: "vocamac-nightly"
+  depends_on arch: :arm64
+  depends_on macos: :ventura
 
   app "VocaMac.app"
 

--- a/homebrew/Casks/vocamac.rb
+++ b/homebrew/Casks/vocamac.rb
@@ -7,9 +7,7 @@ cask "vocamac" do
   desc "Local voice-to-text dictation for macOS, powered by WhisperKit"
   homepage "https://vocamac.com"
 
-  # :no_check is used here because the sha256 will be injected by the
-  # automated cask update workflow when a new release is published.
-  sha256 :no_check
+  sha256 "9de43a316ac885deb7b84ead8fe292d16432cce9968d53941c855cc8ff3bed28"
 
   livecheck do
     url :url


### PR DESCRIPTION
Syncs the main repo cask with the tap repo. Replaces `sha256 :no_check` with the actual v0.6.2 DMG checksum.