### PR TITLE
feat: detect Homebrew cask installs and adjust update flow

### DIFF
--- a/Sources/VocaMac/Models/UpdateInfo.swift
+++ b/Sources/VocaMac/Models/UpdateInfo.swift
@@ -61,6 +61,7 @@ enum UpdateState: Equatable {
     case idle
     case checking
     case updateAvailable(UpdateInfo)
+    case updateAvailableViaHomebrew(info: UpdateInfo)
     case upToDate
     case downloading(progress: Double, bytesDownloaded: Int64, totalBytes: Int64, estimatedSecondsRemaining: Double)
     case verifying

--- a/Sources/VocaMac/Models/UpdateInfo.swift
+++ b/Sources/VocaMac/Models/UpdateInfo.swift
@@ -57,11 +57,19 @@ struct UpdateInfo: Equatable {
     let sha256: String?
 }
 
+struct HomebrewInstall: Equatable {
+    let caskToken: String
+
+    var upgradeCommand: String {
+        "brew upgrade --cask \(caskToken)"
+    }
+}
+
 enum UpdateState: Equatable {
     case idle
     case checking
     case updateAvailable(UpdateInfo)
-    case updateAvailableViaHomebrew(info: UpdateInfo)
+    case updateAvailableViaHomebrew(info: UpdateInfo, install: HomebrewInstall)
     case upToDate
     case downloading(progress: Double, bytesDownloaded: Int64, totalBytes: Int64, estimatedSecondsRemaining: Double)
     case verifying

--- a/Sources/VocaMac/Services/UpdateChecker.swift
+++ b/Sources/VocaMac/Services/UpdateChecker.swift
@@ -38,27 +38,68 @@ enum UpdateCheckerError: LocalizedError {
 final class UpdateChecker: ObservableObject {
     @Published var updateState: UpdateState = .idle
 
-    var isHomebrewInstalled: Bool {
-        if let override = overrideHomebrewInstalled { return override }
-        return Self.isHomebrewPath(Bundle.main.bundlePath)
+    enum HomebrewInstallOverride {
+        case installed(HomebrewInstall)
+        case notInstalled
     }
 
-    var overrideHomebrewInstalled: Bool?
+    var homebrewInstall: HomebrewInstall? {
+        if let override = overrideHomebrewInstall {
+            switch override {
+            case .installed(let install):
+                return install
+            case .notInstalled:
+                return nil
+            }
+        }
+        return Self.detectHomebrewInstall(bundlePath: Bundle.main.bundlePath)
+    }
+
+    var isHomebrewInstalled: Bool {
+        homebrewInstall != nil
+    }
+
+    var overrideHomebrewInstall: HomebrewInstallOverride?
 
     /// Returns the UpdateInfo if the checker is in any active update flow
     /// (available, downloading, verifying, ready to install, or error after a download attempt).
     /// Used to keep banners and sheets visible during the entire update process.
     var activeUpdateInfo: UpdateInfo? {
         switch updateState {
-        case .updateAvailable(let info), .updateAvailableViaHomebrew(let info):
+        case .updateAvailable(let info), .updateAvailableViaHomebrew(let info, _):
             return info
         default:
             return lastKnownUpdateInfo
         }
     }
 
-    nonisolated static func isHomebrewPath(_ path: String) -> Bool {
-        path.contains("/Caskroom/")
+    nonisolated static let supportedHomebrewCaskTokens = ["vocamac", "vocamac-nightly"]
+
+    nonisolated static let defaultHomebrewCaskroomRoots = [
+        URL(fileURLWithPath: "/opt/homebrew/Caskroom", isDirectory: true),
+        URL(fileURLWithPath: "/usr/local/Caskroom", isDirectory: true)
+    ]
+
+    nonisolated static func detectHomebrewInstall(
+        bundlePath: String,
+        caskroomRoots: [URL] = defaultHomebrewCaskroomRoots,
+        fileManager: FileManager = .default
+    ) -> HomebrewInstall? {
+        let normalizedBundlePath = normalizedPath(bundlePath)
+
+        for caskToken in supportedHomebrewCaskTokens {
+            for caskroomRoot in caskroomRoots {
+                let caskRoot = caskroomRoot.appendingPathComponent(caskToken, isDirectory: true)
+                guard hasHomebrewReceipt(in: caskRoot, fileManager: fileManager) else { continue }
+
+                if isPath(normalizedBundlePath, inside: caskRoot.path) ||
+                    caskRootContainsBundlePath(normalizedBundlePath, caskRoot: caskRoot, fileManager: fileManager) {
+                    return HomebrewInstall(caskToken: caskToken)
+                }
+            }
+        }
+
+        return nil
     }
 
     /// Stored when an update is found so views can reference it across state transitions.
@@ -111,9 +152,9 @@ final class UpdateChecker: ObservableObject {
                     throw UpdateCheckerError.noDMGAsset
                 }
                 lastKnownUpdateInfo = info
-                if isHomebrewInstalled {
-                    updateState = .updateAvailableViaHomebrew(info: info)
-                    VocaLogger.info(.updateChecker, "Update available via Homebrew: \(info.tagName)")
+                if let homebrewInstall {
+                    updateState = .updateAvailableViaHomebrew(info: info, install: homebrewInstall)
+                    VocaLogger.info(.updateChecker, "Update available via Homebrew cask \(homebrewInstall.caskToken): \(info.tagName)")
                 } else {
                     updateState = .updateAvailable(info)
                     VocaLogger.info(.updateChecker, "Update available: \(info.tagName)")
@@ -262,6 +303,47 @@ final class UpdateChecker: ObservableObject {
             dmgSize: dmgAsset.size,
             sha256: sha256
         )
+    }
+
+    private nonisolated static func hasHomebrewReceipt(in caskRoot: URL, fileManager: FileManager) -> Bool {
+        let receipt = caskRoot
+            .appendingPathComponent(".metadata", isDirectory: true)
+            .appendingPathComponent("INSTALL_RECEIPT.json")
+        return fileManager.fileExists(atPath: receipt.path)
+    }
+
+    private nonisolated static func caskRootContainsBundlePath(
+        _ bundlePath: String,
+        caskRoot: URL,
+        fileManager: FileManager
+    ) -> Bool {
+        let versionDirectories = (try? fileManager.contentsOfDirectory(
+            at: caskRoot,
+            includingPropertiesForKeys: nil,
+            options: [.skipsHiddenFiles]
+        )) ?? []
+
+        for versionDirectory in versionDirectories {
+            let stagedApp = versionDirectory.appendingPathComponent("VocaMac.app", isDirectory: true)
+            guard fileManager.fileExists(atPath: stagedApp.path) else { continue }
+
+            let stagedPath = normalizedPath(stagedApp.path)
+            let resolvedPath = normalizedPath(stagedApp.resolvingSymlinksInPath().path)
+            if stagedPath == bundlePath || resolvedPath == bundlePath {
+                return true
+            }
+        }
+
+        return false
+    }
+
+    private nonisolated static func isPath(_ path: String, inside directoryPath: String) -> Bool {
+        let normalizedDirectoryPath = normalizedPath(directoryPath)
+        return path == normalizedDirectoryPath || path.hasPrefix(normalizedDirectoryPath + "/")
+    }
+
+    private nonisolated static func normalizedPath(_ path: String) -> String {
+        URL(fileURLWithPath: path).standardizedFileURL.path
     }
 
     // MARK: - Download with Progress

--- a/Sources/VocaMac/Services/UpdateChecker.swift
+++ b/Sources/VocaMac/Services/UpdateChecker.swift
@@ -57,7 +57,7 @@ final class UpdateChecker: ObservableObject {
         }
     }
 
-    static func isHomebrewPath(_ path: String) -> Bool {
+    nonisolated static func isHomebrewPath(_ path: String) -> Bool {
         path.contains("/Caskroom/")
     }
 

--- a/Sources/VocaMac/Services/UpdateChecker.swift
+++ b/Sources/VocaMac/Services/UpdateChecker.swift
@@ -38,16 +38,27 @@ enum UpdateCheckerError: LocalizedError {
 final class UpdateChecker: ObservableObject {
     @Published var updateState: UpdateState = .idle
 
+    var isHomebrewInstalled: Bool {
+        if let override = overrideHomebrewInstalled { return override }
+        return Self.isHomebrewPath(Bundle.main.bundlePath)
+    }
+
+    var overrideHomebrewInstalled: Bool?
+
     /// Returns the UpdateInfo if the checker is in any active update flow
     /// (available, downloading, verifying, ready to install, or error after a download attempt).
     /// Used to keep banners and sheets visible during the entire update process.
     var activeUpdateInfo: UpdateInfo? {
         switch updateState {
-        case .updateAvailable(let info):
+        case .updateAvailable(let info), .updateAvailableViaHomebrew(let info):
             return info
         default:
             return lastKnownUpdateInfo
         }
+    }
+
+    static func isHomebrewPath(_ path: String) -> Bool {
+        path.contains("/Caskroom/")
     }
 
     /// Stored when an update is found so views can reference it across state transitions.
@@ -76,11 +87,15 @@ final class UpdateChecker: ObservableObject {
     }
 
     func checkForUpdates() async {
+        await checkForUpdates(releaseProvider: { try await self.fetchLatestRelease() })
+    }
+
+    func checkForUpdates(releaseProvider: () async throws -> GitHubRelease) async {
         guard updateState != .checking else { return }
         updateState = .checking
 
         do {
-            let release = try await fetchLatestRelease()
+            let release = try await releaseProvider()
             UserDefaults.standard.set(Date().timeIntervalSince1970, forKey: lastCheckKey)
 
             let remoteVersion = normalizeVersion(release.tagName)
@@ -96,8 +111,13 @@ final class UpdateChecker: ObservableObject {
                     throw UpdateCheckerError.noDMGAsset
                 }
                 lastKnownUpdateInfo = info
-                updateState = .updateAvailable(info)
-                VocaLogger.info(.updateChecker, "Update available: \(info.tagName)")
+                if isHomebrewInstalled {
+                    updateState = .updateAvailableViaHomebrew(info: info)
+                    VocaLogger.info(.updateChecker, "Update available via Homebrew: \(info.tagName)")
+                } else {
+                    updateState = .updateAvailable(info)
+                    VocaLogger.info(.updateChecker, "Update available: \(info.tagName)")
+                }
             } else {
                 updateState = .upToDate
             }

--- a/Sources/VocaMac/Views/SettingsView.swift
+++ b/Sources/VocaMac/Views/SettingsView.swift
@@ -682,9 +682,12 @@ struct AboutTab: View {
             Button {
                 Task { @MainActor in
                     await appState.updateChecker.checkForUpdates()
-                    if case .updateAvailable(let info) = appState.updateChecker.updateState {
+                    switch appState.updateChecker.updateState {
+                    case .updateAvailable(let info), .updateAvailableViaHomebrew(let info):
                         updateInfoForSheet = info
                         showingUpdateSheet = true
+                    default:
+                        break
                     }
                 }
             } label: {
@@ -792,6 +795,8 @@ struct AboutTab: View {
             return "You are on the latest version."
         case .updateAvailable(let info):
             return "Update available: \(info.tagName)"
+        case .updateAvailableViaHomebrew:
+            return "Update available via Homebrew. Run: brew upgrade --cask vocamac"
         case .error(let message):
             return message
         case .downloading(let progress, _, _, _):

--- a/Sources/VocaMac/Views/SettingsView.swift
+++ b/Sources/VocaMac/Views/SettingsView.swift
@@ -683,7 +683,7 @@ struct AboutTab: View {
                 Task { @MainActor in
                     await appState.updateChecker.checkForUpdates()
                     switch appState.updateChecker.updateState {
-                    case .updateAvailable(let info), .updateAvailableViaHomebrew(let info):
+                    case .updateAvailable(let info), .updateAvailableViaHomebrew(let info, _):
                         updateInfoForSheet = info
                         showingUpdateSheet = true
                     default:
@@ -795,8 +795,8 @@ struct AboutTab: View {
             return "You are on the latest version."
         case .updateAvailable(let info):
             return "Update available: \(info.tagName)"
-        case .updateAvailableViaHomebrew:
-            return "Update available via Homebrew. Run: brew upgrade --cask vocamac"
+        case .updateAvailableViaHomebrew(_, let install):
+            return "Update available via Homebrew. Run: \(install.upgradeCommand)"
         case .error(let message):
             return message
         case .downloading(let progress, _, _, _):

--- a/Sources/VocaMac/Views/UpdateView.swift
+++ b/Sources/VocaMac/Views/UpdateView.swift
@@ -109,6 +109,23 @@ struct UpdateDetailView: View {
                 }
                 .buttonStyle(.borderedProminent)
             }
+        case .updateAvailableViaHomebrew:
+            VStack(alignment: .leading, spacing: 10) {
+                Text("Updates are managed by Homebrew.")
+                    .foregroundStyle(.secondary)
+                HStack {
+                    Text("brew upgrade --cask vocamac")
+                        .font(.system(.callout, design: .monospaced))
+                        .textSelection(.enabled)
+                    Spacer()
+                    Button("Copy Command") {
+                        let pasteboard = NSPasteboard.general
+                        pasteboard.clearContents()
+                        pasteboard.setString("brew upgrade --cask vocamac", forType: .string)
+                    }
+                    .buttonStyle(.bordered)
+                }
+            }
         case .downloading(let progress, let bytesDownloaded, let totalBytes, let eta):
             VStack(alignment: .leading, spacing: 8) {
                 HStack {

--- a/Sources/VocaMac/Views/UpdateView.swift
+++ b/Sources/VocaMac/Views/UpdateView.swift
@@ -109,19 +109,19 @@ struct UpdateDetailView: View {
                 }
                 .buttonStyle(.borderedProminent)
             }
-        case .updateAvailableViaHomebrew:
+        case .updateAvailableViaHomebrew(_, let install):
             VStack(alignment: .leading, spacing: 10) {
                 Text("Updates are managed by Homebrew.")
                     .foregroundStyle(.secondary)
                 HStack {
-                    Text("brew upgrade --cask vocamac")
+                    Text(install.upgradeCommand)
                         .font(.system(.callout, design: .monospaced))
                         .textSelection(.enabled)
                     Spacer()
                     Button("Copy Command") {
                         let pasteboard = NSPasteboard.general
                         pasteboard.clearContents()
-                        pasteboard.setString("brew upgrade --cask vocamac", forType: .string)
+                        pasteboard.setString(install.upgradeCommand, forType: .string)
                     }
                     .buttonStyle(.bordered)
                 }

--- a/Tests/VocaMacTests/UpdateCheckerTests.swift
+++ b/Tests/VocaMacTests/UpdateCheckerTests.swift
@@ -33,4 +33,77 @@ final class UpdateCheckerTests: XCTestCase {
         XCTAssertEqual(release.assets.count, 1)
         XCTAssertEqual(release.assets.first?.name, "VocaMac-0.4.0-arm64.dmg")
     }
+
+    func testIsHomebrewPathDetectsCaskroom() {
+        XCTAssertTrue(UpdateChecker.isHomebrewPath("/opt/homebrew/Caskroom/vocamac/0.5.0/VocaMac.app"))
+        XCTAssertTrue(UpdateChecker.isHomebrewPath("/usr/local/Caskroom/vocamac/0.5.0/VocaMac.app"))
+        XCTAssertFalse(UpdateChecker.isHomebrewPath("/Applications/VocaMac.app"))
+        XCTAssertFalse(UpdateChecker.isHomebrewPath("/Users/john/Applications/VocaMac.app"))
+    }
+
+    @MainActor
+    func testCheckForUpdatesTransitionsToHomebrewStateWhenInstalledViaHomebrew() async {
+        let checker = UpdateChecker()
+        checker.overrideHomebrewInstalled = true
+
+        let mockRelease = GitHubRelease(
+            tagName: "v99.99.99",
+            name: "v99.99.99",
+            body: "Test release",
+            htmlURL: URL(string: "https://example.com")!,
+            prerelease: false,
+            draft: false,
+            publishedAt: "2026-01-01T00:00:00Z",
+            assets: [
+                GitHubAsset(
+                    name: "VocaMac-99.99.99-arm64.dmg",
+                    size: 1234,
+                    browserDownloadURL: URL(string: "https://example.com/dmg")!,
+                    contentType: "application/x-apple-diskimage",
+                    digest: nil
+                )
+            ]
+        )
+
+        await checker.checkForUpdates(releaseProvider: { mockRelease })
+
+        if case .updateAvailableViaHomebrew(let info) = checker.updateState {
+            XCTAssertEqual(info.tagName, "v99.99.99")
+        } else {
+            XCTFail("Expected .updateAvailableViaHomebrew but got \(String(describing: checker.updateState))")
+        }
+    }
+
+    @MainActor
+    func testCheckForUpdatesTransitionsToUpdateAvailableWhenNotHomebrew() async {
+        let checker = UpdateChecker()
+        checker.overrideHomebrewInstalled = false
+
+        let mockRelease = GitHubRelease(
+            tagName: "v99.99.99",
+            name: "v99.99.99",
+            body: "Test release",
+            htmlURL: URL(string: "https://example.com")!,
+            prerelease: false,
+            draft: false,
+            publishedAt: "2026-01-01T00:00:00Z",
+            assets: [
+                GitHubAsset(
+                    name: "VocaMac-99.99.99-arm64.dmg",
+                    size: 1234,
+                    browserDownloadURL: URL(string: "https://example.com/dmg")!,
+                    contentType: "application/x-apple-diskimage",
+                    digest: nil
+                )
+            ]
+        )
+
+        await checker.checkForUpdates(releaseProvider: { mockRelease })
+
+        if case .updateAvailable(let info) = checker.updateState {
+            XCTAssertEqual(info.tagName, "v99.99.99")
+        } else {
+            XCTFail("Expected .updateAvailable but got \(String(describing: checker.updateState))")
+        }
+    }
 }

--- a/Tests/VocaMacTests/UpdateCheckerTests.swift
+++ b/Tests/VocaMacTests/UpdateCheckerTests.swift
@@ -34,17 +34,45 @@ final class UpdateCheckerTests: XCTestCase {
         XCTAssertEqual(release.assets.first?.name, "VocaMac-0.4.0-arm64.dmg")
     }
 
-    func testIsHomebrewPathDetectsCaskroom() {
-        XCTAssertTrue(UpdateChecker.isHomebrewPath("/opt/homebrew/Caskroom/vocamac/0.5.0/VocaMac.app"))
-        XCTAssertTrue(UpdateChecker.isHomebrewPath("/usr/local/Caskroom/vocamac/0.5.0/VocaMac.app"))
-        XCTAssertFalse(UpdateChecker.isHomebrewPath("/Applications/VocaMac.app"))
-        XCTAssertFalse(UpdateChecker.isHomebrewPath("/Users/john/Applications/VocaMac.app"))
+    func testDetectHomebrewInstallFromCaskroomSymlink() throws {
+        let fixture = try makeHomebrewFixture(caskToken: "vocamac", version: "0.6.2")
+
+        let install = UpdateChecker.detectHomebrewInstall(
+            bundlePath: fixture.appBundle.path,
+            caskroomRoots: [fixture.caskroomRoot]
+        )
+
+        XCTAssertEqual(install?.caskToken, "vocamac")
+        XCTAssertEqual(install?.upgradeCommand, "brew upgrade --cask vocamac")
+    }
+
+    func testDetectHomebrewInstallPreservesNightlyCaskToken() throws {
+        let fixture = try makeHomebrewFixture(caskToken: "vocamac-nightly", version: "nightly")
+
+        let install = UpdateChecker.detectHomebrewInstall(
+            bundlePath: fixture.appBundle.path,
+            caskroomRoots: [fixture.caskroomRoot]
+        )
+
+        XCTAssertEqual(install?.caskToken, "vocamac-nightly")
+        XCTAssertEqual(install?.upgradeCommand, "brew upgrade --cask vocamac-nightly")
+    }
+
+    func testDetectHomebrewInstallRequiresReceipt() throws {
+        let fixture = try makeHomebrewFixture(caskToken: "vocamac", version: "0.6.2", writeReceipt: false)
+
+        let install = UpdateChecker.detectHomebrewInstall(
+            bundlePath: fixture.appBundle.path,
+            caskroomRoots: [fixture.caskroomRoot]
+        )
+
+        XCTAssertNil(install)
     }
 
     @MainActor
     func testCheckForUpdatesTransitionsToHomebrewStateWhenInstalledViaHomebrew() async {
         let checker = UpdateChecker()
-        checker.overrideHomebrewInstalled = true
+        checker.overrideHomebrewInstall = .installed(HomebrewInstall(caskToken: "vocamac-nightly"))
 
         let mockRelease = GitHubRelease(
             tagName: "v99.99.99",
@@ -67,8 +95,9 @@ final class UpdateCheckerTests: XCTestCase {
 
         await checker.checkForUpdates(releaseProvider: { mockRelease })
 
-        if case .updateAvailableViaHomebrew(let info) = checker.updateState {
+        if case .updateAvailableViaHomebrew(let info, let install) = checker.updateState {
             XCTAssertEqual(info.tagName, "v99.99.99")
+            XCTAssertEqual(install.caskToken, "vocamac-nightly")
         } else {
             XCTFail("Expected .updateAvailableViaHomebrew but got \(String(describing: checker.updateState))")
         }
@@ -77,7 +106,7 @@ final class UpdateCheckerTests: XCTestCase {
     @MainActor
     func testCheckForUpdatesTransitionsToUpdateAvailableWhenNotHomebrew() async {
         let checker = UpdateChecker()
-        checker.overrideHomebrewInstalled = false
+        checker.overrideHomebrewInstall = .notInstalled
 
         let mockRelease = GitHubRelease(
             tagName: "v99.99.99",
@@ -105,5 +134,42 @@ final class UpdateCheckerTests: XCTestCase {
         } else {
             XCTFail("Expected .updateAvailable but got \(String(describing: checker.updateState))")
         }
+    }
+
+    private func makeHomebrewFixture(
+        caskToken: String,
+        version: String,
+        writeReceipt: Bool = true,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) throws -> (caskroomRoot: URL, appBundle: URL) {
+        let fileManager = FileManager.default
+        let root = fileManager.temporaryDirectory
+            .appendingPathComponent("VocaMacTests", isDirectory: true)
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        let caskroomRoot = root.appendingPathComponent("Caskroom", isDirectory: true)
+        let appBundle = root
+            .appendingPathComponent("Applications", isDirectory: true)
+            .appendingPathComponent("VocaMac.app", isDirectory: true)
+        let caskRoot = caskroomRoot.appendingPathComponent(caskToken, isDirectory: true)
+        let metadataRoot = caskRoot.appendingPathComponent(".metadata", isDirectory: true)
+        let versionRoot = caskRoot.appendingPathComponent(version, isDirectory: true)
+        let stagedApp = versionRoot.appendingPathComponent("VocaMac.app", isDirectory: true)
+
+        addTeardownBlock {
+            try? fileManager.removeItem(at: root)
+        }
+
+        try fileManager.createDirectory(at: appBundle, withIntermediateDirectories: true)
+        try fileManager.createDirectory(at: metadataRoot, withIntermediateDirectories: true)
+        try fileManager.createDirectory(at: versionRoot, withIntermediateDirectories: true)
+        if writeReceipt {
+            let receipt = metadataRoot.appendingPathComponent("INSTALL_RECEIPT.json")
+            try Data(#"{"uninstall_artifacts":[{"app":["VocaMac.app"]}]}"#.utf8).write(to: receipt)
+        }
+        try fileManager.createSymbolicLink(at: stagedApp, withDestinationURL: appBundle)
+
+        XCTAssertTrue(fileManager.fileExists(atPath: appBundle.path), file: file, line: line)
+        return (caskroomRoot, appBundle)
     }
 }

--- a/docs/DATA_MODEL.md
+++ b/docs/DATA_MODEL.md
@@ -397,8 +397,10 @@ enum UpdateState: Equatable {
     case idle
     case checking
     case updateAvailable(UpdateInfo)
+    case updateAvailableViaHomebrew(info: UpdateInfo)
     case upToDate
-    case downloading(progress: Double)
+    case downloading(progress: Double, bytesDownloaded: Int64, totalBytes: Int64, estimatedSecondsRemaining: Double)
+    case verifying
     case readyToInstall(dmgPath: URL)
     case error(String)
 }

--- a/docs/DATA_MODEL.md
+++ b/docs/DATA_MODEL.md
@@ -397,7 +397,7 @@ enum UpdateState: Equatable {
     case idle
     case checking
     case updateAvailable(UpdateInfo)
-    case updateAvailableViaHomebrew(info: UpdateInfo)
+    case updateAvailableViaHomebrew(info: UpdateInfo, install: HomebrewInstall)
     case upToDate
     case downloading(progress: Double, bytesDownloaded: Int64, totalBytes: Int64, estimatedSecondsRemaining: Double)
     case verifying

--- a/docs/HOMEBREW.md
+++ b/docs/HOMEBREW.md
@@ -190,6 +190,23 @@ zap trash: [
 
 This is useful for a clean reinstall or when troubleshooting. A plain `brew uninstall --cask vocamac` only removes the `.app` bundle and leaves user data intact.
 
+## In-App Update Behavior
+
+When VocaMac is installed via Homebrew Cask, the built-in update checker detects the Homebrew installation and disables in-app DMG downloads. Instead of showing a **"Download & Install"** button, the update banner and About tab display a Homebrew-specific message:
+
+> Updates are managed by Homebrew. Run: `brew upgrade --cask vocamac`
+
+### How Detection Works
+
+VocaMac checks whether `Bundle.main.bundlePath` contains `/Caskroom/`. This path segment is present for both Apple Silicon (`/opt/homebrew/Caskroom/`) and Intel (`/usr/local/Caskroom/`) Homebrew installations.
+
+| Installation Method | Update Behavior |
+|---|---|
+| **DMG (manual)** | In-app download, SHA-256 verification, open DMG |
+| **Homebrew Cask** | Shows Homebrew upgrade command; no in-app download |
+
+This prevents conflicts between Homebrew's version management and the app's own update mechanism. Always use `brew upgrade --cask vocamac` to update a Homebrew-installed copy of VocaMac.
+
 ## Troubleshooting
 
 ### Cask install fails with "SHA256 mismatch"

--- a/docs/HOMEBREW.md
+++ b/docs/HOMEBREW.md
@@ -196,16 +196,20 @@ When VocaMac is installed via Homebrew Cask, the built-in update checker detects
 
 > Updates are managed by Homebrew. Run: `brew upgrade --cask vocamac`
 
+Nightly users see the nightly token instead:
+
+> Updates are managed by Homebrew. Run: `brew upgrade --cask vocamac-nightly`
+
 ### How Detection Works
 
-VocaMac checks whether `Bundle.main.bundlePath` contains `/Caskroom/`. This path segment is present for both Apple Silicon (`/opt/homebrew/Caskroom/`) and Intel (`/usr/local/Caskroom/`) Homebrew installations.
+Homebrew moves the launched app into the configured app directory, usually `/Applications/VocaMac.app`, and keeps cask metadata under the Homebrew prefix. VocaMac checks standard Apple Silicon and Intel Caskroom roots for the supported cask tokens (`vocamac` and `vocamac-nightly`), requires a Homebrew install receipt, and verifies that the cask's staged `VocaMac.app` entry resolves back to the running app bundle.
 
 | Installation Method | Update Behavior |
 |---|---|
 | **DMG (manual)** | In-app download, SHA-256 verification, open DMG |
-| **Homebrew Cask** | Shows Homebrew upgrade command; no in-app download |
+| **Homebrew Cask** | Shows the matching Homebrew upgrade command; no in-app download |
 
-This prevents conflicts between Homebrew's version management and the app's own update mechanism. Always use `brew upgrade --cask vocamac` to update a Homebrew-installed copy of VocaMac.
+This prevents conflicts between Homebrew's version management and the app's own update mechanism. Always use `brew upgrade --cask vocamac` or `brew upgrade --cask vocamac-nightly` to update a Homebrew-installed copy of VocaMac.
 
 ## Troubleshooting
 

--- a/homebrew/README.md
+++ b/homebrew/README.md
@@ -25,6 +25,12 @@ brew install --cask vocamac-nightly
 brew upgrade --cask vocamac
 ```
 
+For nightly builds:
+
+```bash
+brew upgrade --cask vocamac-nightly
+```
+
 ## Uninstall
 
 ```bash


### PR DESCRIPTION
## Summary

Detects when the running VocaMac app is managed by Homebrew Cask and routes available updates to Homebrew instead of the in-app DMG installer.

This now uses Homebrew Cask receipt metadata plus the staged `VocaMac.app` entry that resolves back to the running app bundle, so detection works after Homebrew installs the app into `/Applications`.

## Changes

- Add a `HomebrewInstall` model that carries the cask token and upgrade command.
- Detect supported casks from standard Apple Silicon and Intel Caskroom roots:
  - `vocamac`
  - `vocamac-nightly`
- Require a Homebrew `INSTALL_RECEIPT.json` before treating the app as Homebrew-managed.
- Resolve the cask's staged `VocaMac.app` path or symlink back to the running bundle path.
- Update the update sheet and About tab to show/copy the matching command:
  - `brew upgrade --cask vocamac`
  - `brew upgrade --cask vocamac-nightly`
- Update Homebrew and data model documentation.

## Testing

- `swift test`
  - 195 tests passed
  - 1 skipped
- `git diff --check`

## Related

- Builds on the Homebrew cask infrastructure from #157.
- Addresses conflicts between Homebrew-managed installs and the in-app DMG updater.
