### PR TITLE
feat: custom vocabulary for names and jargon

### DIFF
--- a/Sources/VocaMac/Models/AppState.swift
+++ b/Sources/VocaMac/Models/AppState.swift
@@ -108,6 +108,7 @@ final class AppState: ObservableObject {
     @AppStorage("vocamac.soundEffectsEnabled") var soundEffectsEnabled: Bool = true
     @AppStorage("vocamac.showCursorIndicator") var showCursorIndicator: Bool = true
     @AppStorage("vocamac.translationEnabled") var translationEnabled: Bool = false
+    @AppStorage("vocamac.customVocabulary") var customVocabulary: String = ""
     @AppStorage("vocamac.logLevel") var logLevel: String = "info"
 
     private var hotKeySafetyTimeout: Double {
@@ -593,7 +594,8 @@ final class AppState: ObservableObject {
             let result = try await whisperService.transcribe(
                 audioData: audioData,
                 language: language,
-                translate: translationEnabled
+                translate: translationEnabled,
+                vocabulary: customVocabulary
             )
 
             lastTranscription = result

--- a/Sources/VocaMac/Services/ServiceProtocols.swift
+++ b/Sources/VocaMac/Services/ServiceProtocols.swift
@@ -129,7 +129,7 @@ extension ModelManaging {
 protocol SpeechTranscribing: AnyObject {
     var loadedModelName: String? { get }
     var isModelLoaded: Bool { get }
-    func transcribe(audioData: [Float], language: String?, translate: Bool) async throws -> VocaTranscription
+    func transcribe(audioData: [Float], language: String?, translate: Bool, vocabulary: String) async throws -> VocaTranscription
     func _loadModel(name: String?, folder: URL?, onPhaseChange: ((String) -> Void)?) async throws
 }
 

--- a/Sources/VocaMac/Services/WhisperService.swift
+++ b/Sources/VocaMac/Services/WhisperService.swift
@@ -136,11 +136,14 @@ final class WhisperService: @unchecked Sendable {
     ///   - audioData: Array of Float32 PCM samples at 16kHz mono
     ///   - language: ISO 639-1 language code (e.g., "en"), or nil for auto-detection
     ///   - translate: Whether to translate to English (if true) or transcribe as-is (if false)
+    ///   - vocabulary: Custom terms (newline/comma separated) to bias transcription toward,
+    ///     e.g. proper nouns and jargon like names. Empty string disables it.
     /// - Returns: VocaTranscription with the transcribed text and metadata
     func transcribe(
         audioData: [Float],
         language: String? = nil,
-        translate: Bool = false
+        translate: Bool = false,
+        vocabulary: String = ""
     ) async throws -> VocaTranscription {
         guard let kit = whisperKit else {
             throw WhisperError.modelNotLoaded
@@ -155,15 +158,23 @@ final class WhisperService: @unchecked Sendable {
 
         let startTime = CFAbsoluteTimeGetCurrent()
 
+        // Encode the user's custom vocabulary into conditioning tokens so the
+        // model biases toward their proper nouns / jargon (e.g. names like
+        // "Namrata"). WhisperKit only applies promptTokens when usePrefillPrompt
+        // is true, so we force it on whenever vocabulary is present — otherwise
+        // the terms would be silently ignored in auto-detect mode.
+        let promptTokens = Self.promptTokens(for: vocabulary, tokenizer: kit.tokenizer)
+
         // Configure decoding options — optimized for low latency dictation
         let options = DecodingOptions(
             task: translate ? .translate : .transcribe,
             language: language,
             temperature: 0.0,
             temperatureFallbackCount: 0,  // No fallback for speed
-            usePrefillPrompt: language != nil,
+            usePrefillPrompt: language != nil || promptTokens != nil,
             detectLanguage: language == nil,
             wordTimestamps: false,
+            promptTokens: promptTokens,
             chunkingStrategy: nil  // No chunking for short dictation clips
         )
 
@@ -250,6 +261,30 @@ final class WhisperService: @unchecked Sendable {
         // Collapse multiple spaces left behind by removed tokens
         cleaned = cleaned.replacingOccurrences(of: "  +", with: " ", options: .regularExpression)
         return cleaned.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    // MARK: - Custom Vocabulary
+
+    /// Parse a raw vocabulary string into individual terms. Terms are separated
+    /// by newlines or commas; surrounding whitespace and blank entries are dropped.
+    static func vocabularyTerms(from vocabulary: String) -> [String] {
+        vocabulary
+            .split(whereSeparator: { $0 == "\n" || $0 == "," })
+            .map { $0.trimmingCharacters(in: .whitespaces) }
+            .filter { !$0.isEmpty }
+    }
+
+    /// Encode custom vocabulary into WhisperKit conditioning tokens.
+    /// Returns nil when there are no terms or the tokenizer isn't ready yet.
+    /// Framed as a "Glossary:" prompt, which nudges Whisper to treat the terms
+    /// as domain vocabulary without confusing it about the audio. WhisperKit
+    /// trims to its own token budget and strips special tokens internally.
+    private static func promptTokens(for vocabulary: String, tokenizer: WhisperTokenizer?) -> [Int]? {
+        guard let tokenizer else { return nil }
+        let terms = vocabularyTerms(from: vocabulary)
+        guard !terms.isEmpty else { return nil }
+        let tokens = tokenizer.encode(text: "Glossary: " + terms.joined(separator: ", "))
+        return tokens.isEmpty ? nil : tokens
     }
 
     /// Map a model name string to our ModelSize enum

--- a/Sources/VocaMac/Views/SettingsView.swift
+++ b/Sources/VocaMac/Views/SettingsView.swift
@@ -168,7 +168,11 @@ struct GeneralSettingsTab: View {
                 let count = WhisperService.vocabularyTerms(from: appState.customVocabulary).count
                 Text(count == 0
                     ? "Add names, jargon, or proper nouns (one per line, or comma-separated) that get mis-transcribed. VocaMac hints these to the model so it spells them right."
-                    : "\(count) term\(count == 1 ? "" : "s"). Keep the list short — the model can only use the first ~50–100 words as a hint.")
+                    : "\(count) term\(count == 1 ? "" : "s"). Keep the list short, since the model can only use the first 50 to 100 words as a hint.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+
+                Text("For best results, enter terms in the language you dictate and set a matching Transcription Language above. In Auto-detect, the terms can also nudge which language VocaMac picks.")
                     .font(.caption)
                     .foregroundStyle(.secondary)
             }

--- a/Sources/VocaMac/Views/SettingsView.swift
+++ b/Sources/VocaMac/Views/SettingsView.swift
@@ -149,6 +149,30 @@ struct GeneralSettingsTab: View {
                     .font(.caption)
                     .foregroundStyle(.secondary)
             }
+
+            // Custom Vocabulary
+            Section("Custom Vocabulary") {
+                TextEditor(text: $appState.customVocabulary)
+                    .font(.body)
+                    .frame(minHeight: 90)
+                    .overlay(alignment: .topLeading) {
+                        if appState.customVocabulary.isEmpty {
+                            Text("Namrata\nKubernetes\nVocaMac")
+                                .foregroundStyle(.tertiary)
+                                .padding(.top, 8)
+                                .padding(.leading, 5)
+                                .allowsHitTesting(false)
+                        }
+                    }
+
+                let count = WhisperService.vocabularyTerms(from: appState.customVocabulary).count
+                Text(count == 0
+                    ? "Add names, jargon, or proper nouns (one per line, or comma-separated) that get mis-transcribed. VocaMac hints these to the model so it spells them right."
+                    : "\(count) term\(count == 1 ? "" : "s"). Keep the list short — the model can only use the first ~50–100 words as a hint.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+
             Section("Behavior") {
                 Toggle("Launch at Login", isOn: Binding(
                     get: { appState.launchAtLogin },

--- a/Sources/VocaMac/Views/SettingsView.swift
+++ b/Sources/VocaMac/Views/SettingsView.swift
@@ -157,7 +157,7 @@ struct GeneralSettingsTab: View {
                     .frame(minHeight: 90)
                     .overlay(alignment: .topLeading) {
                         if appState.customVocabulary.isEmpty {
-                            Text("Namrata\nKubernetes\nVocaMac")
+                            Text("kubectl, PostgreSQL, nginx, Grafana")
                                 .foregroundStyle(.tertiary)
                                 .padding(.top, 8)
                                 .padding(.leading, 5)

--- a/Tests/VocaMacTests/Mocks/MockServices.swift
+++ b/Tests/VocaMacTests/Mocks/MockServices.swift
@@ -343,15 +343,17 @@ final class MockWhisperService: SpeechTranscribing {
     var lastTranscribedAudioData: [Float]?
     var lastLanguage: String?
     var lastTranslate: Bool?
+    var lastVocabulary: String?
     var loadRequests: [LoadRequest] = []
     var loadResponses: [Result<String?, Error>] = []
     var mockTranscriptionResult: VocaTranscription = VocaTranscription(text: "mock transcription", duration: 1.0, detectedLanguage: "en", audioLengthSeconds: 1.0, modelUsed: .tiny)
     var shouldThrow = false
 
-    func transcribe(audioData: [Float], language: String?, translate: Bool) async throws -> VocaTranscription {
+    func transcribe(audioData: [Float], language: String?, translate: Bool, vocabulary: String) async throws -> VocaTranscription {
         lastTranscribedAudioData = audioData
         lastLanguage = language
         lastTranslate = translate
+        lastVocabulary = vocabulary
         if shouldThrow {
             throw WhisperError.transcriptionFailed(reason: "mock error")
         }

--- a/Tests/VocaMacTests/WhisperServiceTests.swift
+++ b/Tests/VocaMacTests/WhisperServiceTests.swift
@@ -66,3 +66,26 @@ final class WhisperServiceHallucinationTests: XCTestCase {
         XCTAssertEqual(result, "", "Should return empty after filtering and trimming")
     }
 }
+
+// MARK: - WhisperService Custom Vocabulary Tests
+
+final class WhisperServiceVocabularyTests: XCTestCase {
+
+    func testEmptyStringYieldsNoTerms() {
+        XCTAssertEqual(WhisperService.vocabularyTerms(from: ""), [])
+        XCTAssertEqual(WhisperService.vocabularyTerms(from: "   \n  \n"), [])
+    }
+
+    func testSplitsOnNewlinesAndCommas() {
+        let input = "Namrata\nKubernetes, kubectl\n  etcd  "
+        XCTAssertEqual(
+            WhisperService.vocabularyTerms(from: input),
+            ["Namrata", "Kubernetes", "kubectl", "etcd"]
+        )
+    }
+
+    func testDropsBlankEntries() {
+        let input = "Namrata,,\n\n, ,VocaMac"
+        XCTAssertEqual(WhisperService.vocabularyTerms(from: input), ["Namrata", "VocaMac"])
+    }
+}


### PR DESCRIPTION
Requested in #24: a custom dictionary so names and jargon stop getting mangled by the model. Two users have now asked for it, and the common case is coworker or manager names ("Namrata" coming out as "Normada" or "Nam orda").

## What this does

Adds a Custom Vocabulary text box in Settings > General. You type the terms that get mis-transcribed, one per line or comma-separated. VocaMac feeds them to WhisperKit as prompt context so it biases toward the right spelling.

## How it works

The terms are parsed, framed as a "Glossary: ..." prompt, tokenized via `whisperKit.tokenizer`, and passed to `DecodingOptions.promptTokens`. WhisperKit trims to its own token budget and strips special tokens, so there is nothing to manage on our side.

One thing worth calling out for review: WhisperKit only applies `promptTokens` when `usePrefillPrompt` is true, and we were setting that flag only when the user picked an explicit language. So the vocabulary would have been silently dropped in auto-detect mode, which is the default. This PR forces the flag on whenever vocabulary is present.

## Why a text field and not a config file
<img width="672" height="670" alt="image" src="https://github.com/user-attachments/assets/5caec7ae-05db-4767-b93d-4cdb474fd2ab" />


VocaMac keeps its files out of Documents and the home folder to avoid macOS permission prompts (see the model-storage note in `WhisperService`). A user-facing config file would bring that friction back, plus file watching and parse-error handling. A text field is discoverable and persists through `@AppStorage` like the rest of the settings.

## Testing

Added unit tests for the term parsing (newline and comma split, trimming, dropping blanks). Build is green and all 34 tests pass.

Tested on local as well: 
<img width="1144" height="785" alt="image" src="https://github.com/user-attachments/assets/4caf3d88-b0ef-45bd-b506-5d543d89231c" />
