### PR TITLE
fix: prevent hotkey recording hangs

### DIFF
--- a/Sources/VocaMac/Models/AppState.swift
+++ b/Sources/VocaMac/Models/AppState.swift
@@ -133,6 +133,30 @@ final class AppState: ObservableObject {
     private var cancellables = Set<AnyCancellable>()
     private var hasStarted = false
 
+    /// AudioEngine serializes its own lifecycle internally; this wrapper makes
+    /// the intentional background handoff explicit for Dispatch's @Sendable API.
+    private struct AudioEngineWorker: @unchecked Sendable {
+        let audioEngine: AudioRecording
+
+        func startRecording(
+            silenceThreshold: Float,
+            silenceDuration: Double,
+            maxDuration: TimeInterval,
+            preferredInputDeviceID: String?
+        ) -> Bool {
+            audioEngine.startRecording(
+                silenceThreshold: silenceThreshold,
+                silenceDuration: silenceDuration,
+                maxDuration: maxDuration,
+                preferredInputDeviceID: preferredInputDeviceID
+            )
+        }
+
+        func stopRecording() -> [Float] {
+            audioEngine.stopRecording()
+        }
+    }
+
     /// Process-level flag that prevents performStartup from running more than
     /// once even when SwiftUI instantiates multiple AppState objects (which it
     /// does during MenuBarExtra scene setup). Instance-level `hasStarted` guards
@@ -539,7 +563,7 @@ final class AppState: ObservableObject {
         // Start recording immediately for instant responsiveness.
         // The start sound is played concurrently — any brief bleed into the
         // mic buffer is negligible and handled well by WhisperKit's noise model.
-        let didStartRecording = audioEngine.startRecording(
+        let didStartRecording = await startAudioEngine(
             silenceThreshold: Float(silenceThreshold),
             silenceDuration: silenceDuration,
             maxDuration: TimeInterval(maxRecordingDuration),
@@ -557,7 +581,7 @@ final class AppState: ObservableObject {
         }
 
         // Play start sound after mic is active (fire-and-forget)
-        if soundEffectsEnabled {
+        if soundEffectsEnabled && isRecording && appStatus == .recording {
             soundManager.playStartSound()
         }
     }
@@ -568,7 +592,7 @@ final class AppState: ObservableObject {
         // isRecording and appStatus may be out of sync).
         guard isRecording || appStatus == .recording else { return }
 
-        let audioData = audioEngine.stopRecording()
+        let audioData = await stopAudioEngine()
         isRecording = false
         audioLevel = 0.0
 
@@ -628,6 +652,35 @@ final class AppState: ObservableObject {
                     self?.appStatus = .idle
                     self?.errorMessage = nil
                 }
+            }
+        }
+    }
+
+    private func startAudioEngine(
+        silenceThreshold: Float,
+        silenceDuration: Double,
+        maxDuration: TimeInterval,
+        preferredInputDeviceID: String?
+    ) async -> Bool {
+        let worker = AudioEngineWorker(audioEngine: audioEngine)
+        return await withCheckedContinuation { continuation in
+            DispatchQueue.global(qos: .userInitiated).async {
+                let didStart = worker.startRecording(
+                    silenceThreshold: silenceThreshold,
+                    silenceDuration: silenceDuration,
+                    maxDuration: maxDuration,
+                    preferredInputDeviceID: preferredInputDeviceID
+                )
+                continuation.resume(returning: didStart)
+            }
+        }
+    }
+
+    private func stopAudioEngine() async -> [Float] {
+        let worker = AudioEngineWorker(audioEngine: audioEngine)
+        return await withCheckedContinuation { continuation in
+            DispatchQueue.global(qos: .userInitiated).async {
+                continuation.resume(returning: worker.stopRecording())
             }
         }
     }

--- a/Sources/VocaMac/Services/AudioEngine.swift
+++ b/Sources/VocaMac/Services/AudioEngine.swift
@@ -211,54 +211,67 @@ final class AudioEngine {
             self.maxDuration = maxDuration
 
             resetRecordingState()
-            _isCurrentlyRecording = true
 
-            let engine = acquireEngine()
-            let inputNode = engine.inputNode
-            configurePreferredInputDevice(preferredInputDeviceID, on: inputNode)
-            let inputFormat = inputNode.outputFormat(forBus: 0)
+            for attempt in 1...2 {
+                let engine = acquireEngine()
+                let inputNode = engine.inputNode
+                configurePreferredInputDevice(preferredInputDeviceID, on: inputNode)
+                let inputFormat = inputNode.outputFormat(forBus: 0)
 
-            guard isValidInputFormat(inputFormat) else {
-                VocaLogger.error(
-                    .audioEngine,
-                    "Invalid input format before recording start: sampleRate=\(inputFormat.sampleRate), channels=\(inputFormat.channelCount)"
-                )
-                recoverFromStartFailure(notifyAppState: true)
-                return false
-            }
-
-            // A previous failed start can leave a tap installed even when our
-            // recording flag is false. Remove any stale tap before installing a
-            // fresh one; otherwise AVAudioEngine raises an uncaught NSException.
-            removeInputTap(reason: "pre-start cleanup")
-
-            var startError: Error?
-            let exception = VocaObjCExceptionCatcher.catchException { [weak self] in
-                guard let self = self else { return }
-
-                inputNode.installTap(onBus: 0, bufferSize: 4096, format: inputFormat) { [weak self] buffer, _ in
-                    self?.processAudioBuffer(buffer, inputFormat: inputFormat)
+                guard isValidInputFormat(inputFormat) else {
+                    VocaLogger.error(
+                        .audioEngine,
+                        "Invalid input format before recording start: sampleRate=\(inputFormat.sampleRate), channels=\(inputFormat.channelCount)"
+                    )
+                    recoverFromStartFailure(notifyAppState: false)
+                    return false
                 }
 
-                do {
-                    try engine.start()
-                } catch {
-                    startError = error
+                // A previous failed start can leave a tap installed even when our
+                // recording flag is false. Remove any stale tap before installing a
+                // fresh one; otherwise AVAudioEngine raises an uncaught NSException.
+                removeInputTap(reason: "pre-start cleanup")
+
+                var startError: Error?
+                let exception = VocaObjCExceptionCatcher.catchException { [weak self] in
+                    guard let self = self else { return }
+
+                    inputNode.installTap(onBus: 0, bufferSize: 4096, format: inputFormat) { [weak self] buffer, _ in
+                        self?.processAudioBuffer(buffer, inputFormat: inputFormat)
+                    }
+
+                    do {
+                        try engine.start()
+                    } catch {
+                        startError = error
+                    }
                 }
+
+                if let exception {
+                    VocaLogger.error(.audioEngine, "AVAudioEngine exception while starting recording: \(exception.localizedDescription)")
+                    recoverFromStartFailure(notifyAppState: false)
+                    return false
+                }
+
+                if let startError {
+                    VocaLogger.error(
+                        .audioEngine,
+                        "Failed to start audio engine (attempt \(attempt)): \(Self.describeCoreAudioError(startError))"
+                    )
+                    recoverFromStartFailure(notifyAppState: false)
+
+                    if Self.shouldRetryStart(after: startError, attempt: attempt) {
+                        VocaLogger.warning(.audioEngine, "Retrying audio engine start after hardware-not-running error")
+                        continue
+                    }
+                    return false
+                }
+
+                _isCurrentlyRecording = true
+                return true
             }
 
-            if let exception {
-                VocaLogger.error(.audioEngine, "AVAudioEngine exception while starting recording: \(exception.localizedDescription)")
-                recoverFromStartFailure(notifyAppState: true)
-                return false
-            }
-
-            if let startError {
-                VocaLogger.error(.audioEngine, "Failed to start audio engine: \(startError.localizedDescription)")
-                recoverFromStartFailure(notifyAppState: true)
-                return false
-            }
-            return true
+            return false
         }
     }
 
@@ -385,6 +398,38 @@ final class AudioEngine {
     ) -> Bool {
         elapsedSinceRecordingStart >= 0
             && elapsedSinceRecordingStart <= recoveryWindow
+    }
+
+    static func shouldRetryStart(after error: Error, attempt: Int) -> Bool {
+        guard attempt == 1 else { return false }
+        return OSStatus(truncatingIfNeeded: (error as NSError).code) == kAudioHardwareNotRunningError
+    }
+
+    static func describeCoreAudioError(_ error: Error) -> String {
+        let nsError = error as NSError
+        var parts = [nsError.localizedDescription, "domain=\(nsError.domain)", "code=\(nsError.code)"]
+
+        if let fourCC = fourCharacterCode(forOSStatusCode: nsError.code) {
+            parts.append("'\(fourCC)'")
+        }
+
+        return parts.joined(separator: " ")
+    }
+
+    static func fourCharacterCode(forOSStatusCode code: Int) -> String? {
+        let value = UInt32(bitPattern: Int32(truncatingIfNeeded: code))
+        let bytes = [
+            UInt8((value >> 24) & 0xff),
+            UInt8((value >> 16) & 0xff),
+            UInt8((value >> 8) & 0xff),
+            UInt8(value & 0xff),
+        ]
+
+        guard bytes.allSatisfy({ $0 >= 32 && $0 <= 126 }) else {
+            return nil
+        }
+
+        return String(bytes: bytes, encoding: .ascii)
     }
 
     // MARK: - Audio Processing

--- a/Sources/VocaMac/Services/SoundManager.swift
+++ b/Sources/VocaMac/Services/SoundManager.swift
@@ -22,6 +22,9 @@ final class SoundManager: NSObject, NSSoundDelegate, @unchecked Sendable {
     /// Volume for sound effects (0.0 to 1.0)
     var volume: Float = 0.5
 
+    /// Queue used because NSSound can block while Core Audio wakes or fails.
+    private let soundQueue = DispatchQueue(label: "com.vocamac.sound-playback", qos: .utility)
+
     /// Lock for thread-safe access to continuation
     private let continuationLock = NSLock()
 
@@ -58,13 +61,20 @@ final class SoundManager: NSObject, NSSoundDelegate, @unchecked Sendable {
 
     /// Play a macOS system sound by name (fire-and-forget)
     private func playSystemSound(_ name: String) {
-        let soundPath = "/System/Library/Sounds/\(name).aiff"
-        guard let sound = NSSound(contentsOfFile: soundPath, byReference: true) else {
-            VocaLogger.warning(.soundManager, "Could not load system sound: \(name)")
-            return
+        let volume = self.volume
+
+        soundQueue.async {
+            let soundPath = "/System/Library/Sounds/\(name).aiff"
+            guard let sound = NSSound(contentsOfFile: soundPath, byReference: true) else {
+                VocaLogger.warning(.soundManager, "Could not load system sound: \(name)")
+                return
+            }
+
+            sound.volume = volume
+            if !sound.play() {
+                VocaLogger.warning(.soundManager, "Could not play system sound: \(name)")
+            }
         }
-        sound.volume = volume
-        sound.play()
     }
 
     /// Play a system sound and wait for completion using async/await

--- a/Tests/VocaMacTests/AppStateRecordingTests.swift
+++ b/Tests/VocaMacTests/AppStateRecordingTests.swift
@@ -34,6 +34,43 @@ final class AppStateRecordingTests: XCTestCase {
                      "Error message should mention microphone")
     }
 
+    func testStartRecordingDoesNotBlockMainActorDuringAudioStart() async throws {
+        let (appState, mocks) = AppState.makeTestState()
+        mocks.audioEngine.startRecordingDelay = 0.3
+
+        let start = Date()
+        let task = Task {
+            await appState.startRecording()
+        }
+
+        await Task.yield()
+        try await Task.sleep(nanoseconds: 50_000_000)
+
+        XCTAssertLessThan(Date().timeIntervalSince(start), 0.2,
+                          "Core Audio startup should not block the main actor")
+
+        await task.value
+        XCTAssertEqual(appState.appStatus, .recording)
+    }
+
+    func testStartSoundIsNotPlayedIfRecordingStopsDuringAudioStart() async throws {
+        let (appState, mocks) = AppState.makeTestState()
+        mocks.audioEngine.startRecordingDelay = 0.3
+
+        let task = Task {
+            await appState.startRecording()
+        }
+
+        await Task.yield()
+        try await Task.sleep(nanoseconds: 50_000_000)
+        await appState.stopRecordingAndTranscribe()
+        await task.value
+
+        XCTAssertEqual(mocks.soundManager.startSoundCallCount, 0)
+        XCTAssertEqual(mocks.soundManager.stopSoundCallCount, 1)
+        XCTAssertEqual(appState.appStatus, .idle)
+    }
+
     func testStartRecordingInProcessingStateForceRecovers() async {
         let (appState, _) = AppState.makeTestState()
         appState.appStatus = .processing

--- a/Tests/VocaMacTests/Mocks/MockServices.swift
+++ b/Tests/VocaMacTests/Mocks/MockServices.swift
@@ -24,6 +24,7 @@ final class MockAudioEngine: AudioRecording {
     var stopRecordingResult: [Float] = []
     var forceResetCallCount = 0
     var startRecordingResult = true
+    var startRecordingDelay: TimeInterval = 0
 
     private var permissionStatus: PermissionStatus = .granted
 
@@ -34,6 +35,9 @@ final class MockAudioEngine: AudioRecording {
         maxDuration: TimeInterval,
         preferredInputDeviceID: String?
     ) -> Bool {
+        if startRecordingDelay > 0 {
+            Thread.sleep(forTimeInterval: startRecordingDelay)
+        }
         isCurrentlyRecording = startRecordingResult
         lastSilenceThreshold = silenceThreshold
         lastSilenceDuration = silenceDuration

--- a/Tests/VocaMacTests/ServiceTests.swift
+++ b/Tests/VocaMacTests/ServiceTests.swift
@@ -485,6 +485,30 @@ final class AudioEngineTests: XCTestCase {
     }
 }
 
+final class AudioEngineStartFailureTests: XCTestCase {
+
+    func testFourCharacterCodeDecodesHardwareNotRunningError() {
+        XCTAssertEqual(AudioEngine.fourCharacterCode(forOSStatusCode: 1937010544), "stop")
+    }
+
+    func testStartRetryOnlyAppliesToFirstHardwareNotRunningFailure() {
+        let hardwareNotRunning = NSError(domain: "com.apple.coreaudio.avfaudio", code: 1937010544)
+        let otherError = NSError(domain: "com.apple.coreaudio.avfaudio", code: -1)
+
+        XCTAssertTrue(AudioEngine.shouldRetryStart(after: hardwareNotRunning, attempt: 1))
+        XCTAssertFalse(AudioEngine.shouldRetryStart(after: hardwareNotRunning, attempt: 2))
+        XCTAssertFalse(AudioEngine.shouldRetryStart(after: otherError, attempt: 1))
+    }
+
+    func testCoreAudioErrorDescriptionIncludesFourCharacterCode() {
+        let error = NSError(domain: "com.apple.coreaudio.avfaudio", code: 1937010544)
+        let description = AudioEngine.describeCoreAudioError(error)
+
+        XCTAssertTrue(description.contains("code=1937010544"))
+        XCTAssertTrue(description.contains("'stop'"))
+    }
+}
+
 
 // MARK: - AudioEngine Force Reset Tests
 
@@ -568,17 +592,19 @@ final class AudioEngineForceResetTests: XCTestCase {
             "Engine should be idle after multiple force resets")
     }
 
-    func testIsCurrentlyRecordingReflectsState() {
+    func testIsCurrentlyRecordingReflectsState() throws {
         let engine = AudioEngine()
 
         XCTAssertFalse(engine.isCurrentlyRecording,
             "Engine should not be recording initially")
 
-        engine.startRecording(
+        let didStart = engine.startRecording(
             silenceThreshold: 0.01,
             silenceDuration: 999.0,
             maxDuration: 60.0
         )
+
+        try XCTSkipIf(!didStart, "No microphone available or Core Audio input could not start")
 
         // Allow engine to start
         let startExpectation = XCTestExpectation(description: "Recording started")


### PR DESCRIPTION
## Summary
- move CoreAudio start/stop work off the main actor so hotkey handling stays responsive when the input device stalls
- retry kAudioHardwareNotRunningError / stop once, avoid false device-change recovery callbacks on start failure, and log decoded CoreAudio codes
- make sound effects fire from a background queue so NSSound delays cannot freeze recording flow

## Testing
- swift test: 222 tests, 0 failures, 2 environment skips