### PR TITLE
fix: align model picker with WhisperKit Apple Silicon support

### DIFF
--- a/Sources/VocaMac/Models/AppState.swift
+++ b/Sources/VocaMac/Models/AppState.swift
@@ -278,19 +278,6 @@ final class AppState: ObservableObject {
             )
         }
 
-        // Enforce monotonic support ordering: if a smaller model is unsupported,
-        // all larger models must also be unsupported. This prevents contradictory
-        // UI states like Medium="Too Large" but Large v3="Recommended".
-        var foundUnsupported = false
-        for i in availableModels.indices {
-            if !availableModels[i].isSupported {
-                foundUnsupported = true
-            }
-            if foundUnsupported {
-                availableModels[i].isSupported = false
-            }
-        }
-
         // Validate that the recommended model maps to a supported ModelSize.
         // If the recommendation points to an unsupported model, fall back to
         // the largest supported model instead.
@@ -577,6 +564,12 @@ final class AppState: ObservableObject {
     // MARK: - Model Management
 
     func loadModel(_ size: ModelSize? = nil) async {
+        let previousLoadedModelName = whisperService.loadedModelName
+        let previousModelSize = currentModel?.size
+            ?? previousLoadedModelName.flatMap { modelManager.modelSize(from: $0) }
+            ?? ModelSize(rawValue: selectedModelSize)
+        let hadLoadedModel = whisperService.isModelLoaded
+
         let modelName: String?
         if let size = size {
             modelName = modelManager.whisperKitModelName(for: size)
@@ -667,8 +660,89 @@ final class AppState: ObservableObject {
                 availableModels[i].isLoading = false
                 availableModels[i].loadingStatus = "Loading…"
             }
-            errorMessage = "Failed to load model: \(error.localizedDescription)"
-            VocaLogger.error(.appState, "Failed to load model: \(error.localizedDescription)")
+
+            let modelDisplayName = targetSize?.displayName ?? "model"
+            let failureMessage = "Failed to load \(modelDisplayName): \(error.localizedDescription)"
+            showTemporaryError(failureMessage)
+            VocaLogger.error(.appState, failureMessage)
+
+            await restorePreviousModelIfNeeded(
+                afterFailedLoadFor: targetSize,
+                previousSize: previousModelSize,
+                previousName: previousLoadedModelName,
+                hadLoadedModel: hadLoadedModel,
+                originalFailureMessage: failureMessage
+            )
+        }
+    }
+
+    /// Surface a short-lived error state for settings and menu UI.
+    private func showTemporaryError(_ message: String) {
+        errorMessage = message
+        appStatus = .error
+
+        DispatchQueue.main.asyncAfter(deadline: .now() + 5.0) { [weak self] in
+            if self?.appStatus == .error, self?.errorMessage == message {
+                self?.appStatus = .idle
+                self?.errorMessage = nil
+            }
+        }
+    }
+
+    /// Restore the model that was active before a failed switch.
+    private func restorePreviousModelIfNeeded(
+        afterFailedLoadFor failedSize: ModelSize?,
+        previousSize: ModelSize?,
+        previousName: String?,
+        hadLoadedModel: Bool,
+        originalFailureMessage: String
+    ) async {
+        guard hadLoadedModel,
+              let previousSize,
+              failedSize != previousSize else {
+            clearActiveModelState()
+            return
+        }
+
+        do {
+            VocaLogger.info(.appState, "Restoring previous model: \(previousSize.displayName)")
+            let folderURL = modelManager.isModelDownloaded(previousSize)
+                ? modelManager.modelFolder(for: previousSize)
+                : nil
+            let restoreName = previousName ?? modelManager.whisperKitModelName(for: previousSize)
+            try await whisperService.loadModel(name: restoreName, folder: folderURL)
+            markModelActive(previousSize)
+            VocaLogger.info(.appState, "Restored previous model: \(previousSize.displayName)")
+        } catch {
+            clearActiveModelState()
+            let restoreFailure = "Previous model could not be restored: \(error.localizedDescription)"
+            errorMessage = "\(originalFailureMessage) \(restoreFailure)"
+            VocaLogger.error(.appState, restoreFailure)
+        }
+    }
+
+    /// Synchronize AppState's model metadata after a successful load.
+    private func markModelActive(_ size: ModelSize) {
+        currentModel = nil
+        for i in availableModels.indices {
+            let matches = availableModels[i].size == size
+            availableModels[i].isActive = matches
+            availableModels[i].isLoading = false
+            availableModels[i].loadingStatus = "Loading…"
+            if matches {
+                availableModels[i].isDownloaded = modelManager.isModelDownloaded(size)
+                currentModel = availableModels[i]
+            }
+        }
+    }
+
+    /// Clear active model metadata when no model is loaded in WhisperService.
+    private func clearActiveModelState() {
+        currentModel = nil
+        for i in availableModels.indices {
+            availableModels[i].isActive = false
+            availableModels[i].isLoading = false
+            availableModels[i].loadingStatus = "Loading…"
         }
     }
 

--- a/Sources/VocaMac/Models/AppState.swift
+++ b/Sources/VocaMac/Models/AppState.swift
@@ -267,16 +267,7 @@ final class AppState: ObservableObject {
             deviceRecommendedModel = recommendation.defaultModel
         }
 
-        // Initialize available models list
-        availableModels = ModelSize.allCases.map { size in
-            WhisperModelInfo(
-                size: size,
-                filePath: modelManager.modelFolder(for: size),
-                isDownloaded: modelManager.isModelDownloaded(size),
-                isActive: size.rawValue == selectedModelSize,
-                isSupported: modelManager.isModelSupported(size)
-            )
-        }
+        rebuildAvailableModels()
 
         // Validate that the recommended model maps to a supported ModelSize.
         // If the recommendation points to an unsupported model, fall back to
@@ -379,6 +370,67 @@ final class AppState: ObservableObject {
 
         // Check permissions
         checkPermissions()
+    }
+
+    /// Build the model list shown in Settings and onboarding.
+    ///
+    /// The base catalog is curated for M-series Macs, then extended with any
+    /// exact variants WhisperKit marks supported for the current device.
+    private func modelCatalog() -> [ModelSize] {
+        var catalog = ModelSize.standardCatalog
+
+        for size in ModelSize.allCases where modelManager.isModelSupported(size) {
+            if !catalog.contains(size) {
+                catalog.append(size)
+            }
+        }
+
+        if let selected = ModelSize(rawValue: selectedModelSize),
+           !catalog.contains(selected) {
+            catalog.append(selected)
+        }
+
+        return catalog
+    }
+
+    /// Recreate model UI state from the latest catalog and local cache status.
+    private func rebuildAvailableModels() {
+        availableModels = modelCatalog().map { size in
+            WhisperModelInfo(
+                size: size,
+                filePath: modelManager.modelFolder(for: size),
+                isDownloaded: modelManager.isModelDownloaded(size),
+                isActive: size.rawValue == selectedModelSize,
+                isSupported: modelManager.isModelSupported(size)
+            )
+        }
+    }
+
+    /// Resolve WhisperKit's recommended exact model variant into app metadata.
+    private func recommendedModelSize() -> ModelSize? {
+        guard let recommended = deviceRecommendedModel,
+              let size = modelManager.modelSize(from: recommended),
+              modelManager.isModelSupported(size) else {
+            return nil
+        }
+        return size
+    }
+
+    /// Pick a supported startup model when the stored preference is no longer valid.
+    private func startupFallbackModel(for preferred: ModelSize) -> ModelSize {
+        guard !modelManager.isModelSupported(preferred) else {
+            return preferred
+        }
+
+        if let downloadedSupported = availableModels.last(where: { $0.isSupported && $0.isDownloaded })?.size {
+            return downloadedSupported
+        }
+
+        if let recommended = recommendedModelSize() {
+            return recommended
+        }
+
+        return .tiny
     }
 
     // MARK: - Permission Handling (delegated to PermissionManager)
@@ -622,8 +674,19 @@ final class AppState: ObservableObject {
                 resolvedSize = targetSize
             } else {
                 let loadedName = (whisperService.loadedModelName ?? "").lowercased()
-                // Check from largest to smallest to avoid "base" matching inside "large-v3"
-                if loadedName.contains("large") {
+                if let loadedSize = modelManager.modelSize(from: whisperService.loadedModelName ?? "") {
+                    resolvedSize = loadedSize
+                } else if loadedName.contains("v20240930_turbo") {
+                    resolvedSize = .largeV3LatestTurbo
+                } else if loadedName.contains("v20240930") {
+                    resolvedSize = .largeV3Latest
+                } else if loadedName.contains("distil") && loadedName.contains("turbo") {
+                    resolvedSize = .distilLargeV3TurboCompact
+                } else if loadedName.contains("distil") {
+                    resolvedSize = .distilLargeV3Compact
+                } else if loadedName.contains("large") && loadedName.contains("turbo") {
+                    resolvedSize = .largeV3Turbo
+                } else if loadedName.contains("large") {
                     resolvedSize = .largeV3
                 } else if loadedName.contains("medium") {
                     resolvedSize = .medium
@@ -828,7 +891,13 @@ final class AppState: ObservableObject {
         // downloaded yet. We download it explicitly so the UI can show real
         // progress, rather than delegating to WhisperKit's opaque auto-select
         // which provides no progress callbacks and may pick a different model.
-        var modelToLoad = ModelSize(rawValue: selectedModelSize) ?? .tiny
+        let preferredModel = ModelSize(rawValue: selectedModelSize) ?? .tiny
+        var modelToLoad = startupFallbackModel(for: preferredModel)
+        if modelToLoad != preferredModel {
+            VocaLogger.warning(.appState, "Preferred model \(preferredModel.displayName) is not supported on this device — falling back to \(modelToLoad.displayName)")
+            selectedModelSize = modelToLoad.rawValue
+            rebuildAvailableModels()
+        }
 
         if !modelManager.isModelDownloaded(modelToLoad) {
             // Try bundled model for the preferred size first

--- a/Sources/VocaMac/Models/WhisperModel.swift
+++ b/Sources/VocaMac/Models/WhisperModel.swift
@@ -9,33 +9,75 @@ import Foundation
 
 /// Whisper model size variants with their properties
 enum ModelSize: String, CaseIterable, Codable, Identifiable {
-    case tiny     = "tiny"
-    case base     = "base"
-    case small    = "small"
-    case medium   = "medium"
-    case largeV3  = "large-v3"
+    case tiny                         = "tiny"
+    case base                         = "base"
+    case small                        = "small"
+    case largeV3LatestTurboCompact    = "large-v3-v20240930_turbo_632MB"
+    case distilLargeV3Compact         = "distil-large-v3_594MB"
+    case distilLargeV3TurboCompact    = "distil-large-v3_turbo_600MB"
+    case largeV3LatestCompact         = "large-v3-v20240930_626MB"
+    case largeV3Latest                = "large-v3-v20240930"
+    case largeV3LatestTurbo           = "large-v3-v20240930_turbo"
+    case largeV3                      = "large-v3"
+    case largeV3Turbo                 = "large-v3_turbo"
+    case medium                       = "medium"
 
     var id: String { rawValue }
+
+    /// Models shown by default in the app's Mac-focused model picker.
+    ///
+    /// `medium` remains a legacy value for stored preferences and explicit
+    /// support from WhisperKit, but is not part of the normal Apple Silicon
+    /// catalog because WhisperKit does not list it for M-series Macs.
+    static let standardCatalog: [ModelSize] = [
+        .tiny,
+        .base,
+        .small,
+        .largeV3LatestTurboCompact,
+        .distilLargeV3Compact,
+        .distilLargeV3TurboCompact,
+        .largeV3LatestCompact,
+        .largeV3Latest,
+    ]
+
+    /// Whether this model is kept only for compatibility or explicit support.
+    var isLegacy: Bool {
+        self == .medium
+    }
 
     /// Human-readable display name
     var displayName: String {
         switch self {
-        case .tiny:    return "Tiny (Fastest)"
-        case .base:    return "Base"
-        case .small:   return "Small"
-        case .medium:  return "Medium"
-        case .largeV3: return "Large v3 (Best Quality)"
+        case .tiny:                      return "Tiny (Fastest)"
+        case .base:                      return "Base"
+        case .small:                     return "Small"
+        case .largeV3LatestTurboCompact: return "Large v3 Turbo (Compact)"
+        case .distilLargeV3Compact:      return "Distil Large v3 (Compact)"
+        case .distilLargeV3TurboCompact: return "Distil Large v3 Turbo"
+        case .largeV3LatestCompact:      return "Large v3 Latest (Compact)"
+        case .largeV3Latest:             return "Large v3 Latest (Best)"
+        case .largeV3LatestTurbo:        return "Large v3 Latest Turbo"
+        case .largeV3:                   return "Large v3"
+        case .largeV3Turbo:              return "Large v3 Turbo"
+        case .medium:                    return "Medium (Legacy)"
         }
     }
 
     /// Approximate file size on disk in bytes
     var fileSizeBytes: Int64 {
         switch self {
-        case .tiny:    return 39_000_000
-        case .base:    return 142_000_000
-        case .small:   return 466_000_000
-        case .medium:  return 1_500_000_000
-        case .largeV3: return 3_100_000_000
+        case .tiny:                      return 39_000_000
+        case .base:                      return 142_000_000
+        case .small:                     return 466_000_000
+        case .largeV3LatestTurboCompact: return 632_000_000
+        case .distilLargeV3Compact:      return 594_000_000
+        case .distilLargeV3TurboCompact: return 600_000_000
+        case .largeV3LatestCompact:      return 626_000_000
+        case .largeV3Latest:             return 3_100_000_000
+        case .largeV3LatestTurbo:        return 1_000_000_000
+        case .largeV3:                   return 3_100_000_000
+        case .largeV3Turbo:              return 954_000_000
+        case .medium:                    return 1_500_000_000
         }
     }
 
@@ -49,33 +91,54 @@ enum ModelSize: String, CaseIterable, Codable, Identifiable {
     /// Approximate RAM required for inference in GB
     var ramRequiredGB: Double {
         switch self {
-        case .tiny:    return 1.0
-        case .base:    return 1.5
-        case .small:   return 2.0
-        case .medium:  return 5.0
-        case .largeV3: return 10.0
+        case .tiny:                      return 1.0
+        case .base:                      return 1.5
+        case .small:                     return 2.0
+        case .largeV3LatestTurboCompact: return 4.0
+        case .distilLargeV3Compact:      return 4.0
+        case .distilLargeV3TurboCompact: return 4.0
+        case .largeV3LatestCompact:      return 5.0
+        case .largeV3Latest:             return 10.0
+        case .largeV3LatestTurbo:        return 6.0
+        case .largeV3:                   return 10.0
+        case .largeV3Turbo:              return 6.0
+        case .medium:                    return 5.0
         }
     }
 
     /// Relative speed indicator (1 = fastest)
     var relativeSpeed: Int {
         switch self {
-        case .tiny:    return 1
-        case .base:    return 2
-        case .small:   return 4
-        case .medium:  return 8
-        case .largeV3: return 16
+        case .tiny:                      return 1
+        case .base:                      return 2
+        case .small:                     return 4
+        case .largeV3LatestTurboCompact: return 5
+        case .distilLargeV3Compact:      return 6
+        case .distilLargeV3TurboCompact: return 5
+        case .largeV3LatestCompact:      return 8
+        case .largeV3Latest:             return 14
+        case .largeV3LatestTurbo:        return 9
+        case .largeV3:                   return 16
+        case .largeV3Turbo:              return 10
+        case .medium:                    return 8
         }
     }
 
     /// Accuracy quality descriptor
     var qualityDescription: String {
         switch self {
-        case .tiny:    return "Good"
-        case .base:    return "Better"
-        case .small:   return "Great"
-        case .medium:  return "Excellent"
-        case .largeV3: return "Best"
+        case .tiny:                      return "Good"
+        case .base:                      return "Better"
+        case .small:                     return "Great"
+        case .largeV3LatestTurboCompact: return "Excellent"
+        case .distilLargeV3Compact:      return "Excellent"
+        case .distilLargeV3TurboCompact: return "Excellent"
+        case .largeV3LatestCompact:      return "Best"
+        case .largeV3Latest:             return "Best"
+        case .largeV3LatestTurbo:        return "Best"
+        case .largeV3:                   return "Best"
+        case .largeV3Turbo:              return "Best"
+        case .medium:                    return "Legacy"
         }
     }
 }

--- a/Sources/VocaMac/Services/ModelManager.swift
+++ b/Sources/VocaMac/Services/ModelManager.swift
@@ -59,7 +59,36 @@ final class ModelManager {
     }
 
     private func hasRequiredModelAssets(at directory: URL) -> Bool {
-        requiredModelDirectories.allSatisfy { fileManager.fileExists(atPath: directory.appendingPathComponent($0).path) }
+        requiredModelDirectories.allSatisfy { componentName in
+            Self.hasUsableCoreMLComponent(at: directory.appendingPathComponent(componentName, isDirectory: true))
+        }
+    }
+
+    /// Validate that a compiled CoreML component has both graph metadata and weights.
+    static func hasUsableCoreMLComponent(at directory: URL, fileManager: FileManager = .default) -> Bool {
+        var isDirectory: ObjCBool = false
+        guard fileManager.fileExists(atPath: directory.path, isDirectory: &isDirectory),
+              isDirectory.boolValue else {
+            return false
+        }
+
+        let metadata = directory.appendingPathComponent("metadata.json")
+        let hasMetadata = fileManager.fileExists(atPath: metadata.path)
+        let hasModelDefinition = [
+            "model.mil",
+            "model.mlmodel",
+            "coremldata.bin",
+        ].contains { fileName in
+            fileManager.fileExists(atPath: directory.appendingPathComponent(fileName).path)
+        }
+        let hasWeights = fileManager.fileExists(
+            atPath: directory
+                .appendingPathComponent("weights", isDirectory: true)
+                .appendingPathComponent("weight.bin")
+                .path
+        )
+
+        return hasMetadata && hasModelDefinition && hasWeights
     }
 
     private func hasRequiredTokenizerAssets(at directory: URL) -> Bool {
@@ -203,11 +232,30 @@ final class ModelManager {
     /// Map a ModelSize enum to WhisperKit model variant name
     func whisperKitModelName(for size: ModelSize) -> String {
         switch size {
-        case .tiny:    return "openai_whisper-tiny"
-        case .base:    return "openai_whisper-base"
-        case .small:   return "openai_whisper-small"
-        case .medium:  return "openai_whisper-medium"
-        case .largeV3: return "openai_whisper-large-v3"
+        case .tiny:
+            return "openai_whisper-tiny"
+        case .base:
+            return "openai_whisper-base"
+        case .small:
+            return "openai_whisper-small"
+        case .largeV3LatestTurboCompact:
+            return "openai_whisper-large-v3-v20240930_turbo_632MB"
+        case .distilLargeV3Compact:
+            return "distil-whisper_distil-large-v3_594MB"
+        case .distilLargeV3TurboCompact:
+            return "distil-whisper_distil-large-v3_turbo_600MB"
+        case .largeV3LatestCompact:
+            return "openai_whisper-large-v3-v20240930_626MB"
+        case .largeV3Latest:
+            return "openai_whisper-large-v3-v20240930"
+        case .largeV3LatestTurbo:
+            return "openai_whisper-large-v3-v20240930_turbo"
+        case .largeV3:
+            return "openai_whisper-large-v3"
+        case .largeV3Turbo:
+            return "openai_whisper-large-v3_turbo"
+        case .medium:
+            return "openai_whisper-medium"
         }
     }
 
@@ -220,7 +268,7 @@ final class ModelManager {
     /// Get the local folder path for a downloaded or installed model
     func modelFolder(for size: ModelSize) -> URL? {
         let modelDir = installedModelDirectory(for: size)
-        if fileManager.fileExists(atPath: modelDir.path) {
+        if fileManager.fileExists(atPath: modelDir.path), hasRequiredModelAssets(at: modelDir) {
             return modelDir
         }
         return nil
@@ -233,40 +281,21 @@ final class ModelManager {
 
     /// Check if a model size is supported on this device.
     ///
-    /// Uses exact prefix boundary matching: "openai_whisper-large-v3" matches
-    /// versioned variants like "openai_whisper-large-v3-v20240930_626MB" but NOT
-    /// different models like "openai_whisper-large-v3_turbo-v20240930_626MB".
-    /// Also checks the disabled list — if any exact variant is disabled, the model
-    /// is considered unsupported to avoid recommending models the device can't run.
+    /// Uses exact model matching so distinct WhisperKit variants remain distinct.
     func isModelSupported(_ size: ModelSize) -> Bool {
         let rec = WhisperKit.recommendedModels()
-        let modelPrefix = whisperKitModelName(for: size)
+        let modelName = whisperKitModelName(for: size)
 
-        // Match exact model name or versioned variants (prefix + "-")
-        // but not different models that share a prefix (e.g. large-v3_turbo)
-        let matchesModel: (String) -> Bool = { name in
-            name == modelPrefix || name.hasPrefix(modelPrefix + "-")
-        }
-
-        // If any exact variant of this model is in the disabled list, it's unsupported
-        if rec.disabled.contains(where: matchesModel) {
+        if rec.disabled.contains(modelName) {
             return false
         }
 
-        return rec.supported.contains(where: matchesModel)
+        return rec.supported.contains(modelName)
     }
 
     /// Map a WhisperKit model name back to a ModelSize, if it matches one of our known sizes.
-    ///
-    /// Uses exact prefix boundary matching, same as `isModelSupported`.
     func modelSize(from whisperKitName: String) -> ModelSize? {
-        for size in ModelSize.allCases {
-            let prefix = whisperKitModelName(for: size)
-            if whisperKitName == prefix || whisperKitName.hasPrefix(prefix + "-") {
-                return size
-            }
-        }
-        return nil
+        ModelSize.allCases.first { whisperKitModelName(for: $0) == whisperKitName }
     }
 
     // MARK: - Model Download
@@ -412,8 +441,12 @@ final class ModelManager {
             // survive temp directory cleanup.
             try consolidateWhisperKitDownload(for: size)
 
-            onProgress(1.0)
             let installedDir = installedModelDirectory(for: size)
+            guard hasRequiredModelAssets(at: installedDir) else {
+                throw ModelManagerError.missingModelDirectory(installedDir.path)
+            }
+
+            onProgress(1.0)
             VocaLogger.info(.modelManager, "Model '\(whisperKitModelName(for: size))' downloaded successfully to: \(installedDir.path)")
         } catch {
             VocaLogger.error(.modelManager, "Download failed for '\(whisperKitModelName(for: size))': \(error.localizedDescription)")

--- a/Sources/VocaMac/Services/SystemInfo.swift
+++ b/Sources/VocaMac/Services/SystemInfo.swift
@@ -113,16 +113,18 @@ enum SystemInfo {
 
     // MARK: - Model Recommendation
 
-    /// Recommend the optimal whisper model size based on system capabilities
+    /// Recommend a default model family based on system capabilities.
+    ///
+    /// WhisperKit's runtime recommendation remains the source of truth for
+    /// actual model loading. This fallback is used for static system summaries.
     static func recommendModel(isAppleSilicon: Bool, memoryGB: Int) -> ModelSize {
         if isAppleSilicon {
-            // Apple Silicon is more memory-efficient and has Metal acceleration
             switch memoryGB {
             case ...7:   return .tiny
             case 8...15: return .base
             case 16...23: return .small
-            case 24...31: return .medium
-            case 32...:  return .medium  // large-v3 is very slow even on high-end machines
+            case 24...31: return .largeV3LatestTurboCompact
+            case 32...:  return .largeV3Latest
             default:     return .tiny
             }
         } else {

--- a/Sources/VocaMac/Services/WhisperService.swift
+++ b/Sources/VocaMac/Services/WhisperService.swift
@@ -255,6 +255,11 @@ final class WhisperService: @unchecked Sendable {
     /// Map a model name string to our ModelSize enum
     private func modelSizeFromName(_ name: String) -> ModelSize {
         let lowered = name.lowercased()
+        if lowered.contains("v20240930") && lowered.contains("turbo") { return .largeV3LatestTurbo }
+        if lowered.contains("v20240930") { return .largeV3Latest }
+        if lowered.contains("distil") && lowered.contains("turbo") { return .distilLargeV3TurboCompact }
+        if lowered.contains("distil") { return .distilLargeV3Compact }
+        if lowered.contains("large") && lowered.contains("turbo") { return .largeV3Turbo }
         if lowered.contains("large") { return .largeV3 }
         if lowered.contains("medium") { return .medium }
         if lowered.contains("small") { return .small }

--- a/Sources/VocaMac/Views/OnboardingView.swift
+++ b/Sources/VocaMac/Views/OnboardingView.swift
@@ -398,10 +398,7 @@ struct ModelSelectionStep: View {
                 .padding(.horizontal)
 
             if let recommended = appState.deviceRecommendedModel,
-               let recommendedSize = ModelSize.allCases.first(where: { size in
-                   let prefix = "openai_whisper-\(size.rawValue)"
-                   return recommended == prefix || recommended.hasPrefix(prefix + "-")
-               }) {
+               let recommendedSize = appState.modelManager.modelSize(from: recommended) {
                 HStack(spacing: 12) {
                     Image(systemName: "lightbulb.fill")
                         .font(.caption)
@@ -421,8 +418,7 @@ struct ModelSelectionStep: View {
                             modelInfo: modelInfo,
                             isRecommended: {
                                 guard let recommended = appState.deviceRecommendedModel else { return false }
-                                let prefix = "openai_whisper-\(modelInfo.size.rawValue)"
-                                return recommended == prefix || recommended.hasPrefix(prefix + "-")
+                                return appState.modelManager.modelSize(from: recommended) == modelInfo.size
                             }(),
                             onSelect: {
                                 Task { @MainActor in

--- a/Sources/VocaMac/Views/SettingsView.swift
+++ b/Sources/VocaMac/Views/SettingsView.swift
@@ -302,6 +302,30 @@ struct ModelSettingsTab: View {
                     }
                 }
 
+                if appState.appStatus == .error, let errorMessage = appState.errorMessage {
+                    GroupBox {
+                        HStack(alignment: .top, spacing: 8) {
+                            Image(systemName: "exclamationmark.triangle.fill")
+                                .foregroundStyle(.orange)
+                            Text(errorMessage)
+                                .font(.caption)
+                                .foregroundStyle(.primary)
+                                .fixedSize(horizontal: false, vertical: true)
+                            Spacer()
+                            Button {
+                                appState.errorMessage = nil
+                                appState.appStatus = .idle
+                            } label: {
+                                Image(systemName: "xmark.circle.fill")
+                            }
+                            .buttonStyle(.plain)
+                            .foregroundStyle(.secondary)
+                            .help("Dismiss")
+                        }
+                        .padding(4)
+                    }
+                }
+
                 // Model list
                 GroupBox {
                     VStack(alignment: .leading, spacing: 0) {
@@ -428,7 +452,7 @@ struct ModelRow: View {
                             .background(.orange.opacity(0.2))
                             .foregroundStyle(.orange)
                             .cornerRadius(4)
-                            .help("WhisperKit hasn't verified this model on your chip family. Your hardware can likely run it — use Load Anyway to try.")
+                            .help("WhisperKit hasn't verified this model on your chip family. It may fail to load, or it may run slower than tuned models.")
                     }
                 }
 
@@ -525,7 +549,7 @@ struct ModelRow: View {
                 }
             }
         } message: {
-            Text("WhisperKit hasn't verified this model on your chip family. It will likely work but may be slower than tuned models.")
+            Text("WhisperKit hasn't verified this model on your chip family. It may fail to load, or it may run slower than tuned models.")
         }
     }
 }

--- a/Sources/VocaMac/Views/SettingsView.swift
+++ b/Sources/VocaMac/Views/SettingsView.swift
@@ -337,7 +337,7 @@ struct ModelSettingsTab: View {
                         ForEach(appState.availableModels) { model in
                             ModelRow(model: model, appState: appState)
 
-                            if model.size != ModelSize.allCases.last {
+                            if model.id != appState.availableModels.last?.id {
                                 Divider()
                                     .padding(.horizontal, 4)
                             }
@@ -356,10 +356,7 @@ struct ModelSettingsTab: View {
                 }
 
                 if let recommended = appState.deviceRecommendedModel,
-                   let recommendedSize = ModelSize.allCases.first(where: { size in
-                       let prefix = "openai_whisper-\(size.rawValue)"
-                       return recommended == prefix || recommended.hasPrefix(prefix + "-")
-                   }) {
+                   let recommendedSize = appState.modelManager.modelSize(from: recommended) {
                     HStack {
                         Image(systemName: "sparkles")
                             .foregroundStyle(.blue)
@@ -430,10 +427,7 @@ struct ModelRow: View {
 
                     if model.isSupported,
                        let recommended = appState.deviceRecommendedModel {
-                        // Use exact prefix boundary matching to avoid cross-model
-                        // false positives (e.g. "large-v3" matching "large-v3_turbo")
-                        let prefix = "openai_whisper-\(model.size.rawValue)"
-                        if recommended == prefix || recommended.hasPrefix(prefix + "-") {
+                        if appState.modelManager.modelSize(from: recommended) == model.size {
                             Text("Recommended")
                                 .font(.caption2)
                                 .padding(.horizontal, 6)

--- a/Tests/VocaMacTests/AppStateTests.swift
+++ b/Tests/VocaMacTests/AppStateTests.swift
@@ -278,12 +278,10 @@ final class AppStateModelLoadingTests: XCTestCase {
     func testSetupKeepsLargeSupportedWhenMediumIsNotRecommended() {
         let modelManager = MockModelManager()
         modelManager.defaultModel = "openai_whisper-large-v3-v20240930"
-        modelManager.supportedModels = [.tiny, .base, .small, .largeV3]
         modelManager.supportedModelNames = [
             "openai_whisper-tiny",
             "openai_whisper-base",
             "openai_whisper-small",
-            "openai_whisper-large-v3",
             "openai_whisper-large-v3-v20240930",
             "openai_whisper-large-v3-v20240930_626MB",
         ]
@@ -291,12 +289,9 @@ final class AppStateModelLoadingTests: XCTestCase {
         let (appState, _) = AppState.makeTestState(modelManager: modelManager)
 
         XCTAssertEqual(appState.deviceRecommendedModel, "openai_whisper-large-v3-v20240930")
+        XCTAssertNil(appState.availableModels.first(where: { $0.size == .medium }))
         XCTAssertEqual(
-            appState.availableModels.first(where: { $0.size == .medium })?.isSupported,
-            false
-        )
-        XCTAssertEqual(
-            appState.availableModels.first(where: { $0.size == .largeV3 })?.isSupported,
+            appState.availableModels.first(where: { $0.size == .largeV3Latest })?.isSupported,
             true
         )
     }
@@ -344,5 +339,35 @@ final class AppStateModelLoadingTests: XCTestCase {
             appState.availableModels.first(where: { $0.size == .medium })?.isLoading,
             false
         )
+    }
+
+    @MainActor
+    func testStartupFallsBackFromUnsupportedMediumPreference() async {
+        UserDefaults.standard.set(ModelSize.medium.rawValue, forKey: "vocamac.selectedModelSize")
+
+        let modelManager = MockModelManager()
+        modelManager.defaultModel = "openai_whisper-large-v3-v20240930"
+        modelManager.supportedModelNames = [
+            "openai_whisper-tiny",
+            "openai_whisper-base",
+            "openai_whisper-small",
+            "openai_whisper-large-v3-v20240930",
+        ]
+        modelManager.downloadedModels = [.small, .medium]
+
+        let whisperService = MockWhisperService()
+        whisperService.loadedModelName = nil
+        whisperService.isModelLoaded = false
+
+        let (appState, mocks) = AppState.makeTestState(
+            modelManager: modelManager,
+            whisperService: whisperService
+        )
+
+        await appState.performStartup()
+
+        XCTAssertEqual(mocks.whisperService.loadRequests.first?.name, "openai_whisper-small")
+        XCTAssertEqual(appState.selectedModelSize, ModelSize.small.rawValue)
+        XCTAssertEqual(appState.currentModel?.size, .small)
     }
 }

--- a/Tests/VocaMacTests/AppStateTests.swift
+++ b/Tests/VocaMacTests/AppStateTests.swift
@@ -259,3 +259,90 @@ final class AppStateOnboardingTests: XCTestCase {
         XCTAssertEqual(mocks.whisperService.loadedModelName, "openai_whisper-tiny")
     }
 }
+
+// MARK: - AppState Model Loading Tests
+
+final class AppStateModelLoadingTests: XCTestCase {
+
+    override func setUp() {
+        super.setUp()
+        UserDefaults.standard.removeObject(forKey: "vocamac.selectedModelSize")
+    }
+
+    override func tearDown() {
+        UserDefaults.standard.removeObject(forKey: "vocamac.selectedModelSize")
+        super.tearDown()
+    }
+
+    @MainActor
+    func testSetupKeepsLargeSupportedWhenMediumIsNotRecommended() {
+        let modelManager = MockModelManager()
+        modelManager.defaultModel = "openai_whisper-large-v3-v20240930"
+        modelManager.supportedModels = [.tiny, .base, .small, .largeV3]
+        modelManager.supportedModelNames = [
+            "openai_whisper-tiny",
+            "openai_whisper-base",
+            "openai_whisper-small",
+            "openai_whisper-large-v3",
+            "openai_whisper-large-v3-v20240930",
+            "openai_whisper-large-v3-v20240930_626MB",
+        ]
+
+        let (appState, _) = AppState.makeTestState(modelManager: modelManager)
+
+        XCTAssertEqual(appState.deviceRecommendedModel, "openai_whisper-large-v3-v20240930")
+        XCTAssertEqual(
+            appState.availableModels.first(where: { $0.size == .medium })?.isSupported,
+            false
+        )
+        XCTAssertEqual(
+            appState.availableModels.first(where: { $0.size == .largeV3 })?.isSupported,
+            true
+        )
+    }
+
+    @MainActor
+    func testFailedModelSwitchShowsErrorAndRestoresPreviousModel() async {
+        UserDefaults.standard.set(ModelSize.small.rawValue, forKey: "vocamac.selectedModelSize")
+
+        let modelManager = MockModelManager()
+        modelManager.downloadedModels = [.small, .medium]
+
+        let whisperService = MockWhisperService()
+        whisperService.loadedModelName = "openai_whisper-small"
+        whisperService.isModelLoaded = true
+        let loadError = NSError(
+            domain: "VocaMacTests",
+            code: 1,
+            userInfo: [NSLocalizedDescriptionKey: "CoreML rejected model"]
+        )
+        whisperService.loadResponses = [
+            .failure(loadError),
+            .success("openai_whisper-small"),
+        ]
+
+        let (appState, mocks) = AppState.makeTestState(
+            modelManager: modelManager,
+            whisperService: whisperService
+        )
+
+        await appState.loadModel(.medium)
+
+        XCTAssertEqual(
+            mocks.whisperService.loadRequests.map { $0.name },
+            ["openai_whisper-medium", "openai_whisper-small"]
+        )
+        XCTAssertEqual(appState.appStatus, .error)
+        XCTAssertTrue(appState.errorMessage?.contains("Failed to load Medium") == true)
+        XCTAssertEqual(appState.currentModel?.size, .small)
+        XCTAssertEqual(appState.selectedModelSize, ModelSize.small.rawValue)
+        XCTAssertEqual(
+            appState.availableModels.first(where: { $0.size == .small })?.isActive,
+            true
+        )
+        XCTAssertEqual(
+            appState.availableModels.first(where: { $0.size == .medium })?.isLoading,
+            false
+        )
+    }
+}

--- a/Tests/VocaMacTests/Mocks/MockServices.swift
+++ b/Tests/VocaMacTests/Mocks/MockServices.swift
@@ -239,6 +239,8 @@ final class MockCursorOverlay: CursorOverlayManaging {
 final class MockModelManager: ModelManaging {
     var supportedModels: [ModelSize] = ModelSize.allCases
     var defaultModel: String = "openai_whisper-tiny"
+    var supportedModelNames: [String]?
+    var disabledModelNames: [String] = []
     var downloadedModels: Set<ModelSize> = []
     var diskUsage: String = "100 MB"
     var bundledModels: Set<ModelSize> = []
@@ -247,7 +249,11 @@ final class MockModelManager: ModelManaging {
     var installBundledModelError: Error?
 
     func deviceRecommendation() -> (defaultModel: String, supported: [String], disabled: [String]) {
-        (defaultModel: defaultModel, supported: supportedModels.map(whisperKitModelName(for:)), disabled: [])
+        (
+            defaultModel: defaultModel,
+            supported: supportedModelNames ?? supportedModels.map(whisperKitModelName(for:)),
+            disabled: disabledModelNames
+        )
     }
 
     func modelFolder(for size: ModelSize) -> URL? {
@@ -313,11 +319,15 @@ final class MockModelManager: ModelManaging {
 // MARK: - MockWhisperService
 
 final class MockWhisperService: SpeechTranscribing {
+    typealias LoadRequest = (name: String?, folder: URL?)
+
     var loadedModelName: String? = "openai_whisper-tiny"
     var isModelLoaded: Bool = true
     var lastTranscribedAudioData: [Float]?
     var lastLanguage: String?
     var lastTranslate: Bool?
+    var loadRequests: [LoadRequest] = []
+    var loadResponses: [Result<String?, Error>] = []
     var mockTranscriptionResult: VocaTranscription = VocaTranscription(text: "mock transcription", duration: 1.0, detectedLanguage: "en", audioLengthSeconds: 1.0, modelUsed: .tiny)
     var shouldThrow = false
 
@@ -332,6 +342,23 @@ final class MockWhisperService: SpeechTranscribing {
     }
 
     func _loadModel(name: String?, folder: URL?, onPhaseChange: ((String) -> Void)?) async throws {
+        loadRequests.append((name: name, folder: folder))
+        onPhaseChange?("Loading model…")
+
+        if !loadResponses.isEmpty {
+            let response = loadResponses.removeFirst()
+            switch response {
+            case .success(let loadedName):
+                loadedModelName = loadedName ?? name ?? "mock-model"
+                isModelLoaded = true
+                return
+            case .failure(let error):
+                loadedModelName = nil
+                isModelLoaded = false
+                throw error
+            }
+        }
+
         loadedModelName = name ?? "mock-model"
         isModelLoaded = true
     }
@@ -355,7 +382,10 @@ final class MockTextInjector: TextInjecting {
 
 extension AppState {
     @MainActor
-    static func makeTestState() -> (appState: AppState, mocks: TestMocks) {
+    static func makeTestState(
+        modelManager: MockModelManager = MockModelManager(),
+        whisperService: MockWhisperService = MockWhisperService()
+    ) -> (appState: AppState, mocks: TestMocks) {
         UserDefaults.standard.removeObject(forKey: "vocamac.selectedAudioDeviceID")
         UserDefaults.standard.removeObject(forKey: "vocamac.selectedAudioDeviceName")
 
@@ -364,8 +394,6 @@ extension AppState {
         let hotKeyManager = MockHotKeyManager()
         let permissionManager = MockPermissionManager()
         let cursorOverlay = MockCursorOverlay()
-        let modelManager = MockModelManager()
-        let whisperService = MockWhisperService()
         let textInjector = MockTextInjector()
 
         let mocks = TestMocks(

--- a/Tests/VocaMacTests/Mocks/MockServices.swift
+++ b/Tests/VocaMacTests/Mocks/MockServices.swift
@@ -284,27 +284,44 @@ final class MockModelManager: ModelManaging {
     }
 
     func isModelSupported(_ size: ModelSize) -> Bool {
-        supportedModels.contains(size)
+        if let supportedModelNames {
+            return supportedModelNames.contains(whisperKitModelName(for: size))
+                && !disabledModelNames.contains(whisperKitModelName(for: size))
+        }
+        return supportedModels.contains(size)
     }
 
     func whisperKitModelName(for size: ModelSize) -> String {
         switch size {
-        case .tiny:    return "openai_whisper-tiny"
-        case .base:    return "openai_whisper-base"
-        case .small:   return "openai_whisper-small"
-        case .medium:  return "openai_whisper-medium"
-        case .largeV3: return "openai_whisper-large-v3"
+        case .tiny:
+            return "openai_whisper-tiny"
+        case .base:
+            return "openai_whisper-base"
+        case .small:
+            return "openai_whisper-small"
+        case .largeV3LatestTurboCompact:
+            return "openai_whisper-large-v3-v20240930_turbo_632MB"
+        case .distilLargeV3Compact:
+            return "distil-whisper_distil-large-v3_594MB"
+        case .distilLargeV3TurboCompact:
+            return "distil-whisper_distil-large-v3_turbo_600MB"
+        case .largeV3LatestCompact:
+            return "openai_whisper-large-v3-v20240930_626MB"
+        case .largeV3Latest:
+            return "openai_whisper-large-v3-v20240930"
+        case .largeV3LatestTurbo:
+            return "openai_whisper-large-v3-v20240930_turbo"
+        case .largeV3:
+            return "openai_whisper-large-v3"
+        case .largeV3Turbo:
+            return "openai_whisper-large-v3_turbo"
+        case .medium:
+            return "openai_whisper-medium"
         }
     }
 
     func modelSize(from whisperKitName: String) -> ModelSize? {
-        for size in ModelSize.allCases {
-            let prefix = whisperKitModelName(for: size)
-            if whisperKitName == prefix || whisperKitName.hasPrefix(prefix + "-") {
-                return size
-            }
-        }
-        return nil
+        ModelSize.allCases.first { whisperKitModelName(for: $0) == whisperKitName }
     }
 
     func downloadModel(size: ModelSize, onProgress: @escaping (Double) -> Void) async throws {

--- a/Tests/VocaMacTests/ModelTests.swift
+++ b/Tests/VocaMacTests/ModelTests.swift
@@ -23,8 +23,8 @@ final class SystemInfoTests: XCTestCase {
         XCTAssertEqual(SystemInfo.recommendModel(isAppleSilicon: true, memoryGB: 4), .tiny)
         XCTAssertEqual(SystemInfo.recommendModel(isAppleSilicon: true, memoryGB: 8), .base)
         XCTAssertEqual(SystemInfo.recommendModel(isAppleSilicon: true, memoryGB: 16), .small)
-        XCTAssertEqual(SystemInfo.recommendModel(isAppleSilicon: true, memoryGB: 24), .medium)
-        XCTAssertEqual(SystemInfo.recommendModel(isAppleSilicon: true, memoryGB: 48), .medium)
+        XCTAssertEqual(SystemInfo.recommendModel(isAppleSilicon: true, memoryGB: 24), .largeV3LatestTurboCompact)
+        XCTAssertEqual(SystemInfo.recommendModel(isAppleSilicon: true, memoryGB: 48), .largeV3Latest)
     }
 
     func testModelRecommendationIntel() {
@@ -59,10 +59,9 @@ final class SystemInfoTests: XCTestCase {
 
 final class ModelSizeTests: XCTestCase {
 
-    func testModelSizesAscendingFileSize() {
-        let sizes = ModelSize.allCases.map { $0.fileSizeBytes }
-        for i in 1..<sizes.count {
-            XCTAssertGreaterThan(sizes[i], sizes[i - 1])
+    func testModelSizesHavePositiveFileSizes() {
+        for size in ModelSize.allCases {
+            XCTAssertGreaterThan(size.fileSizeBytes, 0)
         }
     }
 
@@ -78,10 +77,9 @@ final class ModelSizeTests: XCTestCase {
         }
     }
 
-    func testRAMRequirementsIncreasing() {
-        let rams = ModelSize.allCases.map { $0.ramRequiredGB }
-        for i in 1..<rams.count {
-            XCTAssertGreaterThanOrEqual(rams[i], rams[i - 1])
+    func testRAMRequirementsPositive() {
+        for size in ModelSize.allCases {
+            XCTAssertGreaterThan(size.ramRequiredGB, 0)
         }
     }
 
@@ -91,23 +89,34 @@ final class ModelSizeTests: XCTestCase {
         }
     }
 
-    func testRelativeSpeedIncreasing() {
-        let speeds = ModelSize.allCases.map { $0.relativeSpeed }
-        for i in 1..<speeds.count {
-            XCTAssertGreaterThan(speeds[i], speeds[i - 1])
+    func testRelativeSpeedsPositive() {
+        for size in ModelSize.allCases {
+            XCTAssertGreaterThan(size.relativeSpeed, 0)
         }
     }
 
     func testAllCasesCount() {
-        XCTAssertEqual(ModelSize.allCases.count, 5)
+        XCTAssertEqual(ModelSize.allCases.count, 12)
     }
 
     func testRawValues() {
         XCTAssertEqual(ModelSize.tiny.rawValue, "tiny")
         XCTAssertEqual(ModelSize.base.rawValue, "base")
         XCTAssertEqual(ModelSize.small.rawValue, "small")
-        XCTAssertEqual(ModelSize.medium.rawValue, "medium")
+        XCTAssertEqual(ModelSize.largeV3LatestTurboCompact.rawValue, "large-v3-v20240930_turbo_632MB")
+        XCTAssertEqual(ModelSize.distilLargeV3Compact.rawValue, "distil-large-v3_594MB")
+        XCTAssertEqual(ModelSize.distilLargeV3TurboCompact.rawValue, "distil-large-v3_turbo_600MB")
+        XCTAssertEqual(ModelSize.largeV3LatestCompact.rawValue, "large-v3-v20240930_626MB")
+        XCTAssertEqual(ModelSize.largeV3Latest.rawValue, "large-v3-v20240930")
+        XCTAssertEqual(ModelSize.largeV3LatestTurbo.rawValue, "large-v3-v20240930_turbo")
         XCTAssertEqual(ModelSize.largeV3.rawValue, "large-v3")
+        XCTAssertEqual(ModelSize.largeV3Turbo.rawValue, "large-v3_turbo")
+        XCTAssertEqual(ModelSize.medium.rawValue, "medium")
+    }
+
+    func testStandardCatalogExcludesLegacyMedium() {
+        XCTAssertFalse(ModelSize.standardCatalog.contains(.medium))
+        XCTAssertTrue(ModelSize.medium.isLegacy)
     }
 }
 
@@ -120,8 +129,45 @@ final class ModelManagerTests: XCTestCase {
         XCTAssertEqual(manager.whisperKitModelName(for: .tiny), "openai_whisper-tiny")
         XCTAssertEqual(manager.whisperKitModelName(for: .base), "openai_whisper-base")
         XCTAssertEqual(manager.whisperKitModelName(for: .small), "openai_whisper-small")
-        XCTAssertEqual(manager.whisperKitModelName(for: .medium), "openai_whisper-medium")
+        XCTAssertEqual(manager.whisperKitModelName(for: .largeV3LatestTurboCompact), "openai_whisper-large-v3-v20240930_turbo_632MB")
+        XCTAssertEqual(manager.whisperKitModelName(for: .distilLargeV3Compact), "distil-whisper_distil-large-v3_594MB")
+        XCTAssertEqual(manager.whisperKitModelName(for: .distilLargeV3TurboCompact), "distil-whisper_distil-large-v3_turbo_600MB")
+        XCTAssertEqual(manager.whisperKitModelName(for: .largeV3LatestCompact), "openai_whisper-large-v3-v20240930_626MB")
+        XCTAssertEqual(manager.whisperKitModelName(for: .largeV3Latest), "openai_whisper-large-v3-v20240930")
+        XCTAssertEqual(manager.whisperKitModelName(for: .largeV3LatestTurbo), "openai_whisper-large-v3-v20240930_turbo")
         XCTAssertEqual(manager.whisperKitModelName(for: .largeV3), "openai_whisper-large-v3")
+        XCTAssertEqual(manager.whisperKitModelName(for: .largeV3Turbo), "openai_whisper-large-v3_turbo")
+        XCTAssertEqual(manager.whisperKitModelName(for: .medium), "openai_whisper-medium")
+    }
+
+    func testModelSizeFromWhisperKitNameUsesExactVariant() {
+        let manager = ModelManager()
+        XCTAssertEqual(manager.modelSize(from: "openai_whisper-large-v3-v20240930"), .largeV3Latest)
+        XCTAssertEqual(manager.modelSize(from: "openai_whisper-large-v3-v20240930_626MB"), .largeV3LatestCompact)
+        XCTAssertEqual(manager.modelSize(from: "openai_whisper-large-v3"), .largeV3)
+        XCTAssertEqual(manager.modelSize(from: "openai_whisper-large-v3_turbo"), .largeV3Turbo)
+        XCTAssertNil(manager.modelSize(from: "openai_whisper-large-v3-v20240930_extra"))
+    }
+
+    func testUsableCoreMLComponentRequiresWeights() throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+        let component = root.appendingPathComponent("AudioEncoder.mlmodelc", isDirectory: true)
+        try FileManager.default.createDirectory(
+            at: component,
+            withIntermediateDirectories: true
+        )
+        try Data("{}".utf8).write(to: component.appendingPathComponent("metadata.json"))
+        try Data("mil".utf8).write(to: component.appendingPathComponent("model.mil"))
+
+        XCTAssertFalse(ModelManager.hasUsableCoreMLComponent(at: component))
+
+        let weights = component.appendingPathComponent("weights", isDirectory: true)
+        try FileManager.default.createDirectory(at: weights, withIntermediateDirectories: true)
+        try Data("weights".utf8).write(to: weights.appendingPathComponent("weight.bin"))
+
+        XCTAssertTrue(ModelManager.hasUsableCoreMLComponent(at: component))
     }
 
     func testDownloadedModelsReturnsArray() {
@@ -274,4 +320,3 @@ final class ActivationModeTests: XCTestCase {
         XCTAssertEqual(ActivationMode.doubleTapToggle.rawValue, "doubleTapToggle")
     }
 }
-


### PR DESCRIPTION
## Summary
- replace the old size-ladder model picker with a Mac-focused WhisperKit variant catalog
- keep Medium as a legacy value but remove it from the normal Apple Silicon picker unless WhisperKit explicitly supports it
- map recommended and loaded models by exact WhisperKit variant name so Large v3, latest, turbo, compact, and distil variants do not collapse into one bucket
- reject incomplete CoreML model caches that are missing weights, so skeleton folders like the broken Medium cache are not treated as downloaded
- keep the earlier recovery behavior: model-load failures are visible in Settings and the previous working model is restored when possible

## Why
On M-series Macs, WhisperKit does not expose a monotonic Tiny/Base/Small/Medium/Large ladder. Its support table can omit Medium while supporting modern Large v3 variants. The app should follow that exact catalog instead of encouraging users toward an unsupported Medium artifact.

## Tests
- `swift build`
- `git diff --check`
- `swift test --filter "SystemInfoTests|ModelSizeTests|ModelManagerTests|WhisperModelInfoTests"`
- `swift test --filter AppState`
- `swift test` (196 tests, 1 skipped, 0 failures)