### PR TITLE
fix: address stats review follow-ups (persistence, UX, tokenization)

### DIFF
--- a/Sources/VocaMac/Models/UserStats.swift
+++ b/Sources/VocaMac/Models/UserStats.swift
@@ -28,14 +28,30 @@ struct UserStats: Codable {
     /// Key is date string in "yyyy-MM-dd" format
     var dailyWordCounts: [String: Int] = [:]
 
-    /// Daily duration to calculate WPM history
-    var dailyDurationSeconds: [String: Double] = [:]
-
     /// Calculated average Words Per Minute (WPM).
     /// Note: This is "words-per-minute-of-audio", dividing total words by total audio duration.
     var averageWPM: Double {
         guard totalAudioDurationSeconds > 0 else { return 0 }
         let minutes = totalAudioDurationSeconds / 60.0
         return Double(totalWords) / minutes
+    }
+}
+
+extension UserStats {
+    /// Decode leniently so evolving the schema never wipes a user's saved stats:
+    /// any key missing from an older `stats.json` falls back to its default.
+    /// (Synthesized `Codable` requires every non-optional key, so adding a field
+    /// later would otherwise fail decoding and silently reset all history.)
+    /// Declared in an extension to keep the memberwise `UserStats()` initializer.
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.init()
+        totalWords = try container.decodeIfPresent(Int.self, forKey: .totalWords) ?? totalWords
+        totalTranscriptions = try container.decodeIfPresent(Int.self, forKey: .totalTranscriptions) ?? totalTranscriptions
+        totalAudioDurationSeconds = try container.decodeIfPresent(Double.self, forKey: .totalAudioDurationSeconds) ?? totalAudioDurationSeconds
+        lastUsageDate = try container.decodeIfPresent(Date.self, forKey: .lastUsageDate)
+        currentStreak = try container.decodeIfPresent(Int.self, forKey: .currentStreak) ?? currentStreak
+        bestStreak = try container.decodeIfPresent(Int.self, forKey: .bestStreak) ?? bestStreak
+        dailyWordCounts = try container.decodeIfPresent([String: Int].self, forKey: .dailyWordCounts) ?? dailyWordCounts
     }
 }

--- a/Sources/VocaMac/Services/StatsManager.swift
+++ b/Sources/VocaMac/Services/StatsManager.swift
@@ -18,11 +18,15 @@ class StatsManager: StatsManaging, ObservableObject {
     private let statsFileURL: URL
     private let calendar: Calendar
 
+    /// Serial queue for off-main disk writes so recording never blocks the UI.
+    private let saveQueue = DispatchQueue(label: "com.vocamac.stats.save", qos: .utility)
+
     init(statsFileURL: URL? = nil, calendar: Calendar = .current) {
         if let statsFileURL {
             self.statsFileURL = statsFileURL
         } else {
-            let appSupport = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first!
+            let appSupport = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first
+                ?? FileManager.default.temporaryDirectory
             let vMacDir = appSupport.appendingPathComponent("VocaMac", isDirectory: true)
 
             // Ensure directory exists
@@ -50,12 +54,23 @@ class StatsManager: StatsManaging, ObservableObject {
     }
 
     private func saveStats() {
+        // Encode on the main actor (cheap, tiny payload), then write off-main so a
+        // busy disk can't hitch the UI. The serial queue preserves write ordering.
+        let data: Data
         do {
-            let data = try JSONEncoder().encode(stats)
-            try data.write(to: statsFileURL, options: .atomic)
-            VocaLogger.debug(.general, "User stats saved to disk")
+            data = try JSONEncoder().encode(stats)
         } catch {
-            VocaLogger.error(.general, "Failed to save stats: \(error.localizedDescription)")
+            VocaLogger.error(.general, "Failed to encode stats: \(error.localizedDescription)")
+            return
+        }
+        let url = statsFileURL
+        saveQueue.async {
+            do {
+                try data.write(to: url, options: .atomic)
+                VocaLogger.debug(.general, "User stats saved to disk")
+            } catch {
+                VocaLogger.error(.general, "Failed to save stats: \(error.localizedDescription)")
+            }
         }
     }
 
@@ -63,10 +78,12 @@ class StatsManager: StatsManaging, ObservableObject {
         let text = transcription.text.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !text.isEmpty else { return }
 
-        // Estimate word count
-        let words = text.components(separatedBy: .whitespacesAndNewlines)
-            .filter { !$0.isEmpty }
-            .count
+        // Count words using the system tokenizer so space-less scripts
+        // (Chinese, Japanese, Thai, …) aren't undercounted as a single word.
+        var words = 0
+        text.enumerateSubstrings(in: text.startIndex..<text.endIndex, options: .byWords) { _, _, _, _ in
+            words += 1
+        }
 
         let dateKey = dayKey(for: transcription.timestamp)
 
@@ -77,7 +94,6 @@ class StatsManager: StatsManaging, ObservableObject {
 
         // Update daily stats
         stats.dailyWordCounts[dateKey, default: 0] += words
-        stats.dailyDurationSeconds[dateKey, default: 0] += transcription.audioLengthSeconds
 
         // Update streaks
         updateStreaks(currentDate: transcription.timestamp)

--- a/Sources/VocaMac/Views/StatsSettingsTab.swift
+++ b/Sources/VocaMac/Views/StatsSettingsTab.swift
@@ -7,6 +7,7 @@ import SwiftUI
 
 struct StatsSettingsTab: View {
     @EnvironmentObject var appState: AppState
+    @State private var showingResetConfirmation = false
 
     private static let durationFormatter: DateComponentsFormatter = {
         let formatter = DateComponentsFormatter()
@@ -19,6 +20,9 @@ struct StatsSettingsTab: View {
     private static let dateFormatter: DateFormatter = {
         let formatter = DateFormatter()
         formatter.dateFormat = "yyyy-MM-dd"
+        // Fixed locale so the "yyyy-MM-dd" keys (written with a Gregorian calendar)
+        // parse back correctly regardless of the user's default calendar/locale.
+        formatter.locale = Locale(identifier: "en_US_POSIX")
         return formatter
     }()
 
@@ -74,7 +78,7 @@ struct StatsSettingsTab: View {
                                 .font(.system(size: 32, weight: .bold, design: .rounded))
                             + Text(" WPM").font(.headline).foregroundColor(.secondary)
 
-                            Text("Words Per Minute")
+                            Text("Speaking Speed")
                                 .font(.caption)
                                 .foregroundStyle(.secondary)
                         }
@@ -139,7 +143,7 @@ struct StatsSettingsTab: View {
 
                 // Reset Button
                 Button(role: .destructive) {
-                    appState.statsManager.resetStats()
+                    showingResetConfirmation = true
                 } label: {
                     Label("Reset All Statistics", systemImage: "trash")
                 }
@@ -148,6 +152,14 @@ struct StatsSettingsTab: View {
                 .padding(.top, 20)
             }
             .padding()
+        }
+        .alert("Reset All Statistics?", isPresented: $showingResetConfirmation) {
+            Button("Reset", role: .destructive) {
+                appState.statsManager.resetStats()
+            }
+            Button("Cancel", role: .cancel) {}
+        } message: {
+            Text("This permanently deletes all your usage statistics. This action cannot be undone.")
         }
     }
 

--- a/Tests/VocaMacTests/StatsManagerTests.swift
+++ b/Tests/VocaMacTests/StatsManagerTests.swift
@@ -220,4 +220,37 @@ final class StatsManagerTests: XCTestCase {
         XCTAssertEqual(statsManager.stats.totalTranscriptions, 0)
         XCTAssertEqual(statsManager.stats.totalWords, 0)
     }
+
+    @MainActor
+    func testWordCountHandlesSpacelessScripts() {
+        // Japanese has no word separators; a naive whitespace split counts it as 1.
+        let transcription = VocaTranscription(
+            text: "これはテストです",
+            duration: 1.0,
+            detectedLanguage: "ja",
+            audioLengthSeconds: 1.0,
+            modelUsed: .tiny
+        )
+
+        statsManager.recordTranscription(transcription)
+
+        XCTAssertGreaterThan(statsManager.stats.totalWords, 1, "Space-less scripts should be tokenized into multiple words")
+    }
+
+    func testStatsDecodeToleratesMissingAndUnknownKeys() throws {
+        // Simulates an older/newer stats.json: only one known key present, plus a
+        // now-removed legacy key. Decoding must not throw or wipe — missing keys
+        // fall back to defaults and unknown keys are ignored.
+        let json = Data("""
+        {"totalWords": 42, "dailyDurationSeconds": {"2024-01-01": 5.0}}
+        """.utf8)
+
+        let decoded = try JSONDecoder().decode(UserStats.self, from: json)
+
+        XCTAssertEqual(decoded.totalWords, 42)
+        XCTAssertEqual(decoded.totalTranscriptions, 0)
+        XCTAssertEqual(decoded.currentStreak, 0)
+        XCTAssertNil(decoded.lastUsageDate)
+        XCTAssertTrue(decoded.dailyWordCounts.isEmpty)
+    }
 }


### PR DESCRIPTION
## Summary

Follow-up to the review of #148 (stats feature) by @Mr-Sunglasses. Note that #148 is already merged, and #168 landed the two biggest review findings (UTC-vs-local timezone bucketing and the wall-clock streak dependency), along with tests. This PR cleans up the **remaining** review findings.

<img width="672" height="670" alt="image" src="https://github.com/user-attachments/assets/32a58c04-42be-49ad-abea-78ed76a40658" />


## Changes

**Persistence / data safety**
- `UserStats` now decodes leniently (`decodeIfPresent` + defaults). Synthesized `Codable` requires every non-optional key, so the day a new field is added, every existing `stats.json` would fail to decode and silently reset all history. Lenient decoding makes the schema forward/backward compatible. Also ignores now-removed legacy keys.
- Dropped the unused `dailyDurationSeconds` field (written on every transcription but never read).

**Correctness**
- Word counting now uses the system tokenizer (`enumerateSubstrings(options: .byWords)`) instead of splitting on whitespace, so space-less scripts (Chinese, Japanese, Thai) are no longer counted as a single word.
- Date-key parsing in the stats view uses a fixed `en_US_POSIX` locale so the `yyyy-MM-dd` keys parse correctly regardless of the user's default calendar/locale.

**UX**
- "Reset All Statistics" now asks for confirmation before wiping data (was a one-click irreversible destructive action).
- The WPM caption is relabeled "Speaking Speed" — it measures words per minute *of audio*, not typing throughput.

**Robustness / performance**
- Stats are encoded on the main actor (tiny payload) and written to disk off-main on a serial queue, so a busy disk can't hitch the UI on the transcription hot path.
- Replaced the application-support-directory force-unwrap with a temp-dir fallback.

## Tests
- `testStatsDecodeToleratesMissingAndUnknownKeys` — missing keys fall back to defaults; unknown/legacy keys are ignored.
- `testWordCountHandlesSpacelessScripts` — a Japanese sentence tokenizes to more than one word.
- All existing StatsManager tests (including #168's timezone/streak tests) still pass: `swift test --filter StatsManagerTests` → 11 passed.

## Not changed
- The `averageWPM` semantics (words per minute of audio) are unchanged — only the UI label was clarified.
