### PR TITLE
fix: derive PR build version from app default

### DIFF
--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -160,8 +160,15 @@ jobs:
       # ── Build & Package ─────────────────────────────────────────────────────
       - name: Set PR build version
         run: |
-          # Tag the build so it's identifiable (e.g., 0.5.0-pr.106+abc1234)
-          BASE_VERSION="${APP_VERSION:-0.5.0}"
+          # Tag the build so it's identifiable (e.g., 0.6.2-pr.106+abc1234)
+          BASE_VERSION="${APP_VERSION:-}"
+          if [ -z "$BASE_VERSION" ]; then
+            BASE_VERSION="$(grep '^APP_VERSION=' scripts/build.sh | sed 's/.*:-\(.*\)}.*/\1/' | head -1 || true)"
+          fi
+          if [ -z "$BASE_VERSION" ]; then
+            echo "❌ Unable to determine base app version from scripts/build.sh" >&2
+            exit 1
+          fi
           PR_VERSION="${BASE_VERSION}-pr.${{ steps.pr.outputs.pr_number }}+${{ steps.pr.outputs.short_sha }}"
           echo "APP_VERSION=$PR_VERSION" >> "$GITHUB_ENV"
           echo "📦 Build version: $PR_VERSION"

--- a/scripts/dist.sh
+++ b/scripts/dist.sh
@@ -36,8 +36,13 @@ for arg in "$@"; do
     esac
 done
 
-# Get version from APP_VERSION env var (if set) or from build.sh's Info.plist template
-VERSION="${APP_VERSION:-$(grep -A1 'CFBundleShortVersionString' scripts/build.sh | grep '<string>' | sed 's/.*<string>\(.*\)<\/string>/\1/' | head -1)}"
+# Get version from APP_VERSION env var (if set) or from build.sh's default APP_VERSION.
+DEFAULT_APP_VERSION="$(grep '^APP_VERSION=' scripts/build.sh | sed 's/.*:-\(.*\)}.*/\1/' | head -1 || true)"
+VERSION="${APP_VERSION:-$DEFAULT_APP_VERSION}"
+if [ -z "$VERSION" ]; then
+    echo "❌ Unable to determine app version. Set APP_VERSION or update scripts/build.sh." >&2
+    exit 1
+fi
 ARCH=$(uname -m)
 APP_NAME="VocaMac"
 DMG_NAME="${APP_NAME}-${VERSION}-${ARCH}.dmg"


### PR DESCRIPTION
## Summary
- derive `/build` PR artifact versions from `scripts/build.sh` instead of the stale `0.5.0` fallback
- fail the PR build version step if the app default version cannot be read
- update `scripts/dist.sh` to use the same default APP_VERSION source when no env override is provided

## Verification
- `bash -n scripts/dist.sh`
- `git diff --check`
- simulated PR version step: `0.6.2-pr.161+4180b0a`
- simulated APP_VERSION override: `9.9.9-pr.161+4180b0a`
- simulated `dist.sh` fallback version: `0.6.2`