### PR TITLE
chore: bump version to 0.7.0

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -8,8 +8,8 @@
 # 3. Code signs — Developer ID if CODE_SIGN_IDENTITY is set, ad-hoc otherwise
 #
 # Environment variables:
-#   APP_VERSION         — Version string to embed in Info.plist. Defaults to 0.6.2.
-#                         Set by CI for nightly builds (e.g., 0.6.2-nightly.20260512+abc1234).
+#   APP_VERSION         — Version string to embed in Info.plist. Defaults to 0.7.0.
+#                         Set by CI for nightly builds (e.g., 0.7.0-nightly.20260512+abc1234).
 #   CODE_SIGN_IDENTITY  — Signing identity to use. Defaults to auto-detect
 #                         Developer ID Application in the login keychain.
 #                         Set to "-" to force ad-hoc signing.
@@ -29,7 +29,7 @@ BUNDLE_ID="com.vocamac.app"
 APP_NAME="VocaMac"
 APP_DIR="${APP_NAME}.app"
 ENTITLEMENTS="VocaMac.entitlements"
-APP_VERSION="${APP_VERSION:-0.6.2}"
+APP_VERSION="${APP_VERSION:-0.7.0}"
 
 # Resolve signing identity:
 # 1. Use CODE_SIGN_IDENTITY env var if set

--- a/web/layouts/index.html
+++ b/web/layouts/index.html
@@ -39,7 +39,7 @@
             "Open source (AGPL-3.0 license)"
         ],
         "screenshot": "https://vocamac.com/og-image.png",
-        "softwareVersion": "0.6.2",
+        "softwareVersion": "0.7.0",
         "softwareRequirements": "macOS 13 (Ventura) or later, Apple Silicon (M1 or later), 8 GB RAM minimum"
     }
     </script>
@@ -52,7 +52,7 @@
             <div class="hero__content">
                 <div class="hero__badges">
                     <span class="badge badge--beta">BETA RELEASE</span>
-                    <span class="badge badge--outline" id="version-badge">v0.6.2</span>
+                    <span class="badge badge--outline" id="version-badge">v0.7.0</span>
                 </div>
                 <h1 class="hero__headline">
                     Your Voice,<br>


### PR DESCRIPTION
## Summary

Prepares the **v0.7.0** minor release.

**Why minor (0.6.2 → 0.7.0):** several new, backward-compatible features (custom vocabulary, usage stats, hotkey presets, fixed audio input device, Homebrew distribution) and no breaking changes — per `docs/RELEASE.md` semver rules, that's a MINOR bump.

## Changes since v0.6.2

### ✨ Features
| PR | Summary |
|---|---|
| #169 | Custom vocabulary for names and jargon |
| #148 | Usage statistics for VocaMac (new **Stats** settings tab) |
| #139 | Hotkey presets and custom recording |
| #156 | Allow a fixed audio input device |
| #157 | Homebrew Cask distribution (stable + nightly) |
| #159 | Detect Homebrew cask installs and adjust update flow |

### 🐛 Fixes
| PR | Summary |
|---|---|
| #144 | Typing issue in the Raycast search bar |
| #151 | Reset recording state on audio start failure |
| #133 | Sync onboarding hotkey mode immediately |
| #166 | Show onboarding quick-test result |
| #161 | Align model picker with WhisperKit Apple Silicon support |
| #168 | Use local calendar days for stats streaks |
| #170 | Stats review follow-ups (lenient persistence, reset confirmation, CJK-aware word count, off-main writes) |
| c805fe1 | Release AVAudioEngine when idle to free the input route |

### 🛠️ Internal / CI / packaging
| PR | Summary |
|---|---|
| #146 | `/build-quick` to skip notarization for faster dev builds |
| #145 | Auto-label PRs by path |
| #141 | Make `make` default to `make help` |
| #162 | Derive PR build version from app default |
| #158 | Set vocamac cask sha256 for v0.6.2 |
| a2bc3f4 | GitHub Sponsors funding configuration |

### 📚 Docs
| PR | Summary |
|---|---|
| #160, #164 | Promote Homebrew as the primary install method / trust the tap |
| #138 | Clarify VocaMac is Apple Silicon only |
| #155 | Add star-history chart |

## Files updated
- `scripts/build.sh` — `APP_VERSION` default (Info.plist `CFBundleVersion` / `CFBundleShortVersionString`)
- `web/layouts/index.html` — JSON-LD `softwareVersion` + hero version badge

_Homebrew cask is intentionally **not** touched here — `update-homebrew-cask.yml` auto-updates it on release publish._

## Release plan after merge
1. Tag `v0.7.0` and push → `release.yml` builds, signs, notarizes, and drafts the GitHub Release.
2. Paste the finalized end-user notes into the draft and publish.
3. Homebrew tap + website auto-update on publish.

<details>
<summary>Draft end-user release notes (for the GitHub Release page)</summary>

# VocaMac v0.7.0

Our biggest release since 0.6 — smarter transcription, richer controls, and a usage dashboard, plus a much easier way to install via Homebrew.

## ✨ Highlights
- **Custom vocabulary** — Teach VocaMac the names, brands, and jargon you use so they're transcribed correctly. (#169)
- **Usage statistics** — A new **Stats** tab shows lifetime words, transcriptions, total time, speaking speed, and a daily streak, stored locally. (#148, #168, #170)
- **Hotkey presets & custom recording** — Ready-made presets or define your own activation key and recording behavior. (#139)
- **Choose your microphone** — Pin transcription to a specific input device instead of the system default. (#156)
- **Install with Homebrew** — `brew install --cask vocamac` (plus a `vocamac-nightly` cask); in-app updates detect Homebrew installs. (#157, #159)

## 🐛 Fixes & improvements
- Fixed typing/injection in the Raycast search bar. (#144)
- Recording state resets correctly if audio fails to start. (#151)
- Onboarding hotkey mode syncs immediately; quick-test result now shows. (#133, #166)
- Model picker aligned with WhisperKit's Apple Silicon support. (#161)
- Audio engine released when idle, freeing the input route. (c805fe1)

## 📦 Requirements
- macOS 13 (Ventura) or later; Apple Silicon (M1+), 8 GB RAM minimum

_Full changelog: https://github.com/jatinkrmalik/vocamac/compare/v0.6.2...v0.7.0_

</details>
