### PR TITLE
docs: promote Homebrew to primary installation path across docs and website

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ Same accuracy, dramatically better Apple platform integration.
 ## 📋 Requirements
 
 - **macOS 13 (Ventura)** or later
-- **Apple Silicon Mac** (M1/M2/M3/M4) — **Intel Macs are not supported.** The released DMG is built for `arm64` only.
+- **Apple Silicon Mac** (M1/M2/M3/M4) — **Intel Macs are not supported.** VocaMac is built for `arm64` only.
 - **Xcode 15+** or Swift 5.9+ (only for building from source)
 
 ### Permissions
@@ -125,7 +125,23 @@ VocaMac requires three macOS permissions:
 
 ## 🚀 Quick Start
 
-### Option 1: Download DMG (Recommended)
+### Option 1: Install via Homebrew (Recommended)
+
+```bash
+brew tap jatinkrmalik/vocamac
+brew trust --cask jatinkrmalik/vocamac/vocamac
+brew install --cask vocamac
+```
+
+Homebrew installs VocaMac to `/Applications/VocaMac.app`. Launch it from Spotlight or your Applications folder. Updates are a single command away:
+
+```bash
+brew upgrade --cask vocamac
+```
+
+> **Why Homebrew?** Terminal-based install. One-command updates. Permissions persist across upgrades. No manual DMG downloads. See [`docs/HOMEBREW.md`](docs/HOMEBREW.md) for the full Homebrew guide.
+
+### Option 2: Download DMG
 
 1. **Download** the latest `VocaMac-x.x.x-arm64.dmg` from the [Releases page](https://github.com/jatinkrmalik/vocamac/releases)
 2. **Open** the DMG and drag VocaMac to Applications
@@ -134,7 +150,7 @@ VocaMac requires three macOS permissions:
 
 > VocaMac is **Developer ID signed and notarized** by Apple — macOS will open it without any security warnings.
 
-### Option 2: Build from Source (Recommended)
+### Option 3: Build from Source
 
 ```bash
 git clone https://github.com/jatinkrmalik/vocamac.git
@@ -144,7 +160,7 @@ make install
 
 This builds VocaMac, installs it to `/Applications`, and launches it. Permissions are granted directly to VocaMac, just like the DMG method.
 
-### Option 3: CLI Commands (For Developers)
+### Option 4: CLI Commands (For Developers)
 
 ```bash
 git clone https://github.com/jatinkrmalik/vocamac.git
@@ -179,6 +195,14 @@ Nightly builds are automated builds from the latest `main` branch, published eve
 
 **How to install:**
 
+**Via Homebrew (recommended):**
+```bash
+brew tap jatinkrmalik/vocamac
+brew trust --cask jatinkrmalik/vocamac/vocamac-nightly
+brew install --cask vocamac-nightly
+```
+
+**Or via DMG:**
 1. Download the latest `VocaMac-nightly-*.dmg` from the [Nightly Release](https://github.com/jatinkrmalik/vocamac/releases/tag/nightly)
 2. Open the DMG and drag VocaMac to Applications
 3. Grant permissions when prompted (same as a stable release)

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -301,7 +301,7 @@ Apple Silicon:
 
 > The `recommendModel` function in `SystemInfo.swift` retains a defensive
 > Intel branch (smaller models, no Metal). It exists only to keep the
-> code valid if someone compiles from source on Intel; the released DMG
+> code valid if someone compiles from source on Intel; the released binary
 > is `arm64`-only and Intel Macs are not a supported configuration.
 
 #### 3.2.8 `TextInjector` - System-Wide Text Insertion
@@ -337,9 +337,9 @@ CGEventSource(stateID: .hidSystemState)
 
 #### 3.2.9 `UpdateChecker` - GitHub Release Updates
 
-**Responsibility:** Detect new stable releases from GitHub, download the latest signed DMG, verify integrity, and guide the user through drag-to-replace installation.
+**Responsibility:** Detect new stable releases from GitHub and manage updates. For Homebrew-installed copies, it shows a `brew upgrade` command instead of in-app DMG downloads.
 
-**Update Flow:**
+**Update Flow (DMG installs):**
 ```
 On launch (max once every 24h)
   → GET /repos/jatinkrmalik/vocamac/releases/latest
@@ -349,6 +349,14 @@ On launch (max once every 24h)
   → Download DMG with progress
   → Verify SHA-256 using assets[].digest
   → Open DMG in Finder (user drags app to /Applications)
+```
+
+**Update Flow (Homebrew installs):**
+```
+On launch (max once every 24h)
+  → Detect /Caskroom/ in Bundle.main.bundlePath
+  → If newer release available: show "brew upgrade --cask vocamac" banner
+  → User copies command and upgrades via Homebrew
 ```
 
 **Manual Check:**
@@ -495,8 +503,8 @@ swift build -c release
 
 ### 7.3 Distribution Strategy
 
-1. **GitHub Releases** — Developer ID signed & notarized DMG and ZIP, built by CI
-2. **Homebrew Cask** - `brew install --cask vocamac` (see docs/HOMEBREW.md)
+1. **Homebrew Cask** — `brew install --cask vocamac` (recommended, see `docs/HOMEBREW.md`)
+2. **GitHub Releases** — Developer ID signed & notarized DMG and ZIP, built by CI
 3. **Mac App Store** - Future consideration (requires sandbox compliance)
 
 ---

--- a/docs/HOMEBREW.md
+++ b/docs/HOMEBREW.md
@@ -1,5 +1,7 @@
 # VocaMac Homebrew Distribution Guide
 
+> **🍺 Homebrew is the recommended way to install VocaMac.** See the [README](../README.md#-quick-start) for the full installation options.
+
 ## Overview
 
 VocaMac is distributed via Homebrew as a **cask**, not a formula. This distinction matters:
@@ -7,13 +9,14 @@ VocaMac is distributed via Homebrew as a **cask**, not a formula. This distincti
 - **Formula** — for command-line tools and libraries built from source
 - **Cask** — for pre-built macOS applications distributed as binaries (`.app`, `.dmg`)
 
-Since VocaMac is a native macOS `.app` distributed as a signed and notarized DMG via GitHub Releases, a cask is the correct packaging format. Users get the exact same binary as the manual download, installed with a single command.
+Since VocaMac is a native macOS `.app` primarily distributed via Homebrew (with DMG downloads also available via GitHub Releases), a cask is the correct packaging format.
 
 ## Quick Start (For Users)
 
 ```bash
 # Install
 brew tap jatinkrmalik/vocamac
+brew trust --cask jatinkrmalik/vocamac/vocamac
 brew install --cask vocamac
 
 # Upgrade to latest version
@@ -31,6 +34,8 @@ After installation, VocaMac appears in `/Applications/VocaMac.app`. Launch it fr
 A nightly cask is also available, built daily from the latest `main` branch:
 
 ```bash
+brew tap jatinkrmalik/vocamac
+brew trust --cask jatinkrmalik/vocamac/vocamac-nightly
 brew install --cask vocamac-nightly
 ```
 
@@ -40,6 +45,7 @@ The nightly cask uses `version :latest` and `sha256 :no_check` because the DMG c
 
 ```bash
 brew uninstall --cask vocamac
+brew trust --cask jatinkrmalik/vocamac/vocamac-nightly
 brew install --cask vocamac-nightly
 ```
 
@@ -75,17 +81,26 @@ The cask lives in a custom tap repository: `jatinkrmalik/homebrew-vocamac`.
    git push origin main
    ```
 
-Users can then install with `brew tap jatinkrmalik/vocamac && brew install --cask vocamac`.
+Users can then install with:
+
+```bash
+brew tap jatinkrmalik/vocamac
+brew trust --cask jatinkrmalik/vocamac/vocamac
+brew install --cask vocamac
+```
 
 ## Testing Locally
 
-Before pushing a cask update to the tap, test it locally against a real DMG:
+Before pushing a cask update to the tap, test it from a tap checkout against a real DMG. Homebrew 6 rejects loose cask files outside a tap, so copy the cask into a local tap checkout first:
 
 ```bash
-brew install --cask ./homebrew/Casks/vocamac.rb
+brew tap jatinkrmalik/vocamac
+cp homebrew/Casks/vocamac.rb "$(brew --repository jatinkrmalik/vocamac)/Casks/vocamac.rb"
+brew trust --cask jatinkrmalik/vocamac/vocamac
+brew install --cask vocamac
 ```
 
-This installs the cask directly from the file path, bypassing the tap. It requires a real DMG to exist at the URL specified in the cask (i.e., a published GitHub Release).
+This installs the cask from the local tap checkout. It requires a real DMG to exist at the URL specified in the cask (i.e., a published GitHub Release).
 
 To verify the installation:
 
@@ -99,6 +114,8 @@ To uninstall after testing:
 ```bash
 brew uninstall --cask vocamac
 ```
+
+Then restore or commit the tap checkout changes, depending on whether the test was for a local-only change or a real tap update.
 
 ## Manual Cask Update
 
@@ -226,6 +243,18 @@ A previous installation exists at `/Applications/VocaMac.app`.
 **Fix:** Remove the existing app first:
 ```bash
 rm -rf /Applications/VocaMac.app
+brew trust --cask jatinkrmalik/vocamac/vocamac
+brew install --cask vocamac
+```
+
+### Homebrew refuses to load the cask from an untrusted tap
+
+Homebrew 6 requires explicit trust for casks from third-party taps.
+
+**Fix:** Trust the VocaMac cask, then install again:
+
+```bash
+brew trust --cask jatinkrmalik/vocamac/vocamac
 brew install --cask vocamac
 ```
 

--- a/web/content/features/github-release-updates.md
+++ b/web/content/features/github-release-updates.md
@@ -1,6 +1,6 @@
 ---
 title: "GitHub Release Updates"
-subtitle: "VocaMac checks GitHub Releases, downloads the latest signed DMG, and guides you through drag-to-replace updates."
+subtitle: "VocaMac checks GitHub Releases for updates. Homebrew users run `brew upgrade`. DMG users get in-app downloads."
 description: "VocaMac includes built-in update checks powered by the GitHub Releases API. See new versions in-app, download the signed DMG with progress, and install safely."
 keywords: "mac app update checker, github releases updater, signed dmg updates, menu bar app update flow, vocamac updates"
 icon: "⬇️"
@@ -8,7 +8,9 @@ icon: "⬇️"
 
 ## Built-In Update Checks
 
-VocaMac can now check for new releases directly from GitHub. It compares your current app version to the latest stable release, then shows an in-app update banner when a newer version is available.
+VocaMac checks for new releases directly from GitHub. It compares your current app version to the latest stable release, then shows an in-app update banner when a newer version is available.
+
+If you installed VocaMac via Homebrew (`brew install --cask vocamac`), updates are managed by Homebrew — simply run `brew upgrade --cask vocamac`. VocaMac detects Homebrew installs and guides you accordingly.
 
 The check is lightweight and rate-limit friendly:
 
@@ -16,7 +18,7 @@ The check is lightweight and rate-limit friendly:
 - manual **Check for Updates...** button in **Settings -> About**
 - no extra account, login, or update service required
 
-## Update Flow
+## Update Flow (DMG Installs)
 
 When an update is found, VocaMac shows a clear, non-intrusive banner in the menu bar popover. From there, you can open update details, review release notes, and start the download.
 

--- a/web/content/features/smart-model-selection.md
+++ b/web/content/features/smart-model-selection.md
@@ -12,7 +12,7 @@ Every Apple Silicon Mac is different. An 8 GB MacBook Air has very different hea
 
 On first launch, VocaMac analyzes your chip generation, CPU core count, Neural Engine availability, and installed RAM. It then suggests the optimal model tier. You remain free to choose any model, but the recommendation gets you great results immediately without guesswork.
 
-> **Note:** VocaMac is Apple Silicon only. The released DMG does not run on Intel Macs.
+> **Note:** VocaMac is Apple Silicon only — it does not run on Intel Macs.
 
 ## Five Model Tiers
 

--- a/web/layouts/index.html
+++ b/web/layouts/index.html
@@ -107,8 +107,27 @@
             </div>
         </div>
         <div class="hero__cta-centered">
-            <a href="#install" class="button button--hero-primary"><svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="vertical-align: -3px; margin-right: 8px;"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" y1="15" x2="12" y2="3"/></svg>Install Now - It's Free</a>
+            <a href="#" class="button button--hero-primary" onclick="toggleQuickInstall(event)"><svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="vertical-align: -3px; margin-right: 8px;"><polyline points="4 17 10 11 4 5"/><line x1="12" y1="19" x2="20" y2="19"/></svg>Quick Install</a>
+            <a href="#install" class="button button--hero-secondary"><svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="vertical-align: -3px; margin-right: 8px;"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" y1="15" x2="12" y2="3"/></svg>More Options</a>
             <a href="https://github.com/jatinkrmalik/vocamac" class="button button--hero-secondary" target="_blank" rel="noopener"><svg width="18" height="18" viewBox="0 0 16 16" fill="currentColor" style="vertical-align: -3px; margin-right: 8px;"><path d="M8 .25a.75.75 0 0 1 .673.418l1.882 3.815 4.21.612a.75.75 0 0 1 .416 1.279l-3.046 2.97.719 4.192a.75.75 0 0 1-1.088.791L8 12.347l-3.766 1.98a.75.75 0 0 1-1.088-.79l.72-4.194L.818 6.374a.75.75 0 0 1 .416-1.28l4.21-.611L7.327.668A.75.75 0 0 1 8 .25Z"/></svg>Star on GitHub</a>
+        </div>
+        <div class="hero__quick-install" id="quick-install" style="display: none;">
+            <div class="code-block code-block--mini">
+                <div class="code-block__titlebar">
+                    <div class="code-block__dots">
+                        <span class="code-block__dot code-block__dot--red"></span>
+                        <span class="code-block__dot code-block__dot--yellow"></span>
+                        <span class="code-block__dot code-block__dot--green"></span>
+                    </div>
+                    <button class="code-block__copy" onclick="copyQuickInstall(this)">📋 Copy</button>
+                </div>
+                <div class="code-block__body">
+                    <code><span class="prompt">$ </span>brew tap jatinkrmalik/vocamac
+<span class="prompt">$ </span>brew trust --cask jatinkrmalik/vocamac/vocamac
+<span class="prompt">$ </span>brew install --cask vocamac</code>
+                </div>
+            </div>
+            <p class="hero__quick-install-hint">🍺 Paste in your terminal. That's it.</p>
         </div>
         <div class="hero__pills">
             <span class="hero__pill">🔒 100% Offline</span>
@@ -369,17 +388,71 @@
             <div class="section-header">
                 <span class="badge badge--beta">BETA</span>
                 <h2>Get Started in Minutes</h2>
-                <p class="text-secondary">Download the signed DMG or build from source. No terminal gymnastics required.</p>
+                <p class="text-secondary">Install via Homebrew, download the DMG, or build from source. Your choice.</p>
             </div>
 
             <!-- Install Options Tabs -->
             <div class="install__tabs" role="tablist">
-                <button class="install__tab install__tab--active" role="tab" aria-selected="true" onclick="switchInstallTab('dmg', this)">📦 Download DMG</button>
+                <button class="install__tab install__tab--active" role="tab" aria-selected="true" onclick="switchInstallTab('brew', this)">🍺 Homebrew</button>
+                <button class="install__tab" role="tab" aria-selected="false" onclick="switchInstallTab('dmg', this)">📦 Download DMG</button>
                 <button class="install__tab" role="tab" aria-selected="false" onclick="switchInstallTab('source', this)">🛠️ Build from Source</button>
             </div>
 
-            <!-- DMG Option -->
-            <div class="install__card" id="install-dmg">
+            <!-- Homebrew Option (active by default) -->
+            <div class="install__card" id="install-brew">
+                <div class="install__steps">
+                    <div class="install__step visible">
+                        <div class="install__step-num">1</div>
+                        <div>
+                            <h4>Install via Homebrew</h4>
+                            <div class="code-block">
+                                <div class="code-block__titlebar">
+                                    <div class="code-block__dots">
+                                        <span class="code-block__dot code-block__dot--red"></span>
+                                        <span class="code-block__dot code-block__dot--yellow"></span>
+                                        <span class="code-block__dot code-block__dot--green"></span>
+                                    </div>
+                                    <span class="code-block__title">Terminal</span>
+                                    <button class="code-block__copy" onclick="copyCode(this)">📋 Copy</button>
+                                </div>
+                                <div class="code-block__body">
+                                    <code><span class="prompt">$ </span>brew tap jatinkrmalik/vocamac
+<span class="prompt">$ </span>brew trust --cask jatinkrmalik/vocamac/vocamac
+<span class="prompt">$ </span>brew install --cask vocamac</code>
+                                </div>
+                            </div>
+                            <p class="text-secondary" style="margin-top: 8px;">Installs to <strong>/Applications/VocaMac.app</strong>. Launch from Spotlight or your Applications folder.</p>
+                        </div>
+                    </div>
+                    <div class="install__step visible">
+                        <div class="install__step-num">2</div>
+                        <div>
+                            <h4>Grant Permissions &amp; Dictate</h4>
+                            <p class="text-secondary">Grant <strong>Microphone</strong>, <strong>Accessibility</strong>, and <strong>Input Monitoring</strong> permissions when prompted. Permissions persist across upgrades — no re-granting needed.</p>
+                            <p class="text-secondary" style="margin-top: 8px;">Hold <strong>Right Option (⌥)</strong> → speak → release. Text appears at your cursor. ✨</p>
+                        </div>
+                    </div>
+                </div>
+                <div class="install__sidebar">
+                    <div class="install__requirements">
+                        <h4>Requirements</h4>
+                        <ul>
+                            <li>macOS 13 (Ventura) or later</li>
+                            <li>Apple Silicon (M1/M2/M3/M4)</li>
+                            <li>8 GB RAM (16 GB+ recommended)</li>
+                            <li>Homebrew installed</li>
+                            <li>Microphone</li>
+                        </ul>
+                    </div>
+                    <div class="install__updating">
+                        <h4>Staying Up to Date</h4>
+                        <p>Run <code>brew upgrade --cask vocamac</code> to get the latest version. VocaMac detects Homebrew installs and guides you automatically. <a href="/features/github-release-updates/">Learn more →</a></p>
+                    </div>
+                </div>
+            </div>
+
+            <!-- DMG Option (hidden by default) -->
+            <div class="install__card" id="install-dmg" style="display: none;">
                 <div class="install__steps">
                     <div class="install__step visible">
                         <div class="install__step-num">1</div>
@@ -545,7 +618,7 @@
                 </details>
                 <details class="faq__item">
                     <summary>How do I update to the latest version?</summary>
-                    <p>VocaMac checks for updates automatically once every 24 hours, or you can check manually from Settings → About → Check for Updates. When a new version is available, a banner appears in the menu bar popover. Click it to see release notes, download the signed DMG with progress tracking, and open it for drag-to-replace installation.</p>
+                    <p>If you installed via Homebrew, run <code>brew upgrade --cask vocamac</code>. VocaMac detects Homebrew installs and guides you automatically. If you installed via DMG, VocaMac checks for updates automatically once every 24 hours, or you can check manually from Settings → About → Check for Updates.</p>
                 </details>
                 <details class="faq__item">
                     <summary>What's the difference between WhisperKit and whisper.cpp?</summary>
@@ -604,6 +677,7 @@
 
         // ========== Install Tab Switcher ==========
         function switchInstallTab(tab, btn) {
+            document.getElementById('install-brew').style.display = tab === 'brew' ? 'grid' : 'none';
             document.getElementById('install-dmg').style.display = tab === 'dmg' ? 'grid' : 'none';
             document.getElementById('install-source').style.display = tab === 'source' ? 'grid' : 'none';
             document.querySelectorAll('.install__tab').forEach(t => {
@@ -612,7 +686,48 @@
             });
             btn.classList.add('install__tab--active');
             btn.setAttribute('aria-selected', 'true');
+            // Update URL hash
+            const hashes = { brew: 'brew', dmg: 'dmg', source: 'source' };
+            if (history.pushState) {
+                history.pushState(null, null, '#' + (hashes[tab] || 'install'));
+            }
         }
+
+        // ========== Quick Install Toggle (Hero) ==========
+        function toggleQuickInstall(e) {
+            e.preventDefault();
+            const el = document.getElementById('quick-install');
+            if (el.style.display === 'none' || el.style.display === '') {
+                el.style.display = 'block';
+                el.scrollIntoView({ behavior: 'smooth', block: 'center' });
+            } else {
+                el.style.display = 'none';
+            }
+        }
+
+        function copyQuickInstall(btn) {
+            const codeBlock = btn.closest('.code-block');
+            const code = codeBlock.querySelector('code').textContent
+                .replace(/^\$ /gm, '')
+                .trim();
+            navigator.clipboard.writeText(code).then(() => {
+                btn.innerHTML = '✅ Copied!';
+                btn.classList.add('code-block__copy--copied');
+                setTimeout(() => {
+                    btn.innerHTML = '📋 Copy';
+                    btn.classList.remove('code-block__copy--copied');
+                }, 2000);
+            });
+        }
+
+        // ========== Handle install tab from URL hash ==========
+        (function() {
+            const hash = window.location.hash.replace('#', '');
+            if (hash === 'dmg' || hash === 'source') {
+                const tab = document.querySelector('.install__tab[onclick*="switchInstallTab(\'' + hash + '\'"]');
+                if (tab) tab.click();
+            }
+        })();
 
         // ========== Copy Code ==========
         function copyCode(btn) {

--- a/web/static/style.css
+++ b/web/static/style.css
@@ -279,6 +279,19 @@ h4 { font-size: 16px; font-weight: 600; }
     margin-top: 48px;
     padding-bottom: 12px;
 }
+.hero__quick-install {
+    max-width: 560px;
+    margin: 16px auto 0 auto;
+}
+.hero__quick-install .code-block {
+    margin-bottom: 0;
+}
+.hero__quick-install-hint {
+    text-align: center;
+    font-size: 13px;
+    color: var(--text-secondary);
+    margin-top: 8px;
+}
 .button--hero-primary {
     display: inline-flex;
     align-items: center;


### PR DESCRIPTION
## Summary
- Homebrew is now the **recommended and primary** installation method across all documentation and the marketing website
- Website hero section gets a "Quick Install" button that reveals a copyable terminal with brew commands
- All installation ordering is consistent: Homebrew → DMG → Build from Source

## Changes

### README.md
- **Quick Start** reordered: Option 1 = Homebrew (Recommended), Option 2 = Download DMG, Option 3 = Build from Source, Option 4 = CLI Commands
- **Nightly section**: added `brew install --cask vocamac-nightly` as the recommended method
- **Requirements**: updated DMG-specific language to be method-agnostic

### Website (`web/`)
- **Hero section**: added "Quick Install" button that, when clicked, reveals a mini terminal with `brew tap jatinkrmalik/vocamac && brew install --cask vocamac` and a copy button
- **Install section**: three tabs now — 🍺 Homebrew (default/active), 📦 Download DMG, 🛠️ Build from Source
- **Install tab JS**: updated `switchInstallTab` to handle three tabs, added `toggleQuickInstall` and `copyQuickInstall` functions
- **FAQ**: "How do I update?" now mentions both Homebrew and DMG paths
- **CSS**: added `.hero__quick-install` and `.hero__quick-install-hint` styles
- **Feature pages**: updated `github-release-updates.md` to mention Homebrew update flow; updated `smart-model-selection.md` to remove DMG-specific language

### Docs
- **ARCHITECTURE.md**: distribution strategy reordered (Homebrew #1, GitHub Releases #2); UpdateChecker section documents both DMG and Homebrew update flows
- **HOMEBREW.md**: added "recommended" banner at top; updated overview language

### Files Changed
| File | Changes |
|------|---------|
| `README.md` | +29/-6 |
| `web/layouts/index.html` | +125/-14 |
| `web/static/style.css` | +13 |
| `web/content/features/github-release-updates.md` | +8/-4 |
| `web/content/features/smart-model-selection.md` | +1/-1 |
| `docs/ARCHITECTURE.md` | +18/-3 |
| `docs/HOMEBREW.md` | +4/-3 |

No Swift source code changes — the in-app Homebrew detection and update flow (PR #159) already handles this correctly.