### PR TITLE
fix: use local calendar days for stats streaks

### DIFF
--- a/Sources/VocaMac/Services/StatsManager.swift
+++ b/Sources/VocaMac/Services/StatsManager.swift
@@ -18,14 +18,6 @@ class StatsManager: StatsManaging, ObservableObject {
     private let statsFileURL: URL
     private let calendar: Calendar
 
-    private static let dateFormatter: DateFormatter = {
-        let formatter = DateFormatter()
-        formatter.dateFormat = "yyyy-MM-dd"
-        formatter.locale = Locale(identifier: "en_US_POSIX")
-        formatter.timeZone = TimeZone(secondsFromGMT: 0)
-        return formatter
-    }()
-
     init(statsFileURL: URL? = nil, calendar: Calendar = .current) {
         if let statsFileURL {
             self.statsFileURL = statsFileURL
@@ -76,7 +68,7 @@ class StatsManager: StatsManaging, ObservableObject {
             .filter { !$0.isEmpty }
             .count
 
-        let dateKey = Self.dateFormatter.string(from: transcription.timestamp)
+        let dateKey = dayKey(for: transcription.timestamp)
 
         // Update basic counts
         stats.totalWords += words
@@ -100,6 +92,14 @@ class StatsManager: StatsManaging, ObservableObject {
         saveStats()
     }
 
+    private func dayKey(for date: Date) -> String {
+        let components = calendar.dateComponents([.year, .month, .day], from: date)
+        guard let year = components.year, let month = components.month, let day = components.day else {
+            return "unknown"
+        }
+        return String(format: "%04d-%02d-%02d", year, month, day)
+    }
+
     private func updateStreaks(currentDate: Date) {
         guard let lastDate = stats.lastUsageDate else {
             // First time usage
@@ -108,16 +108,19 @@ class StatsManager: StatsManaging, ObservableObject {
             return
         }
 
-        // Check if last usage was yesterday
-        if calendar.isDateInYesterday(lastDate) {
+        let lastDay = calendar.startOfDay(for: lastDate)
+        let currentDay = calendar.startOfDay(for: currentDate)
+        let daysBetween = calendar.dateComponents([.day], from: lastDay, to: currentDay).day
+
+        switch daysBetween {
+        case 0:
+            // Already used on this calendar day, streak remains same
+            break
+        case 1:
             // Continuation of streak
-            if !calendar.isDate(lastDate, inSameDayAs: currentDate) {
-                stats.currentStreak += 1
-            }
-        } else if calendar.isDate(lastDate, inSameDayAs: currentDate) {
-            // Already used today, streak remains same
-        } else {
-            // Streak broken
+            stats.currentStreak += 1
+        default:
+            // Streak broken or older transcription recorded out of order
             stats.currentStreak = 1
         }
 

--- a/Tests/VocaMacTests/StatsManagerTests.swift
+++ b/Tests/VocaMacTests/StatsManagerTests.swift
@@ -129,6 +129,88 @@ final class StatsManagerTests: XCTestCase {
     }
 
     @MainActor
+    func testDailyBucketsUseInjectedCalendarTimeZone() {
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = TimeZone(secondsFromGMT: 2 * 60 * 60)!
+        statsManager = StatsManager(statsFileURL: tempFileURL, calendar: calendar)
+
+        let nearMidnightUTC = Date(timeIntervalSince1970: 1_704_060_000) // 2023-12-31 22:00:00 UTC, 2024-01-01 in GMT+2
+        let transcription = VocaTranscription(
+            text: "local day",
+            duration: 1.0,
+            detectedLanguage: "en",
+            audioLengthSeconds: 1.0,
+            modelUsed: .tiny,
+            timestamp: nearMidnightUTC
+        )
+
+        statsManager.recordTranscription(transcription)
+
+        XCTAssertEqual(statsManager.stats.dailyWordCounts["2024-01-01"], 2)
+        XCTAssertNil(statsManager.stats.dailyWordCounts["2023-12-31"])
+    }
+
+    @MainActor
+    func testStreakUsesTranscriptionDateRatherThanCurrentDate() {
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = TimeZone(secondsFromGMT: 0)!
+        statsManager = StatsManager(statsFileURL: tempFileURL, calendar: calendar)
+
+        let firstDay = Date(timeIntervalSince1970: 946_684_800) // 2000-01-01 00:00:00 UTC
+        let secondDay = Date(timeIntervalSince1970: 946_771_200) // 2000-01-02 00:00:00 UTC
+
+        statsManager.recordTranscription(VocaTranscription(
+            text: "first day",
+            duration: 1.0,
+            detectedLanguage: "en",
+            audioLengthSeconds: 1.0,
+            modelUsed: .tiny,
+            timestamp: firstDay
+        ))
+        statsManager.recordTranscription(VocaTranscription(
+            text: "second day",
+            duration: 1.0,
+            detectedLanguage: "en",
+            audioLengthSeconds: 1.0,
+            modelUsed: .tiny,
+            timestamp: secondDay
+        ))
+
+        XCTAssertEqual(statsManager.stats.currentStreak, 2)
+        XCTAssertEqual(statsManager.stats.bestStreak, 2)
+    }
+
+    @MainActor
+    func testSameDayTranscriptionsDoNotIncrementStreak() {
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = TimeZone(secondsFromGMT: 0)!
+        statsManager = StatsManager(statsFileURL: tempFileURL, calendar: calendar)
+
+        let first = Date(timeIntervalSince1970: 946_684_800) // 2000-01-01 00:00:00 UTC
+        let second = Date(timeIntervalSince1970: 946_728_000) // 2000-01-01 12:00:00 UTC
+
+        statsManager.recordTranscription(VocaTranscription(
+            text: "morning words",
+            duration: 1.0,
+            detectedLanguage: "en",
+            audioLengthSeconds: 1.0,
+            modelUsed: .tiny,
+            timestamp: first
+        ))
+        statsManager.recordTranscription(VocaTranscription(
+            text: "afternoon words",
+            duration: 1.0,
+            detectedLanguage: "en",
+            audioLengthSeconds: 1.0,
+            modelUsed: .tiny,
+            timestamp: second
+        ))
+
+        XCTAssertEqual(statsManager.stats.currentStreak, 1)
+        XCTAssertEqual(statsManager.stats.bestStreak, 1)
+    }
+
+    @MainActor
     func testResetStats() {
         let transcription = VocaTranscription(text: "Test", duration: 1.0, detectedLanguage: "en", audioLengthSeconds: 1.0, modelUsed: .tiny)
         statsManager.recordTranscription(transcription)


### PR DESCRIPTION
## Summary
- derive stats daily buckets from the injected calendar instead of a UTC-only formatter
- calculate streak continuity relative to the transcription timestamp instead of the machine's current date
- add regression coverage for local day boundaries, historical consecutive days, and same-day transcriptions

## Tests
- `swift test --filter StatsManagerTests`

Note: I also started a full `swift test` run locally, but it hung after build output with no test logs, so I stopped that process and relied on the focused stats regression suite for this follow-up.