### PR TITLE
feat: add local LLM text post-processing

### DIFF
--- a/Sources/VocaMac/Models/AppState.swift
+++ b/Sources/VocaMac/Models/AppState.swift
@@ -774,21 +774,22 @@ final class AppState: ObservableObject {
         guard !isPreparingPostProcessingModel else { return }
 
         refreshPostProcessingRunner()
+        let model = LocalLLMModel.model(for: postProcessingModelID)
         isPreparingPostProcessingModel = true
-        postProcessingSetupMessage = "Preparing \(LocalLLMModel.model(for: postProcessingModelID).displayName)…"
+        postProcessingSetupMessage = "Preparing \(model.displayName). First setup can take a few minutes…"
         defer { isPreparingPostProcessingModel = false }
 
         do {
             try await textPostProcessor.prepare(
                 configuration: TextPostProcessingConfiguration(
                     runnerPath: postProcessingRunnerPath,
-                    modelID: postProcessingModelID,
+                    modelID: model.id,
                     customModelPath: postProcessingModelPath,
                     instructions: postProcessingInstructions
                 )
             )
             postProcessingEnabled = true
-            postProcessingSetupMessage = "\(LocalLLMModel.model(for: postProcessingModelID).displayName) ready."
+            postProcessingSetupMessage = "\(model.displayName) ready."
         } catch {
             postProcessingSetupMessage = "Model setup failed: \(error.localizedDescription)"
             VocaLogger.error(.textPostProcessor, postProcessingSetupMessage ?? "Model setup failed")

--- a/Sources/VocaMac/Models/AppState.swift
+++ b/Sources/VocaMac/Models/AppState.swift
@@ -90,6 +90,11 @@ final class AppState: ObservableObject {
     /// WhisperKit's recommended model for this device
     @Published var deviceRecommendedModel: String?
 
+    /// Local LLM setup status for the Text settings tab.
+    @Published var isInstallingLlamaCpp: Bool = false
+    @Published var isPreparingPostProcessingModel: Bool = false
+    @Published var postProcessingSetupMessage: String?
+
     // MARK: - User Settings (persisted via UserDefaults)
 
     @AppStorage("vocamac.hasCompletedOnboarding") var hasCompletedOnboarding: Bool = false
@@ -111,6 +116,7 @@ final class AppState: ObservableObject {
     @AppStorage("vocamac.customVocabulary") var customVocabulary: String = ""
     @AppStorage("vocamac.postProcessingEnabled") var postProcessingEnabled: Bool = false
     @AppStorage("vocamac.postProcessingRunnerPath") var postProcessingRunnerPath: String = LocalLLMPostProcessor.defaultRunnerPath
+    @AppStorage("vocamac.postProcessingModelID") var postProcessingModelID: String = LocalLLMModel.recommendedID
     @AppStorage("vocamac.postProcessingModelPath") var postProcessingModelPath: String = ""
     @AppStorage("vocamac.postProcessingInstructions") var postProcessingInstructions: String = LocalLLMPostProcessor.defaultInstructions
     @AppStorage("vocamac.logLevel") var logLevel: String = "info"
@@ -416,6 +422,8 @@ final class AppState: ObservableObject {
 
         // Check permissions
         checkPermissions()
+
+        refreshPostProcessingRunner()
     }
 
     /// Build the model list shown in Settings and onboarding.
@@ -647,7 +655,8 @@ final class AppState: ObservableObject {
                         finalText,
                         configuration: TextPostProcessingConfiguration(
                             runnerPath: postProcessingRunnerPath,
-                            modelPath: postProcessingModelPath,
+                            modelID: postProcessingModelID,
+                            customModelPath: postProcessingModelPath,
                             instructions: postProcessingInstructions
                         )
                     )
@@ -730,6 +739,59 @@ final class AppState: ObservableObject {
             DispatchQueue.global(qos: .userInitiated).async {
                 continuation.resume(returning: worker.stopRecording())
             }
+        }
+    }
+
+    // MARK: - Local AI Post-processing
+
+    func refreshPostProcessingRunner() {
+        guard !LocalLLMPostProcessor.runnerExists(at: postProcessingRunnerPath),
+              let detected = LocalLLMPostProcessor.detectedRunnerPath() else {
+            return
+        }
+
+        postProcessingRunnerPath = detected
+    }
+
+    func installLlamaCpp() async {
+        guard !isInstallingLlamaCpp else { return }
+
+        isInstallingLlamaCpp = true
+        postProcessingSetupMessage = "Installing llama.cpp…"
+        defer { isInstallingLlamaCpp = false }
+
+        do {
+            let runner = try await LocalLLMPostProcessor.installLlamaCpp()
+            postProcessingRunnerPath = runner
+            postProcessingSetupMessage = "llama.cpp ready."
+        } catch {
+            postProcessingSetupMessage = "Install failed: \(error.localizedDescription)"
+            VocaLogger.error(.textPostProcessor, postProcessingSetupMessage ?? "llama.cpp install failed")
+        }
+    }
+
+    func preparePostProcessingModel() async {
+        guard !isPreparingPostProcessingModel else { return }
+
+        refreshPostProcessingRunner()
+        isPreparingPostProcessingModel = true
+        postProcessingSetupMessage = "Preparing \(LocalLLMModel.model(for: postProcessingModelID).displayName)…"
+        defer { isPreparingPostProcessingModel = false }
+
+        do {
+            try await textPostProcessor.prepare(
+                configuration: TextPostProcessingConfiguration(
+                    runnerPath: postProcessingRunnerPath,
+                    modelID: postProcessingModelID,
+                    customModelPath: postProcessingModelPath,
+                    instructions: postProcessingInstructions
+                )
+            )
+            postProcessingEnabled = true
+            postProcessingSetupMessage = "\(LocalLLMModel.model(for: postProcessingModelID).displayName) ready."
+        } catch {
+            postProcessingSetupMessage = "Model setup failed: \(error.localizedDescription)"
+            VocaLogger.error(.textPostProcessor, postProcessingSetupMessage ?? "Model setup failed")
         }
     }
 

--- a/Sources/VocaMac/Models/AppState.swift
+++ b/Sources/VocaMac/Models/AppState.swift
@@ -109,6 +109,10 @@ final class AppState: ObservableObject {
     @AppStorage("vocamac.showCursorIndicator") var showCursorIndicator: Bool = true
     @AppStorage("vocamac.translationEnabled") var translationEnabled: Bool = false
     @AppStorage("vocamac.customVocabulary") var customVocabulary: String = ""
+    @AppStorage("vocamac.postProcessingEnabled") var postProcessingEnabled: Bool = false
+    @AppStorage("vocamac.postProcessingRunnerPath") var postProcessingRunnerPath: String = LocalLLMPostProcessor.defaultRunnerPath
+    @AppStorage("vocamac.postProcessingModelPath") var postProcessingModelPath: String = ""
+    @AppStorage("vocamac.postProcessingInstructions") var postProcessingInstructions: String = LocalLLMPostProcessor.defaultInstructions
     @AppStorage("vocamac.logLevel") var logLevel: String = "info"
 
     private var hotKeySafetyTimeout: Double {
@@ -120,6 +124,7 @@ final class AppState: ObservableObject {
     let audioEngine: AudioRecording
     let whisperService: SpeechTranscribing
     let textInjector: TextInjecting
+    let textPostProcessor: TextPostProcessing
     let hotKeyManager: HotKeyMonitoring
     let modelManager: ModelManaging
     let soundManager: SoundPlaying
@@ -175,6 +180,7 @@ final class AppState: ObservableObject {
         audioEngine: AudioRecording = AudioEngine(),
         whisperService: SpeechTranscribing = WhisperService(),
         textInjector: TextInjecting = TextInjector(),
+        textPostProcessor: TextPostProcessing = LocalLLMPostProcessor(),
         hotKeyManager: HotKeyMonitoring = HotKeyManager(),
         modelManager: ModelManaging = ModelManager(),
         soundManager: SoundPlaying = SoundManager(),
@@ -186,6 +192,7 @@ final class AppState: ObservableObject {
         self.audioEngine = audioEngine
         self.whisperService = whisperService
         self.textInjector = textInjector
+        self.textPostProcessor = textPostProcessor
         self.hotKeyManager = hotKeyManager
         self.modelManager = modelManager
         self.soundManager = soundManager
@@ -632,14 +639,40 @@ final class AppState: ObservableObject {
                 vocabulary: customVocabulary
             )
 
-            lastTranscription = result
+            var finalText = result.text.trimmingCharacters(in: .whitespacesAndNewlines)
+            var postProcessingError: String?
+            if postProcessingEnabled, !finalText.isEmpty {
+                do {
+                    finalText = try await textPostProcessor.improve(
+                        finalText,
+                        configuration: TextPostProcessingConfiguration(
+                            runnerPath: postProcessingRunnerPath,
+                            modelPath: postProcessingModelPath,
+                            instructions: postProcessingInstructions
+                        )
+                    )
+                } catch {
+                    postProcessingError = "Post-processing failed: \(error.localizedDescription)"
+                    VocaLogger.error(.textPostProcessor, postProcessingError ?? "Post-processing failed")
+                }
+            }
+
+            let finalResult = VocaTranscription(
+                text: finalText,
+                duration: result.duration,
+                detectedLanguage: result.detectedLanguage,
+                audioLengthSeconds: result.audioLengthSeconds,
+                modelUsed: result.modelUsed,
+                timestamp: result.timestamp
+            )
+            lastTranscription = finalResult
 
             // Update stats
-            statsManager.recordTranscription(result)
+            statsManager.recordTranscription(finalResult)
 
             // Inject text at cursor position
             // by WhisperService to remove hallucination tokens like [BLANK_AUDIO])
-            let trimmedText = result.text.trimmingCharacters(in: .whitespacesAndNewlines)
+            let trimmedText = finalResult.text.trimmingCharacters(in: .whitespacesAndNewlines)
             if !trimmedText.isEmpty {
                 textInjector.inject(
                     text: trimmedText,
@@ -650,7 +683,12 @@ final class AppState: ObservableObject {
             }
 
             cursorOverlay.hide()
-            appStatus = .idle
+            if let postProcessingError {
+                appStatus = .idle
+                showTemporaryWarning(postProcessingError)
+            } else {
+                appStatus = .idle
+            }
         } catch {
             cursorOverlay.hide()
             errorMessage = "Transcription failed: \(error.localizedDescription)"
@@ -829,6 +867,17 @@ final class AppState: ObservableObject {
         DispatchQueue.main.asyncAfter(deadline: .now() + 5.0) { [weak self] in
             if self?.appStatus == .error, self?.errorMessage == message {
                 self?.appStatus = .idle
+                self?.errorMessage = nil
+            }
+        }
+    }
+
+    /// Surface a non-blocking warning while keeping dictation ready.
+    private func showTemporaryWarning(_ message: String) {
+        errorMessage = message
+
+        DispatchQueue.main.asyncAfter(deadline: .now() + 5.0) { [weak self] in
+            if self?.appStatus == .idle, self?.errorMessage == message {
                 self?.errorMessage = nil
             }
         }

--- a/Sources/VocaMac/Services/LocalLLMPostProcessor.swift
+++ b/Sources/VocaMac/Services/LocalLLMPostProcessor.swift
@@ -6,7 +6,7 @@
 import Foundation
 
 struct LocalLLMModel: Identifiable, Equatable {
-    static let recommendedID = "qwen3-1.7b-q8"
+    static let recommendedID = "gemma-3-1b-q4"
     static let customID = "custom-gguf"
 
     let id: String
@@ -16,16 +16,16 @@ struct LocalLLMModel: Identifiable, Equatable {
 
     static let catalog: [LocalLLMModel] = [
         LocalLLMModel(
-            id: recommendedID,
-            displayName: "Qwen3 1.7B",
-            detail: "Best quality, 1.83 GB",
-            reference: "Qwen/Qwen3-1.7B-GGUF:Q8_0"
-        ),
-        LocalLLMModel(
             id: "gemma-3-1b-q4",
             displayName: "Gemma 3 1B",
-            detail: "Fast setup, 806 MB",
+            detail: "Recommended default, 806 MB",
             reference: "ggml-org/gemma-3-1b-it-GGUF:Q4_K_M"
+        ),
+        LocalLLMModel(
+            id: "qwen3-1.7b-q8",
+            displayName: "Qwen3 1.7B",
+            detail: "Larger option, 1.83 GB",
+            reference: "Qwen/Qwen3-1.7B-GGUF:Q8_0"
         ),
         LocalLLMModel(
             id: customID,
@@ -49,6 +49,7 @@ enum TextPostProcessingError: LocalizedError {
     case processFailed(Int32, String)
     case timedOut
     case emptyOutput
+    case unexpectedResponse(String)
 
     var errorDescription: String? {
         switch self {
@@ -68,13 +69,17 @@ enum TextPostProcessingError: LocalizedError {
             return "Local LLM timed out."
         case .emptyOutput:
             return "Local LLM returned no text."
+        case .unexpectedResponse(let response):
+            return response.isEmpty
+                ? "Local LLM returned an unexpected response."
+                : "Local LLM returned an unexpected response: \(response)"
         }
     }
 }
 
 final class LocalLLMPostProcessor: TextPostProcessing {
     static let defaultRunnerPath = detectedRunnerPath() ?? "/opt/homebrew/bin/llama-cli"
-    static let defaultInstructions = "Clean up dictation into polished text while preserving my meaning. Remove filler words, false starts, duplicate phrases, and obvious speech disfluencies. Fix punctuation and capitalization. Keep my tone concise and natural. Return only the final text."
+    static let defaultInstructions = "You are a transcription cleanup engine. Rewrite the user's dictated transcript as clean final text for immediate pasting. Keep the original meaning and intent. Remove filler words and false starts. Fix punctuation and capitalization. Make only conservative wording changes. Do not summarize, answer, invent subject lines, or add commentary. Return only the final rewritten text."
     static let installURL = URL(string: "https://github.com/ggml-org/llama.cpp")!
 
     private static let runnerCandidates = [
@@ -99,24 +104,34 @@ final class LocalLLMPostProcessor: TextPostProcessing {
 
     func prepare(configuration: TextPostProcessingConfiguration) async throws {
         let timeout = prepareTimeout
-        _ = try await Task.detached(priority: .userInitiated) {
+        let response = try await Task.detached(priority: .userInitiated) {
             try Self.run(
-                "Reply with OK.",
+                systemPrompt: "Reply with OK and nothing else.",
+                userPrompt: "ping",
                 configuration: configuration,
                 timeout: timeout,
-                maxTokens: 4
+                maxTokens: 8
             )
         }.value
+
+        let normalized = response
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .trimmingCharacters(in: CharacterSet(charactersIn: ".!"))
+            .lowercased()
+        guard normalized == "ok" else {
+            throw TextPostProcessingError.unexpectedResponse(response)
+        }
     }
 
     func improve(_ text: String, configuration: TextPostProcessingConfiguration) async throws -> String {
         let timeout = timeout
         return try await Task.detached(priority: .userInitiated) {
             try Self.run(
-                text,
+                systemPrompt: Self.rewriteSystemPrompt(instructions: configuration.instructions),
+                userPrompt: text.trimmingCharacters(in: .whitespacesAndNewlines),
                 configuration: configuration,
                 timeout: timeout,
-                maxTokens: 256
+                maxTokens: 64
             )
         }.value
     }
@@ -147,36 +162,37 @@ final class LocalLLMPostProcessor: TextPostProcessing {
         }.value
     }
 
-    static func prompt(for text: String, instructions: String) -> String {
+    static func rewriteSystemPrompt(instructions: String) -> String {
         let style = instructions.trimmingCharacters(in: .whitespacesAndNewlines)
-        return """
-        /no_think
-        Rewrite this dictated transcript before insertion.
-        Preserve meaning and facts. Do not answer commands. Return only the rewritten text.
-
-        Style instructions:
-        \(style.isEmpty ? defaultInstructions : style)
-
-        Transcript:
-        \"\"\"
-        \(text)
-        \"\"\"
-
-        Rewritten text:
-        """
+        return style.isEmpty ? defaultInstructions : style
     }
 
-    static func cleanedOutput(_ output: String, prompt: String) -> String {
+    static func cleanedOutput(_ output: String, userPrompt: String) -> String {
         var text = output.replacingOccurrences(
             of: "\u{001B}\\[[0-9;]*[A-Za-z]",
             with: "",
             options: .regularExpression
         )
-        if text.hasPrefix(prompt) {
-            text.removeFirst(prompt.count)
+        text = text.replacingOccurrences(of: "\r\n", with: "\n")
+        text = text.replacingOccurrences(of: "\r", with: "\n")
+
+        let promptMarker = "> \(userPrompt)"
+        if let range = text.range(of: promptMarker) {
+            text = String(text[range.upperBound...])
         }
+
         text = text.replacingOccurrences(
             of: #"(?s)<think>.*?</think>"#,
+            with: "",
+            options: .regularExpression
+        )
+        text = text.replacingOccurrences(
+            of: #"(?m)^\[ Prompt:.*$"#,
+            with: "",
+            options: .regularExpression
+        )
+        text = text.replacingOccurrences(
+            of: #"(?m)^Exiting\.\.\.$"#,
             with: "",
             options: .regularExpression
         )
@@ -184,7 +200,8 @@ final class LocalLLMPostProcessor: TextPostProcessing {
     }
 
     private static func run(
-        _ text: String,
+        systemPrompt: String,
+        userPrompt: String,
         configuration: TextPostProcessingConfiguration,
         timeout: TimeInterval,
         maxTokens: Int
@@ -196,33 +213,35 @@ final class LocalLLMPostProcessor: TextPostProcessing {
             throw TextPostProcessingError.runnerNotExecutable(runnerPath)
         }
 
-        let prompt = prompt(for: text, instructions: configuration.instructions)
         let task = Process()
-        let stdout = Pipe()
+        let outputPipe = Pipe()
         let finished = DispatchSemaphore(value: 0)
         let outputRead = DispatchSemaphore(value: 0)
         var outputData = Data()
 
         task.executableURL = URL(fileURLWithPath: runnerPath)
         task.arguments = runnerCommandPrefix(for: runnerPath) + (try modelArguments(for: configuration)) + [
-            "-p", prompt,
+            "-sys", systemPrompt,
+            "-p", userPrompt,
             "-n", "\(maxTokens)",
             "-c", "2048",
-            "--temp", "0.3",
+            "--temp", "0.1",
             "--top-k", "20",
             "--top-p", "0.8",
-            "--presence-penalty", "1.1",
+            "--simple-io",
             "--no-display-prompt",
+            "-st",
+            "--reasoning", "off",
         ]
         task.standardInput = FileHandle.nullDevice
-        task.standardOutput = stdout
-        task.standardError = FileHandle.nullDevice
+        task.standardOutput = outputPipe
+        task.standardError = outputPipe
         task.terminationHandler = { _ in finished.signal() }
 
         try task.run()
 
         DispatchQueue.global(qos: .utility).async {
-            outputData = stdout.fileHandleForReading.readDataToEndOfFile()
+            outputData = outputPipe.fileHandleForReading.readDataToEndOfFile()
             outputRead.signal()
         }
 
@@ -232,12 +251,15 @@ final class LocalLLMPostProcessor: TextPostProcessing {
         }
 
         outputRead.wait()
+        let output = String(data: outputData, encoding: .utf8) ?? ""
         guard task.terminationStatus == 0 else {
-            throw TextPostProcessingError.processFailed(task.terminationStatus, "")
+            throw TextPostProcessingError.processFailed(
+                task.terminationStatus,
+                output.trimmingCharacters(in: .whitespacesAndNewlines)
+            )
         }
 
-        let output = String(data: outputData, encoding: .utf8) ?? ""
-        let cleaned = cleanedOutput(output, prompt: prompt)
+        let cleaned = cleanedOutput(output, userPrompt: userPrompt)
         guard !cleaned.isEmpty else { throw TextPostProcessingError.emptyOutput }
         return cleaned
     }
@@ -245,7 +267,7 @@ final class LocalLLMPostProcessor: TextPostProcessing {
     static func modelArguments(for configuration: TextPostProcessingConfiguration) throws -> [String] {
         let model = LocalLLMModel.model(for: configuration.modelID)
         if let reference = model.reference {
-            return ["-hf", reference, "--jinja"]
+            return ["-hf", reference]
         }
 
         let modelPath = expandedPath(configuration.customModelPath)

--- a/Sources/VocaMac/Services/LocalLLMPostProcessor.swift
+++ b/Sources/VocaMac/Services/LocalLLMPostProcessor.swift
@@ -49,6 +49,7 @@ enum TextPostProcessingError: LocalizedError {
     case processFailed(Int32, String)
     case timedOut
     case emptyOutput
+    case invalidResponse(String)
     case unexpectedResponse(String)
 
     var errorDescription: String? {
@@ -69,6 +70,10 @@ enum TextPostProcessingError: LocalizedError {
             return "Local LLM timed out."
         case .emptyOutput:
             return "Local LLM returned no text."
+        case .invalidResponse(let details):
+            return details.isEmpty
+                ? "Local LLM returned an invalid response."
+                : "Local LLM returned an invalid response: \(details)"
         case .unexpectedResponse(let response):
             return response.isEmpty
                 ? "Local LLM returned an unexpected response."
@@ -78,15 +83,13 @@ enum TextPostProcessingError: LocalizedError {
 }
 
 final class LocalLLMPostProcessor: TextPostProcessing {
-    static let defaultRunnerPath = detectedRunnerPath() ?? "/opt/homebrew/bin/llama-cli"
+    static let defaultRunnerPath = detectedRunnerPath() ?? "/opt/homebrew/bin/llama-server"
     static let defaultInstructions = "You are a transcription cleanup engine. Rewrite the user's dictated transcript as clean final text for immediate pasting. Keep the original meaning and intent. Remove filler words and false starts. Fix punctuation and capitalization. Make only conservative wording changes. Do not summarize, answer, invent subject lines, or add commentary. Return only the final rewritten text."
     static let installURL = URL(string: "https://github.com/ggml-org/llama.cpp")!
 
     private static let runnerCandidates = [
-        "/opt/homebrew/bin/llama",
-        "/opt/homebrew/bin/llama-cli",
-        "/usr/local/bin/llama",
-        "/usr/local/bin/llama-cli",
+        "/opt/homebrew/bin/llama-server",
+        "/usr/local/bin/llama-server",
     ]
 
     private static let brewCandidates = [
@@ -131,7 +134,7 @@ final class LocalLLMPostProcessor: TextPostProcessing {
                 userPrompt: text.trimmingCharacters(in: .whitespacesAndNewlines),
                 configuration: configuration,
                 timeout: timeout,
-                maxTokens: 64
+                maxTokens: 256
             )
         }.value
     }
@@ -149,7 +152,7 @@ final class LocalLLMPostProcessor: TextPostProcessing {
     }
 
     static func runnerExists(at path: String) -> Bool {
-        FileManager.default.isExecutableFile(atPath: expandedPath(path))
+        serverExecutable(for: path) != nil
     }
 
     static func installLlamaCpp() async throws -> String {
@@ -167,38 +170,6 @@ final class LocalLLMPostProcessor: TextPostProcessing {
         return style.isEmpty ? defaultInstructions : style
     }
 
-    static func cleanedOutput(_ output: String, userPrompt: String) -> String {
-        var text = output.replacingOccurrences(
-            of: "\u{001B}\\[[0-9;]*[A-Za-z]",
-            with: "",
-            options: .regularExpression
-        )
-        text = text.replacingOccurrences(of: "\r\n", with: "\n")
-        text = text.replacingOccurrences(of: "\r", with: "\n")
-
-        let promptMarker = "> \(userPrompt)"
-        if let range = text.range(of: promptMarker) {
-            text = String(text[range.upperBound...])
-        }
-
-        text = text.replacingOccurrences(
-            of: #"(?s)<think>.*?</think>"#,
-            with: "",
-            options: .regularExpression
-        )
-        text = text.replacingOccurrences(
-            of: #"(?m)^\[ Prompt:.*$"#,
-            with: "",
-            options: .regularExpression
-        )
-        text = text.replacingOccurrences(
-            of: #"(?m)^Exiting\.\.\.$"#,
-            with: "",
-            options: .regularExpression
-        )
-        return text.trimmingCharacters(in: .whitespacesAndNewlines)
-    }
-
     private static func run(
         systemPrompt: String,
         userPrompt: String,
@@ -206,62 +177,174 @@ final class LocalLLMPostProcessor: TextPostProcessing {
         timeout: TimeInterval,
         maxTokens: Int
     ) throws -> String {
-        let runnerPath = expandedPath(configuration.runnerPath)
-
-        guard !runnerPath.isEmpty else { throw TextPostProcessingError.missingRunnerPath }
-        guard FileManager.default.isExecutableFile(atPath: runnerPath) else {
-            throw TextPostProcessingError.runnerNotExecutable(runnerPath)
+        let configuredPath = expandedPath(configuration.runnerPath)
+        guard !configuredPath.isEmpty else { throw TextPostProcessingError.missingRunnerPath }
+        guard let runnerPath = serverExecutable(for: configuredPath) else {
+            throw TextPostProcessingError.runnerNotExecutable(configuredPath)
         }
 
+        let socketURL = URL(fileURLWithPath: "/tmp")
+            .appendingPathComponent("vocamac-\(UUID().uuidString).sock")
+        let server = Process()
+        let serverOutput = Pipe()
+        let serverFinished = DispatchSemaphore(value: 0)
+        let serverOutputRead = DispatchSemaphore(value: 0)
+        var serverOutputData = Data()
+
+        server.executableURL = URL(fileURLWithPath: runnerPath)
+        server.arguments = (try modelArguments(for: configuration)) + [
+            "--host", socketURL.path,
+            "-c", "2048",
+            "--reasoning", "off",
+        ]
+        server.standardInput = FileHandle.nullDevice
+        server.standardOutput = serverOutput
+        server.standardError = serverOutput
+        server.terminationHandler = { _ in serverFinished.signal() }
+
+        try server.run()
+
+        DispatchQueue.global(qos: .utility).async {
+            serverOutputData = serverOutput.fileHandleForReading.readDataToEndOfFile()
+            serverOutputRead.signal()
+        }
+
+        defer {
+            if server.isRunning {
+                server.terminate()
+            }
+            _ = serverFinished.wait(timeout: .now() + 5)
+            try? FileManager.default.removeItem(at: socketURL)
+        }
+
+        let deadline = Date().addingTimeInterval(timeout)
+        try waitUntilReady(
+            server: server,
+            socketURL: socketURL,
+            deadline: deadline,
+            outputRead: serverOutputRead,
+            outputData: { serverOutputData }
+        )
+
+        let request = ChatCompletionRequest(
+            messages: [
+                ChatMessage(role: "system", content: systemPrompt),
+                ChatMessage(role: "user", content: userPrompt),
+            ],
+            maxTokens: maxTokens,
+            temperature: 0.1,
+            topP: 0.8,
+            stream: false
+        )
+        let requestData = try JSONEncoder().encode(request)
+        let remaining = deadline.timeIntervalSinceNow
+        guard remaining > 0 else { throw TextPostProcessingError.timedOut }
+
+        let responseData = try runCurl(
+            arguments: [
+                "--silent",
+                "--show-error",
+                "--fail-with-body",
+                "--max-time", "\(Int(ceil(remaining)))",
+                "--unix-socket", socketURL.path,
+                "--header", "Content-Type: application/json",
+                "--data-binary", "@-",
+                "http://localhost/v1/chat/completions",
+            ],
+            input: requestData,
+            timeout: remaining
+        )
+        return try responseText(from: responseData)
+    }
+
+    static func responseText(from data: Data) throws -> String {
+        do {
+            let response = try JSONDecoder().decode(ChatCompletionResponse.self, from: data)
+            let text = response.choices.first?.message.content
+                .trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+            guard !text.isEmpty else { throw TextPostProcessingError.emptyOutput }
+            return text
+        } catch let error as TextPostProcessingError {
+            throw error
+        } catch {
+            throw TextPostProcessingError.invalidResponse(error.localizedDescription)
+        }
+    }
+
+    private static func waitUntilReady(
+        server: Process,
+        socketURL: URL,
+        deadline: Date,
+        outputRead: DispatchSemaphore,
+        outputData: () -> Data
+    ) throws {
+        while Date() < deadline {
+            guard server.isRunning else {
+                _ = outputRead.wait(timeout: .now() + 1)
+                let details = String(data: outputData(), encoding: .utf8)?
+                    .trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+                throw TextPostProcessingError.processFailed(server.terminationStatus, details)
+            }
+
+            if FileManager.default.fileExists(atPath: socketURL.path),
+               (try? runCurl(
+                   arguments: [
+                       "--silent",
+                       "--fail",
+                       "--max-time", "1",
+                       "--unix-socket", socketURL.path,
+                       "http://localhost/health",
+                   ],
+                   timeout: 2
+               )) != nil {
+                return
+            }
+            Thread.sleep(forTimeInterval: 0.1)
+        }
+        throw TextPostProcessingError.timedOut
+    }
+
+    private static func runCurl(
+        arguments: [String],
+        input: Data? = nil,
+        timeout: TimeInterval
+    ) throws -> Data {
         let task = Process()
-        let outputPipe = Pipe()
+        let output = Pipe()
+        let inputPipe = input.map { _ in Pipe() }
         let finished = DispatchSemaphore(value: 0)
         let outputRead = DispatchSemaphore(value: 0)
         var outputData = Data()
 
-        task.executableURL = URL(fileURLWithPath: runnerPath)
-        task.arguments = runnerCommandPrefix(for: runnerPath) + (try modelArguments(for: configuration)) + [
-            "-sys", systemPrompt,
-            "-p", userPrompt,
-            "-n", "\(maxTokens)",
-            "-c", "2048",
-            "--temp", "0.1",
-            "--top-k", "20",
-            "--top-p", "0.8",
-            "--simple-io",
-            "--no-display-prompt",
-            "-st",
-            "--reasoning", "off",
-        ]
-        task.standardInput = FileHandle.nullDevice
-        task.standardOutput = outputPipe
-        task.standardError = outputPipe
+        task.executableURL = URL(fileURLWithPath: "/usr/bin/curl")
+        task.arguments = arguments
+        task.standardInput = inputPipe ?? FileHandle.nullDevice
+        task.standardOutput = output
+        task.standardError = output
         task.terminationHandler = { _ in finished.signal() }
 
         try task.run()
-
         DispatchQueue.global(qos: .utility).async {
-            outputData = outputPipe.fileHandleForReading.readDataToEndOfFile()
+            outputData = output.fileHandleForReading.readDataToEndOfFile()
             outputRead.signal()
+        }
+        if let input, let inputPipe {
+            inputPipe.fileHandleForWriting.write(input)
+            inputPipe.fileHandleForWriting.closeFile()
         }
 
         guard finished.wait(timeout: .now() + timeout) == .success else {
             task.terminate()
             throw TextPostProcessingError.timedOut
         }
-
         outputRead.wait()
-        let output = String(data: outputData, encoding: .utf8) ?? ""
-        guard task.terminationStatus == 0 else {
-            throw TextPostProcessingError.processFailed(
-                task.terminationStatus,
-                output.trimmingCharacters(in: .whitespacesAndNewlines)
-            )
-        }
 
-        let cleaned = cleanedOutput(output, userPrompt: userPrompt)
-        guard !cleaned.isEmpty else { throw TextPostProcessingError.emptyOutput }
-        return cleaned
+        guard task.terminationStatus == 0 else {
+            let details = String(data: outputData, encoding: .utf8)?
+                .trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+            throw TextPostProcessingError.processFailed(task.terminationStatus, details)
+        }
+        return outputData
     }
 
     static func modelArguments(for configuration: TextPostProcessingConfiguration) throws -> [String] {
@@ -281,6 +364,22 @@ final class LocalLLMPostProcessor: TextPostProcessing {
     static func expandedPath(_ path: String) -> String {
         path.trimmingCharacters(in: .whitespacesAndNewlines)
             .replacingOccurrences(of: #"^~(?=/|$)"#, with: NSHomeDirectory(), options: .regularExpression)
+    }
+
+    private static func serverExecutable(for configuredPath: String) -> String? {
+        let path = expandedPath(configuredPath)
+        guard !path.isEmpty else { return nil }
+
+        if URL(fileURLWithPath: path).lastPathComponent == "llama-server",
+           FileManager.default.isExecutableFile(atPath: path) {
+            return path
+        }
+
+        let sibling = URL(fileURLWithPath: path)
+            .deletingLastPathComponent()
+            .appendingPathComponent("llama-server")
+            .path
+        return FileManager.default.isExecutableFile(atPath: sibling) ? sibling : nil
     }
 
     private static func installLlamaCpp(using brewPath: String) throws -> String {
@@ -303,13 +402,37 @@ final class LocalLLMPostProcessor: TextPostProcessing {
             throw TextPostProcessingError.processFailed(task.terminationStatus, "")
         }
         guard let runner = detectedRunnerPath() else {
-            throw TextPostProcessingError.runnerNotExecutable("llama.cpp installed, but no llama runner was found.")
+            throw TextPostProcessingError.runnerNotExecutable("llama.cpp installed, but llama-server was not found.")
         }
         return runner
     }
 
-    private static func runnerCommandPrefix(for runnerPath: String) -> [String] {
-        URL(fileURLWithPath: runnerPath).lastPathComponent == "llama" ? ["cli"] : []
+    private struct ChatCompletionRequest: Encodable {
+        let messages: [ChatMessage]
+        let maxTokens: Int
+        let temperature: Double
+        let topP: Double
+        let stream: Bool
+
+        enum CodingKeys: String, CodingKey {
+            case messages
+            case maxTokens = "max_tokens"
+            case temperature
+            case topP = "top_p"
+            case stream
+        }
     }
 
+    private struct ChatMessage: Codable {
+        let role: String
+        let content: String
+    }
+
+    private struct ChatCompletionResponse: Decodable {
+        let choices: [Choice]
+
+        struct Choice: Decodable {
+            let message: ChatMessage
+        }
+    }
 }

--- a/Sources/VocaMac/Services/LocalLLMPostProcessor.swift
+++ b/Sources/VocaMac/Services/LocalLLMPostProcessor.swift
@@ -1,0 +1,146 @@
+// LocalLLMPostProcessor.swift
+// VocaMac
+//
+// Optional local LLM pass for cleaning up dictated text before insertion.
+
+import Foundation
+
+enum TextPostProcessingError: LocalizedError {
+    case missingRunnerPath
+    case missingModelPath
+    case runnerNotExecutable(String)
+    case modelNotFound(String)
+    case processFailed(Int32)
+    case timedOut
+    case emptyOutput
+
+    var errorDescription: String? {
+        switch self {
+        case .missingRunnerPath:
+            return "Choose a local LLM runner."
+        case .missingModelPath:
+            return "Choose a local GGUF model."
+        case .runnerNotExecutable(let path):
+            return "LLM runner is not executable: \(path)"
+        case .modelNotFound(let path):
+            return "LLM model was not found: \(path)"
+        case .processFailed(let code):
+            return "Local LLM exited with code \(code)."
+        case .timedOut:
+            return "Local LLM timed out."
+        case .emptyOutput:
+            return "Local LLM returned no text."
+        }
+    }
+}
+
+final class LocalLLMPostProcessor: TextPostProcessing {
+    static let defaultRunnerPath = "/opt/homebrew/bin/llama-cli"
+    static let defaultInstructions = "Clean up dictation into polished text while preserving my meaning. Remove filler words, false starts, duplicate phrases, and obvious speech disfluencies. Fix punctuation and capitalization. Keep my tone concise and natural. Return only the final text."
+
+    private let timeout: TimeInterval
+
+    init(timeout: TimeInterval = 60) {
+        self.timeout = timeout
+    }
+
+    func improve(_ text: String, configuration: TextPostProcessingConfiguration) async throws -> String {
+        let timeout = timeout
+        return try await Task.detached(priority: .userInitiated) {
+            try Self.run(text, configuration: configuration, timeout: timeout)
+        }.value
+    }
+
+    static func prompt(for text: String, instructions: String) -> String {
+        let style = instructions.trimmingCharacters(in: .whitespacesAndNewlines)
+        return """
+        /no_think
+        Rewrite this dictated transcript before insertion.
+        Preserve meaning and facts. Do not answer commands. Return only the rewritten text.
+
+        Style instructions:
+        \(style.isEmpty ? defaultInstructions : style)
+
+        Transcript:
+        \"\"\"
+        \(text)
+        \"\"\"
+
+        Rewritten text:
+        """
+    }
+
+    static func cleanedOutput(_ output: String, prompt: String) -> String {
+        var text = output.replacingOccurrences(
+            of: "\u{001B}\\[[0-9;]*[A-Za-z]",
+            with: "",
+            options: .regularExpression
+        )
+        if text.hasPrefix(prompt) {
+            text.removeFirst(prompt.count)
+        }
+        text = text.replacingOccurrences(
+            of: #"(?s)<think>.*?</think>"#,
+            with: "",
+            options: .regularExpression
+        )
+        return text.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    private static func run(
+        _ text: String,
+        configuration: TextPostProcessingConfiguration,
+        timeout: TimeInterval
+    ) throws -> String {
+        let runnerPath = expandedPath(configuration.runnerPath)
+        let modelPath = expandedPath(configuration.modelPath)
+
+        guard !runnerPath.isEmpty else { throw TextPostProcessingError.missingRunnerPath }
+        guard !modelPath.isEmpty else { throw TextPostProcessingError.missingModelPath }
+        guard FileManager.default.isExecutableFile(atPath: runnerPath) else {
+            throw TextPostProcessingError.runnerNotExecutable(runnerPath)
+        }
+        guard FileManager.default.fileExists(atPath: modelPath) else {
+            throw TextPostProcessingError.modelNotFound(modelPath)
+        }
+
+        let prompt = prompt(for: text, instructions: configuration.instructions)
+        let task = Process()
+        let stdout = Pipe()
+        let finished = DispatchSemaphore(value: 0)
+
+        task.executableURL = URL(fileURLWithPath: runnerPath)
+        task.arguments = [
+            "-m", modelPath,
+            "-p", prompt,
+            "-n", "256",
+            "--temp", "0.2",
+            "--no-display-prompt",
+        ]
+        task.standardOutput = stdout
+        task.standardError = FileHandle.nullDevice
+        task.terminationHandler = { _ in finished.signal() }
+
+        try task.run()
+
+        guard finished.wait(timeout: .now() + timeout) == .success else {
+            task.terminate()
+            throw TextPostProcessingError.timedOut
+        }
+
+        let data = stdout.fileHandleForReading.readDataToEndOfFile()
+        guard task.terminationStatus == 0 else {
+            throw TextPostProcessingError.processFailed(task.terminationStatus)
+        }
+
+        let output = String(data: data, encoding: .utf8) ?? ""
+        let cleaned = cleanedOutput(output, prompt: prompt)
+        guard !cleaned.isEmpty else { throw TextPostProcessingError.emptyOutput }
+        return cleaned
+    }
+
+    private static func expandedPath(_ path: String) -> String {
+        path.trimmingCharacters(in: .whitespacesAndNewlines)
+            .replacingOccurrences(of: #"^~(?=/|$)"#, with: NSHomeDirectory(), options: .regularExpression)
+    }
+}

--- a/Sources/VocaMac/Services/LocalLLMPostProcessor.swift
+++ b/Sources/VocaMac/Services/LocalLLMPostProcessor.swift
@@ -5,12 +5,48 @@
 
 import Foundation
 
+struct LocalLLMModel: Identifiable, Equatable {
+    static let recommendedID = "qwen3-1.7b-q8"
+    static let customID = "custom-gguf"
+
+    let id: String
+    let displayName: String
+    let detail: String
+    let reference: String?
+
+    static let catalog: [LocalLLMModel] = [
+        LocalLLMModel(
+            id: recommendedID,
+            displayName: "Qwen3 1.7B",
+            detail: "Best quality, 1.83 GB",
+            reference: "Qwen/Qwen3-1.7B-GGUF:Q8_0"
+        ),
+        LocalLLMModel(
+            id: "gemma-3-1b-q4",
+            displayName: "Gemma 3 1B",
+            detail: "Fast setup, 806 MB",
+            reference: "ggml-org/gemma-3-1b-it-GGUF:Q4_K_M"
+        ),
+        LocalLLMModel(
+            id: customID,
+            displayName: "Custom GGUF",
+            detail: "Use a local model file",
+            reference: nil
+        ),
+    ]
+
+    static func model(for id: String) -> LocalLLMModel {
+        catalog.first { $0.id == id } ?? catalog[0]
+    }
+}
+
 enum TextPostProcessingError: LocalizedError {
     case missingRunnerPath
     case missingModelPath
     case runnerNotExecutable(String)
     case modelNotFound(String)
-    case processFailed(Int32)
+    case homebrewNotFound
+    case processFailed(Int32, String)
     case timedOut
     case emptyOutput
 
@@ -24,8 +60,10 @@ enum TextPostProcessingError: LocalizedError {
             return "LLM runner is not executable: \(path)"
         case .modelNotFound(let path):
             return "LLM model was not found: \(path)"
-        case .processFailed(let code):
-            return "Local LLM exited with code \(code)."
+        case .homebrewNotFound:
+            return "Homebrew was not found. Install llama.cpp manually."
+        case .processFailed(let code, let details):
+            return details.isEmpty ? "Local LLM exited with code \(code)." : "Local LLM exited with code \(code): \(details)"
         case .timedOut:
             return "Local LLM timed out."
         case .emptyOutput:
@@ -35,19 +73,77 @@ enum TextPostProcessingError: LocalizedError {
 }
 
 final class LocalLLMPostProcessor: TextPostProcessing {
-    static let defaultRunnerPath = "/opt/homebrew/bin/llama-cli"
+    static let defaultRunnerPath = detectedRunnerPath() ?? "/opt/homebrew/bin/llama-cli"
     static let defaultInstructions = "Clean up dictation into polished text while preserving my meaning. Remove filler words, false starts, duplicate phrases, and obvious speech disfluencies. Fix punctuation and capitalization. Keep my tone concise and natural. Return only the final text."
+    static let installURL = URL(string: "https://github.com/ggml-org/llama.cpp")!
+
+    private static let runnerCandidates = [
+        "/opt/homebrew/bin/llama",
+        "/opt/homebrew/bin/llama-cli",
+        "/usr/local/bin/llama",
+        "/usr/local/bin/llama-cli",
+    ]
+
+    private static let brewCandidates = [
+        "/opt/homebrew/bin/brew",
+        "/usr/local/bin/brew",
+    ]
 
     private let timeout: TimeInterval
+    private let prepareTimeout: TimeInterval
 
-    init(timeout: TimeInterval = 60) {
+    init(timeout: TimeInterval = 60, prepareTimeout: TimeInterval = 600) {
         self.timeout = timeout
+        self.prepareTimeout = prepareTimeout
+    }
+
+    func prepare(configuration: TextPostProcessingConfiguration) async throws {
+        let timeout = prepareTimeout
+        _ = try await Task.detached(priority: .userInitiated) {
+            try Self.run(
+                "Reply with OK.",
+                configuration: configuration,
+                timeout: timeout,
+                maxTokens: 4
+            )
+        }.value
     }
 
     func improve(_ text: String, configuration: TextPostProcessingConfiguration) async throws -> String {
         let timeout = timeout
         return try await Task.detached(priority: .userInitiated) {
-            try Self.run(text, configuration: configuration, timeout: timeout)
+            try Self.run(
+                text,
+                configuration: configuration,
+                timeout: timeout,
+                maxTokens: 256
+            )
+        }.value
+    }
+
+    static func detectedRunnerPath() -> String? {
+        detectedRunnerPath(in: runnerCandidates)
+    }
+
+    static func detectedRunnerPath(in candidates: [String]) -> String? {
+        candidates.first { runnerExists(at: $0) }
+    }
+
+    static func detectedBrewPath() -> String? {
+        brewCandidates.first { FileManager.default.isExecutableFile(atPath: $0) }
+    }
+
+    static func runnerExists(at path: String) -> Bool {
+        FileManager.default.isExecutableFile(atPath: expandedPath(path))
+    }
+
+    static func installLlamaCpp() async throws -> String {
+        guard let brewPath = detectedBrewPath() else {
+            throw TextPostProcessingError.homebrewNotFound
+        }
+
+        return try await Task.detached(priority: .userInitiated) {
+            try installLlamaCpp(using: brewPath)
         }.value
     }
 
@@ -90,18 +186,14 @@ final class LocalLLMPostProcessor: TextPostProcessing {
     private static func run(
         _ text: String,
         configuration: TextPostProcessingConfiguration,
-        timeout: TimeInterval
+        timeout: TimeInterval,
+        maxTokens: Int
     ) throws -> String {
         let runnerPath = expandedPath(configuration.runnerPath)
-        let modelPath = expandedPath(configuration.modelPath)
 
         guard !runnerPath.isEmpty else { throw TextPostProcessingError.missingRunnerPath }
-        guard !modelPath.isEmpty else { throw TextPostProcessingError.missingModelPath }
         guard FileManager.default.isExecutableFile(atPath: runnerPath) else {
             throw TextPostProcessingError.runnerNotExecutable(runnerPath)
-        }
-        guard FileManager.default.fileExists(atPath: modelPath) else {
-            throw TextPostProcessingError.modelNotFound(modelPath)
         }
 
         let prompt = prompt(for: text, instructions: configuration.instructions)
@@ -110,11 +202,14 @@ final class LocalLLMPostProcessor: TextPostProcessing {
         let finished = DispatchSemaphore(value: 0)
 
         task.executableURL = URL(fileURLWithPath: runnerPath)
-        task.arguments = [
-            "-m", modelPath,
+        task.arguments = runnerCommandPrefix(for: runnerPath) + (try modelArguments(for: configuration)) + [
             "-p", prompt,
-            "-n", "256",
-            "--temp", "0.2",
+            "-n", "\(maxTokens)",
+            "-c", "2048",
+            "--temp", "0.3",
+            "--top-k", "20",
+            "--top-p", "0.8",
+            "--presence-penalty", "1.1",
             "--no-display-prompt",
         ]
         task.standardOutput = stdout
@@ -130,7 +225,7 @@ final class LocalLLMPostProcessor: TextPostProcessing {
 
         let data = stdout.fileHandleForReading.readDataToEndOfFile()
         guard task.terminationStatus == 0 else {
-            throw TextPostProcessingError.processFailed(task.terminationStatus)
+            throw TextPostProcessingError.processFailed(task.terminationStatus, "")
         }
 
         let output = String(data: data, encoding: .utf8) ?? ""
@@ -139,8 +234,52 @@ final class LocalLLMPostProcessor: TextPostProcessing {
         return cleaned
     }
 
-    private static func expandedPath(_ path: String) -> String {
+    static func modelArguments(for configuration: TextPostProcessingConfiguration) throws -> [String] {
+        let model = LocalLLMModel.model(for: configuration.modelID)
+        if let reference = model.reference {
+            return ["-hf", reference, "--jinja"]
+        }
+
+        let modelPath = expandedPath(configuration.customModelPath)
+        guard !modelPath.isEmpty else { throw TextPostProcessingError.missingModelPath }
+        guard FileManager.default.fileExists(atPath: modelPath) else {
+            throw TextPostProcessingError.modelNotFound(modelPath)
+        }
+        return ["-m", modelPath]
+    }
+
+    static func expandedPath(_ path: String) -> String {
         path.trimmingCharacters(in: .whitespacesAndNewlines)
             .replacingOccurrences(of: #"^~(?=/|$)"#, with: NSHomeDirectory(), options: .regularExpression)
     }
+
+    private static func installLlamaCpp(using brewPath: String) throws -> String {
+        let task = Process()
+        let finished = DispatchSemaphore(value: 0)
+
+        task.executableURL = URL(fileURLWithPath: brewPath)
+        task.arguments = ["install", "llama.cpp"]
+        task.standardOutput = FileHandle.nullDevice
+        task.standardError = FileHandle.nullDevice
+        task.terminationHandler = { _ in finished.signal() }
+
+        try task.run()
+        guard finished.wait(timeout: .now() + 600) == .success else {
+            task.terminate()
+            throw TextPostProcessingError.timedOut
+        }
+
+        guard task.terminationStatus == 0 else {
+            throw TextPostProcessingError.processFailed(task.terminationStatus, "")
+        }
+        guard let runner = detectedRunnerPath() else {
+            throw TextPostProcessingError.runnerNotExecutable("llama.cpp installed, but no llama runner was found.")
+        }
+        return runner
+    }
+
+    private static func runnerCommandPrefix(for runnerPath: String) -> [String] {
+        URL(fileURLWithPath: runnerPath).lastPathComponent == "llama" ? ["cli"] : []
+    }
+
 }

--- a/Sources/VocaMac/Services/LocalLLMPostProcessor.swift
+++ b/Sources/VocaMac/Services/LocalLLMPostProcessor.swift
@@ -200,6 +200,8 @@ final class LocalLLMPostProcessor: TextPostProcessing {
         let task = Process()
         let stdout = Pipe()
         let finished = DispatchSemaphore(value: 0)
+        let outputRead = DispatchSemaphore(value: 0)
+        var outputData = Data()
 
         task.executableURL = URL(fileURLWithPath: runnerPath)
         task.arguments = runnerCommandPrefix(for: runnerPath) + (try modelArguments(for: configuration)) + [
@@ -212,23 +214,29 @@ final class LocalLLMPostProcessor: TextPostProcessing {
             "--presence-penalty", "1.1",
             "--no-display-prompt",
         ]
+        task.standardInput = FileHandle.nullDevice
         task.standardOutput = stdout
         task.standardError = FileHandle.nullDevice
         task.terminationHandler = { _ in finished.signal() }
 
         try task.run()
 
+        DispatchQueue.global(qos: .utility).async {
+            outputData = stdout.fileHandleForReading.readDataToEndOfFile()
+            outputRead.signal()
+        }
+
         guard finished.wait(timeout: .now() + timeout) == .success else {
             task.terminate()
             throw TextPostProcessingError.timedOut
         }
 
-        let data = stdout.fileHandleForReading.readDataToEndOfFile()
+        outputRead.wait()
         guard task.terminationStatus == 0 else {
             throw TextPostProcessingError.processFailed(task.terminationStatus, "")
         }
 
-        let output = String(data: data, encoding: .utf8) ?? ""
+        let output = String(data: outputData, encoding: .utf8) ?? ""
         let cleaned = cleanedOutput(output, prompt: prompt)
         guard !cleaned.isEmpty else { throw TextPostProcessingError.emptyOutput }
         return cleaned

--- a/Sources/VocaMac/Services/Logger.swift
+++ b/Sources/VocaMac/Services/Logger.swift
@@ -16,6 +16,7 @@ enum LogCategory: String {
     case modelManager = "ModelManager"
     case soundManager = "SoundManager"
     case textInjector = "TextInjector"
+    case textPostProcessor = "TextPostProcessor"
     case cursorOverlay = "CursorOverlay"
     case updateChecker = "UpdateChecker"
     case onboarding = "Onboarding"

--- a/Sources/VocaMac/Services/ServiceProtocols.swift
+++ b/Sources/VocaMac/Services/ServiceProtocols.swift
@@ -149,11 +149,13 @@ protocol TextInjecting: AnyObject {
 
 struct TextPostProcessingConfiguration {
     let runnerPath: String
-    let modelPath: String
+    let modelID: String
+    let customModelPath: String
     let instructions: String
 }
 
 protocol TextPostProcessing: AnyObject {
+    func prepare(configuration: TextPostProcessingConfiguration) async throws
     func improve(_ text: String, configuration: TextPostProcessingConfiguration) async throws -> String
 }
 

--- a/Sources/VocaMac/Services/ServiceProtocols.swift
+++ b/Sources/VocaMac/Services/ServiceProtocols.swift
@@ -145,6 +145,18 @@ protocol TextInjecting: AnyObject {
     func inject(text: String, preserveClipboard: Bool)
 }
 
+// MARK: - TextPostProcessing
+
+struct TextPostProcessingConfiguration {
+    let runnerPath: String
+    let modelPath: String
+    let instructions: String
+}
+
+protocol TextPostProcessing: AnyObject {
+    func improve(_ text: String, configuration: TextPostProcessingConfiguration) async throws -> String
+}
+
 // MARK: - StatsManaging
 
 @MainActor

--- a/Sources/VocaMac/Views/MenuBarView.swift
+++ b/Sources/VocaMac/Views/MenuBarView.swift
@@ -434,7 +434,7 @@ struct MenuBarView: View {
 
     private var statusText: String {
         switch appState.appStatus {
-        case .idle:       return "Ready"
+        case .idle:       return appState.errorMessage ?? "Ready"
         case .recording:  return "Recording..."
         case .processing: return "Transcribing..."
         case .error:      return appState.errorMessage ?? "Error"
@@ -443,7 +443,7 @@ struct MenuBarView: View {
 
     private var statusColor: Color {
         switch appState.appStatus {
-        case .idle:       return .green
+        case .idle:       return appState.errorMessage == nil ? .green : .yellow
         case .recording:  return .red
         case .processing: return .orange
         case .error:      return .yellow

--- a/Sources/VocaMac/Views/SettingsView.swift
+++ b/Sources/VocaMac/Views/SettingsView.swift
@@ -177,6 +177,50 @@ struct GeneralSettingsTab: View {
                     .foregroundStyle(.secondary)
             }
 
+            Section("Local AI Post-processing") {
+                Toggle("Rewrite text before pasting", isOn: $appState.postProcessingEnabled)
+
+                VStack(alignment: .leading, spacing: 8) {
+                    HStack {
+                        TextField("llama-cli path", text: $appState.postProcessingRunnerPath)
+                            .textFieldStyle(.roundedBorder)
+                        Button {
+                            chooseFile { appState.postProcessingRunnerPath = $0 }
+                        } label: {
+                            Label("Choose", systemImage: "folder")
+                        }
+                    }
+
+                    HStack {
+                        TextField("GGUF model path", text: $appState.postProcessingModelPath)
+                            .textFieldStyle(.roundedBorder)
+                        Button {
+                            chooseFile { appState.postProcessingModelPath = $0 }
+                        } label: {
+                            Label("Choose", systemImage: "folder")
+                        }
+                    }
+
+                    TextEditor(text: $appState.postProcessingInstructions)
+                        .font(.body)
+                        .frame(minHeight: 90)
+                        .overlay(alignment: .topLeading) {
+                            if appState.postProcessingInstructions.isEmpty {
+                                Text("Keep my tone concise, warm, and direct.")
+                                    .foregroundStyle(.tertiary)
+                                    .padding(.top, 8)
+                                    .padding(.leading, 5)
+                                    .allowsHitTesting(false)
+                            }
+                        }
+                }
+                .disabled(!appState.postProcessingEnabled)
+
+                Text("Runs a local llama.cpp-compatible model after Whisper and before insertion. Try Qwen3-1.7B or Gemma 3 1B GGUF on M-series Macs; use a larger Q4 model if the delay is acceptable.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+
             Section("Behavior") {
                 Toggle("Launch at Login", isOn: Binding(
                     get: { appState.launchAtLogin },
@@ -194,6 +238,16 @@ struct GeneralSettingsTab: View {
 
         }
         .formStyle(.grouped)
+    }
+
+    private func chooseFile(_ update: (String) -> Void) {
+        let panel = NSOpenPanel()
+        panel.canChooseFiles = true
+        panel.canChooseDirectories = false
+        panel.allowsMultipleSelection = false
+        if panel.runModal() == .OK, let url = panel.url {
+            update(url.path)
+        }
     }
 }
 
@@ -335,7 +389,7 @@ struct ModelSettingsTab: View {
                     }
                 }
 
-                if appState.appStatus == .error, let errorMessage = appState.errorMessage {
+                if let errorMessage = appState.errorMessage {
                     GroupBox {
                         HStack(alignment: .top, spacing: 8) {
                             Image(systemName: "exclamationmark.triangle.fill")

--- a/Sources/VocaMac/Views/SettingsView.swift
+++ b/Sources/VocaMac/Views/SettingsView.swift
@@ -2,7 +2,7 @@
 // VocaMac
 //
 // Settings window for VocaMac configuration.
-// Organized into tabs: General, Models, Audio, Debug, About.
+// Organized into tabs: General, Text, Models, Stats, Audio, Debug, About.
 
 import SwiftUI
 
@@ -16,6 +16,11 @@ struct SettingsView: View {
             GeneralSettingsTab()
                 .tabItem {
                     Label("General", systemImage: "gear")
+                }
+
+            TextSettingsTab()
+                .tabItem {
+                    Label("Text", systemImage: "text.bubble")
                 }
 
             ModelSettingsTab()
@@ -43,7 +48,7 @@ struct SettingsView: View {
                     Label("About", systemImage: "info.circle")
                 }
         }
-        .frame(minWidth: 560, minHeight: 520)
+        .frame(minWidth: 620, minHeight: 560)
     }
 }
 
@@ -105,9 +110,48 @@ struct GeneralSettingsTab: View {
                 }
             }
 
-            // Language
-            Section("Transcription Language") {
-                Picker("Language", selection: $appState.selectedLanguage) {
+            Section("Behavior") {
+                Toggle("Launch at Login", isOn: Binding(
+                    get: { appState.launchAtLogin },
+                    set: { appState.setLaunchAtLogin($0) }
+                ))
+
+                Toggle("Show mic indicator near cursor while recording", isOn: $appState.showCursorIndicator)
+            }
+
+        }
+        .formStyle(.grouped)
+    }
+}
+
+// MARK: - Text Settings
+
+struct TextSettingsTab: View {
+    @EnvironmentObject var appState: AppState
+
+    private var selectedModel: LocalLLMModel {
+        LocalLLMModel.model(for: appState.postProcessingModelID)
+    }
+
+    private var runnerReady: Bool {
+        LocalLLMPostProcessor.runnerExists(at: appState.postProcessingRunnerPath)
+    }
+
+    private var brewAvailable: Bool {
+        LocalLLMPostProcessor.detectedBrewPath() != nil
+    }
+
+    private var canPrepareModel: Bool {
+        runnerReady &&
+        !appState.isPreparingPostProcessingModel &&
+        !appState.isInstallingLlamaCpp &&
+        (selectedModel.reference != nil || !appState.postProcessingModelPath.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+    }
+
+    var body: some View {
+        Form {
+            Section("Language") {
+                Picker("Transcription Language", selection: $appState.selectedLanguage) {
                     Text("Auto-detect").tag("auto")
                     Divider()
                     Group {
@@ -134,23 +178,9 @@ struct GeneralSettingsTab: View {
                     }
                 }
 
-                Text("Auto-detect works well for most cases. Set a specific language for better accuracy.")
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
+                Toggle("Translate speech", isOn: $appState.translationEnabled)
             }
 
-            // Translation
-            Section("Translation") {
-                Toggle("Enable translation", isOn: $appState.translationEnabled)
-
-                Text(appState.translationEnabled
-                    ? "Speech will be translated to the selected language (or English if Auto-detect)."
-                    : "Speech will be transcribed as-is in the spoken language. The language setting is used as a recognition hint only.")
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
-            }
-
-            // Custom Vocabulary
             Section("Custom Vocabulary") {
                 TextEditor(text: $appState.customVocabulary)
                     .font(.body)
@@ -167,30 +197,22 @@ struct GeneralSettingsTab: View {
 
                 let count = WhisperService.vocabularyTerms(from: appState.customVocabulary).count
                 Text(count == 0
-                    ? "Add names, jargon, or proper nouns (one per line, or comma-separated) that get mis-transcribed. VocaMac hints these to the model so it spells them right."
-                    : "\(count) term\(count == 1 ? "" : "s"). Keep the list short, since the model can only use the first 50 to 100 words as a hint.")
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
-
-                Text("For best results, enter terms in the language you dictate and set a matching Transcription Language above. In Auto-detect, the terms can also nudge which language VocaMac picks.")
+                    ? "Add names, jargon, or proper nouns."
+                    : "\(count) term\(count == 1 ? "" : "s")")
                     .font(.caption)
                     .foregroundStyle(.secondary)
             }
 
-            Section("Local AI Post-processing") {
+            Section("AI Rewrite") {
                 Toggle("Rewrite text before pasting", isOn: $appState.postProcessingEnabled)
 
-                VStack(alignment: .leading, spacing: 8) {
-                    HStack {
-                        TextField("llama-cli path", text: $appState.postProcessingRunnerPath)
-                            .textFieldStyle(.roundedBorder)
-                        Button {
-                            chooseFile { appState.postProcessingRunnerPath = $0 }
-                        } label: {
-                            Label("Choose", systemImage: "folder")
-                        }
+                Picker("Model", selection: $appState.postProcessingModelID) {
+                    ForEach(LocalLLMModel.catalog) { model in
+                        Text("\(model.displayName) - \(model.detail)").tag(model.id)
                     }
+                }
 
+                if selectedModel.id == LocalLLMModel.customID {
                     HStack {
                         TextField("GGUF model path", text: $appState.postProcessingModelPath)
                             .textFieldStyle(.roundedBorder)
@@ -200,44 +222,82 @@ struct GeneralSettingsTab: View {
                             Label("Choose", systemImage: "folder")
                         }
                     }
-
-                    TextEditor(text: $appState.postProcessingInstructions)
-                        .font(.body)
-                        .frame(minHeight: 90)
-                        .overlay(alignment: .topLeading) {
-                            if appState.postProcessingInstructions.isEmpty {
-                                Text("Keep my tone concise, warm, and direct.")
-                                    .foregroundStyle(.tertiary)
-                                    .padding(.top, 8)
-                                    .padding(.leading, 5)
-                                    .allowsHitTesting(false)
-                            }
-                        }
                 }
-                .disabled(!appState.postProcessingEnabled)
 
-                Text("Runs a local llama.cpp-compatible model after Whisper and before insertion. Try Qwen3-1.7B or Gemma 3 1B GGUF on M-series Macs; use a larger Q4 model if the delay is acceptable.")
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
+                HStack {
+                    TextField("llama runner path", text: $appState.postProcessingRunnerPath)
+                        .textFieldStyle(.roundedBorder)
+                    Button {
+                        chooseFile { appState.postProcessingRunnerPath = $0 }
+                    } label: {
+                        Label("Choose", systemImage: "folder")
+                    }
+                }
+
+                HStack {
+                    Label(runnerReady ? "llama.cpp ready" : "llama.cpp not found", systemImage: runnerReady ? "checkmark.circle.fill" : "exclamationmark.triangle.fill")
+                        .foregroundStyle(runnerReady ? .green : .orange)
+
+                    Spacer()
+
+                    if !runnerReady, brewAvailable {
+                        Button {
+                            Task { @MainActor in await appState.installLlamaCpp() }
+                        } label: {
+                            Label("Install llama.cpp", systemImage: "terminal")
+                        }
+                        .disabled(appState.isInstallingLlamaCpp)
+                    } else if !runnerReady {
+                        Button {
+                            NSWorkspace.shared.open(LocalLLMPostProcessor.installURL)
+                        } label: {
+                            Label("Install llama.cpp", systemImage: "safari")
+                        }
+                    }
+                }
+
+                HStack {
+                    Button {
+                        Task { @MainActor in await appState.preparePostProcessingModel() }
+                    } label: {
+                        Label("Prepare Selected Model", systemImage: "arrow.down.circle")
+                    }
+                    .disabled(!canPrepareModel)
+
+                    if appState.isPreparingPostProcessingModel || appState.isInstallingLlamaCpp {
+                        ProgressView()
+                            .controlSize(.small)
+                    }
+                }
+
+                if let message = appState.postProcessingSetupMessage {
+                    Text(message)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+
+                TextEditor(text: $appState.postProcessingInstructions)
+                    .font(.body)
+                    .frame(minHeight: 90)
+                    .overlay(alignment: .topLeading) {
+                        if appState.postProcessingInstructions.isEmpty {
+                            Text("Keep my tone concise, warm, and direct.")
+                                .foregroundStyle(.tertiary)
+                                .padding(.top, 8)
+                                .padding(.leading, 5)
+                                .allowsHitTesting(false)
+                        }
+                    }
             }
 
-            Section("Behavior") {
-                Toggle("Launch at Login", isOn: Binding(
-                    get: { appState.launchAtLogin },
-                    set: { appState.setLaunchAtLogin($0) }
-                ))
-
+            Section("Insertion") {
                 Toggle("Preserve clipboard after text injection", isOn: $appState.preserveClipboard)
-
-                Toggle("Show mic indicator near cursor while recording", isOn: $appState.showCursorIndicator)
-
-                Text("When enabled, your clipboard contents are restored after injecting text.")
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
             }
-
         }
         .formStyle(.grouped)
+        .onAppear {
+            appState.refreshPostProcessingRunner()
+        }
     }
 
     private func chooseFile(_ update: (String) -> Void) {

--- a/Sources/VocaMac/Views/SettingsView.swift
+++ b/Sources/VocaMac/Views/SettingsView.swift
@@ -231,7 +231,7 @@ struct TextSettingsTab: View {
                 }
 
                 HStack {
-                    TextField("llama runner path", text: $appState.postProcessingRunnerPath)
+                    TextField("llama-server path", text: $appState.postProcessingRunnerPath)
                         .textFieldStyle(.roundedBorder)
                         .disabled(isPostProcessingSetupBusy)
                     Button {
@@ -243,7 +243,7 @@ struct TextSettingsTab: View {
                 }
 
                 HStack {
-                    Label(runnerReady ? "llama.cpp ready" : "llama.cpp not found", systemImage: runnerReady ? "checkmark.circle.fill" : "exclamationmark.triangle.fill")
+                    Label(runnerReady ? "llama-server ready" : "llama-server not found", systemImage: runnerReady ? "checkmark.circle.fill" : "exclamationmark.triangle.fill")
                         .foregroundStyle(runnerReady ? .green : .orange)
 
                     Spacer()

--- a/Sources/VocaMac/Views/SettingsView.swift
+++ b/Sources/VocaMac/Views/SettingsView.swift
@@ -141,10 +141,13 @@ struct TextSettingsTab: View {
         LocalLLMPostProcessor.detectedBrewPath() != nil
     }
 
+    private var isPostProcessingSetupBusy: Bool {
+        appState.isPreparingPostProcessingModel || appState.isInstallingLlamaCpp
+    }
+
     private var canPrepareModel: Bool {
         runnerReady &&
-        !appState.isPreparingPostProcessingModel &&
-        !appState.isInstallingLlamaCpp &&
+        !isPostProcessingSetupBusy &&
         (selectedModel.reference != nil || !appState.postProcessingModelPath.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
     }
 
@@ -211,27 +214,32 @@ struct TextSettingsTab: View {
                         Text("\(model.displayName) - \(model.detail)").tag(model.id)
                     }
                 }
+                .disabled(isPostProcessingSetupBusy)
 
                 if selectedModel.id == LocalLLMModel.customID {
                     HStack {
                         TextField("GGUF model path", text: $appState.postProcessingModelPath)
                             .textFieldStyle(.roundedBorder)
+                            .disabled(isPostProcessingSetupBusy)
                         Button {
                             chooseFile { appState.postProcessingModelPath = $0 }
                         } label: {
                             Label("Choose", systemImage: "folder")
                         }
+                        .disabled(isPostProcessingSetupBusy)
                     }
                 }
 
                 HStack {
                     TextField("llama runner path", text: $appState.postProcessingRunnerPath)
                         .textFieldStyle(.roundedBorder)
+                        .disabled(isPostProcessingSetupBusy)
                     Button {
                         chooseFile { appState.postProcessingRunnerPath = $0 }
                     } label: {
                         Label("Choose", systemImage: "folder")
                     }
+                    .disabled(isPostProcessingSetupBusy)
                 }
 
                 HStack {
@@ -264,7 +272,7 @@ struct TextSettingsTab: View {
                     }
                     .disabled(!canPrepareModel)
 
-                    if appState.isPreparingPostProcessingModel || appState.isInstallingLlamaCpp {
+                    if isPostProcessingSetupBusy {
                         ProgressView()
                             .controlSize(.small)
                     }

--- a/Tests/VocaMacTests/AppStateRecordingTests.swift
+++ b/Tests/VocaMacTests/AppStateRecordingTests.swift
@@ -317,14 +317,17 @@ final class AppStateRecordingTests: XCTestCase {
     func testPreparePostProcessingModelEnablesRewrite() async {
         let postProcessor = MockTextPostProcessor()
         let (appState, _) = AppState.makeTestState(textPostProcessor: postProcessor)
-        appState.postProcessingRunnerPath = "/bin/echo"
+        appState.postProcessingRunnerPath = LocalLLMPostProcessor.defaultRunnerPath
         appState.postProcessingModelID = "gemma-3-1b-q4"
         appState.postProcessingInstructions = "Keep it tidy."
 
         await appState.preparePostProcessingModel()
 
         XCTAssertEqual(postProcessor.prepareCallCount, 1)
-        XCTAssertEqual(postProcessor.lastPrepareConfiguration?.runnerPath, "/bin/echo")
+        XCTAssertEqual(
+            postProcessor.lastPrepareConfiguration?.runnerPath,
+            LocalLLMPostProcessor.defaultRunnerPath
+        )
         XCTAssertEqual(postProcessor.lastPrepareConfiguration?.modelID, "gemma-3-1b-q4")
         XCTAssertEqual(postProcessor.lastPrepareConfiguration?.instructions, "Keep it tidy.")
         XCTAssertTrue(appState.postProcessingEnabled)

--- a/Tests/VocaMacTests/AppStateRecordingTests.swift
+++ b/Tests/VocaMacTests/AppStateRecordingTests.swift
@@ -169,6 +169,13 @@ final class AppStateRecordingTests: XCTestCase {
                       "Translation should be disabled by default")
     }
 
+    func testPostProcessingDisabledByDefault() {
+        let (appState, _) = AppState.makeTestState()
+
+        XCTAssertFalse(appState.postProcessingEnabled,
+                      "Local AI post-processing should be disabled by default")
+    }
+
     func testSelectedLanguageDefault() {
         let (appState, _) = AppState.makeTestState()
 
@@ -271,6 +278,68 @@ final class AppStateRecordingTests: XCTestCase {
 
         XCTAssertEqual(mocks.audioEngine.lastPreferredInputDeviceID, "coreaudio-device-uid",
                        "Selected audio device ID should be forwarded to AudioEngine")
+    }
+
+    func testPostProcessingEnabledInjectsProcessedText() async {
+        let postProcessor = MockTextPostProcessor()
+        postProcessor.result = "Email Namrata about the launch."
+        let whisperService = MockWhisperService()
+        whisperService.mockTranscriptionResult = VocaTranscription(
+            text: "um email nam rata about the launch",
+            duration: 1,
+            detectedLanguage: "en",
+            audioLengthSeconds: 1,
+            modelUsed: .tiny
+        )
+        let (appState, mocks) = AppState.makeTestState(
+            whisperService: whisperService,
+            textPostProcessor: postProcessor
+        )
+        appState.postProcessingEnabled = true
+        appState.postProcessingRunnerPath = "/mock/llama-cli"
+        appState.postProcessingModelPath = "/mock/qwen.gguf"
+        appState.postProcessingInstructions = "Keep it concise."
+        appState.isRecording = true
+        appState.appStatus = .recording
+        mocks.audioEngine.stopRecordingResult = [0.1, 0.2]
+
+        await appState.stopRecordingAndTranscribe()
+
+        XCTAssertEqual(postProcessor.improveCallCount, 1)
+        XCTAssertEqual(postProcessor.lastText, "um email nam rata about the launch")
+        XCTAssertEqual(postProcessor.lastConfiguration?.runnerPath, "/mock/llama-cli")
+        XCTAssertEqual(postProcessor.lastConfiguration?.modelPath, "/mock/qwen.gguf")
+        XCTAssertEqual(postProcessor.lastConfiguration?.instructions, "Keep it concise.")
+        XCTAssertEqual(mocks.textInjector.lastInjectedText, "Email Namrata about the launch.")
+        XCTAssertEqual(appState.lastTranscription?.text, "Email Namrata about the launch.")
+    }
+
+    func testPostProcessingFailureInjectsRawText() async {
+        let postProcessor = MockTextPostProcessor()
+        postProcessor.error = TextPostProcessingError.emptyOutput
+        let whisperService = MockWhisperService()
+        whisperService.mockTranscriptionResult = VocaTranscription(
+            text: "raw transcription",
+            duration: 1,
+            detectedLanguage: "en",
+            audioLengthSeconds: 1,
+            modelUsed: .tiny
+        )
+        let (appState, mocks) = AppState.makeTestState(
+            whisperService: whisperService,
+            textPostProcessor: postProcessor
+        )
+        appState.postProcessingEnabled = true
+        appState.isRecording = true
+        appState.appStatus = .recording
+        mocks.audioEngine.stopRecordingResult = [0.1, 0.2]
+
+        await appState.stopRecordingAndTranscribe()
+
+        XCTAssertEqual(mocks.textInjector.lastInjectedText, "raw transcription")
+        XCTAssertEqual(appState.lastTranscription?.text, "raw transcription")
+        XCTAssertEqual(appState.appStatus, .idle)
+        XCTAssertTrue(appState.errorMessage?.contains("Post-processing failed") == true)
     }
 }
 

--- a/Tests/VocaMacTests/AppStateRecordingTests.swift
+++ b/Tests/VocaMacTests/AppStateRecordingTests.swift
@@ -297,7 +297,7 @@ final class AppStateRecordingTests: XCTestCase {
         )
         appState.postProcessingEnabled = true
         appState.postProcessingRunnerPath = "/mock/llama-cli"
-        appState.postProcessingModelPath = "/mock/qwen.gguf"
+        appState.postProcessingModelID = "gemma-3-1b-q4"
         appState.postProcessingInstructions = "Keep it concise."
         appState.isRecording = true
         appState.appStatus = .recording
@@ -308,10 +308,27 @@ final class AppStateRecordingTests: XCTestCase {
         XCTAssertEqual(postProcessor.improveCallCount, 1)
         XCTAssertEqual(postProcessor.lastText, "um email nam rata about the launch")
         XCTAssertEqual(postProcessor.lastConfiguration?.runnerPath, "/mock/llama-cli")
-        XCTAssertEqual(postProcessor.lastConfiguration?.modelPath, "/mock/qwen.gguf")
+        XCTAssertEqual(postProcessor.lastConfiguration?.modelID, "gemma-3-1b-q4")
         XCTAssertEqual(postProcessor.lastConfiguration?.instructions, "Keep it concise.")
         XCTAssertEqual(mocks.textInjector.lastInjectedText, "Email Namrata about the launch.")
         XCTAssertEqual(appState.lastTranscription?.text, "Email Namrata about the launch.")
+    }
+
+    func testPreparePostProcessingModelEnablesRewrite() async {
+        let postProcessor = MockTextPostProcessor()
+        let (appState, _) = AppState.makeTestState(textPostProcessor: postProcessor)
+        appState.postProcessingRunnerPath = "/bin/echo"
+        appState.postProcessingModelID = "gemma-3-1b-q4"
+        appState.postProcessingInstructions = "Keep it tidy."
+
+        await appState.preparePostProcessingModel()
+
+        XCTAssertEqual(postProcessor.prepareCallCount, 1)
+        XCTAssertEqual(postProcessor.lastPrepareConfiguration?.runnerPath, "/bin/echo")
+        XCTAssertEqual(postProcessor.lastPrepareConfiguration?.modelID, "gemma-3-1b-q4")
+        XCTAssertEqual(postProcessor.lastPrepareConfiguration?.instructions, "Keep it tidy.")
+        XCTAssertTrue(appState.postProcessingEnabled)
+        XCTAssertEqual(appState.postProcessingSetupMessage, "Gemma 3 1B ready.")
     }
 
     func testPostProcessingFailureInjectsRawText() async {

--- a/Tests/VocaMacTests/LocalLLMPostProcessorTests.swift
+++ b/Tests/VocaMacTests/LocalLLMPostProcessorTests.swift
@@ -62,4 +62,31 @@ final class LocalLLMPostProcessorTests: XCTestCase {
             "/bin/echo"
         )
     }
+
+    func testPrepareDrainsChattyRunnerOutput() async throws {
+        let scriptURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("vocamac-chatty-runner-\(UUID().uuidString).sh")
+        defer { try? FileManager.default.removeItem(at: scriptURL) }
+        let script = """
+        #!/bin/sh
+        i=0
+        while [ "$i" -lt 5000 ]; do
+          printf 'xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx\\n'
+          i=$((i + 1))
+        done
+        printf 'OK\\n'
+        """
+        try script.write(to: scriptURL, atomically: true, encoding: .utf8)
+        try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: scriptURL.path)
+
+        let processor = LocalLLMPostProcessor(prepareTimeout: 2)
+        try await processor.prepare(
+            configuration: TextPostProcessingConfiguration(
+                runnerPath: scriptURL.path,
+                modelID: "gemma-3-1b-q4",
+                customModelPath: "",
+                instructions: ""
+            )
+        )
+    }
 }

--- a/Tests/VocaMacTests/LocalLLMPostProcessorTests.swift
+++ b/Tests/VocaMacTests/LocalLLMPostProcessorTests.swift
@@ -12,30 +12,36 @@ final class LocalLLMPostProcessorTests: XCTestCase {
         )
     }
 
-    func testCleanedOutputExtractsAssistantReplyFromChatTranscript() {
-        let userPrompt = "um let's email Namrata about the launch"
-        let output = """
-        Loading model...
-
-        available commands:
-          /exit or Ctrl+C     stop or exit
-
-        > um let's email Namrata about the launch
-
-        <think>
-        hidden reasoning
-        </think>
-        Email Namrata about the launch.
-
-        [ Prompt: 99.6 t/s | Generation: 214.6 t/s ]
-
-        Exiting...
+    func testResponseTextDecodesStructuredAssistantReply() throws {
+        let response = """
+        {
+          "choices": [
+            {
+              "message": {
+                "role": "assistant",
+                "content": "Email Namrata about the launch."
+              }
+            }
+          ]
+        }
         """
 
         XCTAssertEqual(
-            LocalLLMPostProcessor.cleanedOutput(output, userPrompt: userPrompt),
+            try LocalLLMPostProcessor.responseText(from: Data(response.utf8)),
             "Email Namrata about the launch."
         )
+    }
+
+    func testResponseTextRejectsMissingAssistantReply() {
+        let response = #"{"choices":[]}"#
+
+        XCTAssertThrowsError(
+            try LocalLLMPostProcessor.responseText(from: Data(response.utf8))
+        ) { error in
+            guard case TextPostProcessingError.emptyOutput = error else {
+                return XCTFail("Expected emptyOutput, got \(error)")
+            }
+        }
     }
 
     func testModelArgumentsUseHuggingFaceReferenceForCatalogModel() throws {
@@ -63,40 +69,57 @@ final class LocalLLMPostProcessorTests: XCTestCase {
         XCTAssertThrowsError(try LocalLLMPostProcessor.modelArguments(for: config))
     }
 
-    func testDetectedRunnerPathUsesFirstExecutableCandidate() {
+    func testDetectedRunnerPathUsesFirstExecutableServerCandidate() throws {
+        let directoryURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("vocamac-llama-tools-\(UUID().uuidString)")
+        let serverURL = directoryURL.appendingPathComponent("llama-server")
+        defer { try? FileManager.default.removeItem(at: directoryURL) }
+        try FileManager.default.createDirectory(at: directoryURL, withIntermediateDirectories: true)
+        try "#!/bin/sh\n".write(to: serverURL, atomically: true, encoding: .utf8)
+        try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: serverURL.path)
+
         XCTAssertEqual(
-            LocalLLMPostProcessor.detectedRunnerPath(in: ["/definitely/missing", "/bin/echo"]),
-            "/bin/echo"
+            LocalLLMPostProcessor.detectedRunnerPath(in: ["/definitely/missing", serverURL.path]),
+            serverURL.path
         )
     }
 
-    func testPrepareDrainsChattyRunnerOutput() async throws {
-        let scriptURL = FileManager.default.temporaryDirectory
-            .appendingPathComponent("vocamac-chatty-runner-\(UUID().uuidString).sh")
-        defer { try? FileManager.default.removeItem(at: scriptURL) }
-        let script = """
-        #!/bin/sh
-        i=0
-        while [ "$i" -lt 5000 ]; do
-          printf 'xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx\\n'
-          i=$((i + 1))
-        done
-        printf '> ping\\n\\n'
-        printf 'OK\\n\\n'
-        printf '[ Prompt: 1.0 t/s | Generation: 1.0 t/s ]\\n\\n'
-        printf 'Exiting...\\n'
-        """
-        try script.write(to: scriptURL, atomically: true, encoding: .utf8)
-        try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: scriptURL.path)
+    func testRunnerExistsResolvesServerNextToLegacyCLIPath() throws {
+        let directoryURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("vocamac-llama-tools-\(UUID().uuidString)")
+        let serverURL = directoryURL.appendingPathComponent("llama-server")
+        defer { try? FileManager.default.removeItem(at: directoryURL) }
+        try FileManager.default.createDirectory(at: directoryURL, withIntermediateDirectories: true)
+        try "#!/bin/sh\n".write(to: serverURL, atomically: true, encoding: .utf8)
+        try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: serverURL.path)
 
-        let processor = LocalLLMPostProcessor(prepareTimeout: 2)
-        try await processor.prepare(
+        XCTAssertTrue(
+            LocalLLMPostProcessor.runnerExists(
+                at: directoryURL.appendingPathComponent("llama-cli").path
+            )
+        )
+    }
+
+    func testLocalLlamaServerIntegrationWhenEnabled() async throws {
+        guard ProcessInfo.processInfo.environment["VOCAMAC_RUN_LOCAL_LLM_TEST"] == "1" else {
+            throw XCTSkip("Set VOCAMAC_RUN_LOCAL_LLM_TEST=1 to run the local model integration test.")
+        }
+        guard LocalLLMPostProcessor.runnerExists(at: LocalLLMPostProcessor.defaultRunnerPath) else {
+            throw XCTSkip("llama-server is not installed.")
+        }
+
+        let result = try await LocalLLMPostProcessor().improve(
+            "um the launch moved to friday",
             configuration: TextPostProcessingConfiguration(
-                runnerPath: scriptURL.path,
-                modelID: "gemma-3-1b-q4",
+                runnerPath: LocalLLMPostProcessor.defaultRunnerPath,
+                modelID: LocalLLMModel.recommendedID,
                 customModelPath: "",
                 instructions: ""
             )
         )
+
+        XCTAssertTrue(result.localizedCaseInsensitiveContains("Friday"))
+        XCTAssertFalse(result.contains("\"choices\""))
+        XCTAssertFalse(result.contains("Loading model"))
     }
 }

--- a/Tests/VocaMacTests/LocalLLMPostProcessorTests.swift
+++ b/Tests/VocaMacTests/LocalLLMPostProcessorTests.swift
@@ -30,4 +30,36 @@ final class LocalLLMPostProcessorTests: XCTestCase {
             "Email Namrata about the launch."
         )
     }
+
+    func testModelArgumentsUseHuggingFaceReferenceForCatalogModel() throws {
+        let config = TextPostProcessingConfiguration(
+            runnerPath: "/usr/bin/false",
+            modelID: "gemma-3-1b-q4",
+            customModelPath: "",
+            instructions: ""
+        )
+
+        XCTAssertEqual(
+            try LocalLLMPostProcessor.modelArguments(for: config),
+            ["-hf", "ggml-org/gemma-3-1b-it-GGUF:Q4_K_M", "--jinja"]
+        )
+    }
+
+    func testModelArgumentsValidateCustomModelPath() {
+        let config = TextPostProcessingConfiguration(
+            runnerPath: "/usr/bin/false",
+            modelID: LocalLLMModel.customID,
+            customModelPath: "/definitely/not/a/model.gguf",
+            instructions: ""
+        )
+
+        XCTAssertThrowsError(try LocalLLMPostProcessor.modelArguments(for: config))
+    }
+
+    func testDetectedRunnerPathUsesFirstExecutableCandidate() {
+        XCTAssertEqual(
+            LocalLLMPostProcessor.detectedRunnerPath(in: ["/definitely/missing", "/bin/echo"]),
+            "/bin/echo"
+        )
+    }
 }

--- a/Tests/VocaMacTests/LocalLLMPostProcessorTests.swift
+++ b/Tests/VocaMacTests/LocalLLMPostProcessorTests.swift
@@ -1,0 +1,33 @@
+// LocalLLMPostProcessorTests.swift
+// VocaMac Tests
+
+import XCTest
+@testable import VocaMac
+
+final class LocalLLMPostProcessorTests: XCTestCase {
+    func testPromptIncludesTranscriptAndInstructions() {
+        let prompt = LocalLLMPostProcessor.prompt(
+            for: "um let's email Namrata about the launch",
+            instructions: "Keep it concise."
+        )
+
+        XCTAssertTrue(prompt.contains("Keep it concise."))
+        XCTAssertTrue(prompt.contains("um let's email Namrata about the launch"))
+        XCTAssertTrue(prompt.contains("Return only the rewritten text."))
+    }
+
+    func testCleanedOutputRemovesPromptAndThinkingBlock() {
+        let prompt = "Prompt:"
+        let output = """
+        \u{001B}[32mPrompt:<think>
+        hidden reasoning
+        </think>
+        Email Namrata about the launch.
+        """
+
+        XCTAssertEqual(
+            LocalLLMPostProcessor.cleanedOutput(output, prompt: prompt),
+            "Email Namrata about the launch."
+        )
+    }
+}

--- a/Tests/VocaMacTests/LocalLLMPostProcessorTests.swift
+++ b/Tests/VocaMacTests/LocalLLMPostProcessorTests.swift
@@ -5,28 +5,35 @@ import XCTest
 @testable import VocaMac
 
 final class LocalLLMPostProcessorTests: XCTestCase {
-    func testPromptIncludesTranscriptAndInstructions() {
-        let prompt = LocalLLMPostProcessor.prompt(
-            for: "um let's email Namrata about the launch",
-            instructions: "Keep it concise."
+    func testRewriteSystemPromptUsesCustomInstructions() {
+        XCTAssertEqual(
+            LocalLLMPostProcessor.rewriteSystemPrompt(instructions: "Keep it concise."),
+            "Keep it concise."
         )
-
-        XCTAssertTrue(prompt.contains("Keep it concise."))
-        XCTAssertTrue(prompt.contains("um let's email Namrata about the launch"))
-        XCTAssertTrue(prompt.contains("Return only the rewritten text."))
     }
 
-    func testCleanedOutputRemovesPromptAndThinkingBlock() {
-        let prompt = "Prompt:"
+    func testCleanedOutputExtractsAssistantReplyFromChatTranscript() {
+        let userPrompt = "um let's email Namrata about the launch"
         let output = """
-        \u{001B}[32mPrompt:<think>
+        Loading model...
+
+        available commands:
+          /exit or Ctrl+C     stop or exit
+
+        > um let's email Namrata about the launch
+
+        <think>
         hidden reasoning
         </think>
         Email Namrata about the launch.
+
+        [ Prompt: 99.6 t/s | Generation: 214.6 t/s ]
+
+        Exiting...
         """
 
         XCTAssertEqual(
-            LocalLLMPostProcessor.cleanedOutput(output, prompt: prompt),
+            LocalLLMPostProcessor.cleanedOutput(output, userPrompt: userPrompt),
             "Email Namrata about the launch."
         )
     }
@@ -41,7 +48,7 @@ final class LocalLLMPostProcessorTests: XCTestCase {
 
         XCTAssertEqual(
             try LocalLLMPostProcessor.modelArguments(for: config),
-            ["-hf", "ggml-org/gemma-3-1b-it-GGUF:Q4_K_M", "--jinja"]
+            ["-hf", "ggml-org/gemma-3-1b-it-GGUF:Q4_K_M"]
         )
     }
 
@@ -74,7 +81,10 @@ final class LocalLLMPostProcessorTests: XCTestCase {
           printf 'xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx\\n'
           i=$((i + 1))
         done
-        printf 'OK\\n'
+        printf '> ping\\n\\n'
+        printf 'OK\\n\\n'
+        printf '[ Prompt: 1.0 t/s | Generation: 1.0 t/s ]\\n\\n'
+        printf 'Exiting...\\n'
         """
         try script.write(to: scriptURL, atomically: true, encoding: .utf8)
         try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: scriptURL.path)

--- a/Tests/VocaMacTests/Mocks/MockServices.swift
+++ b/Tests/VocaMacTests/Mocks/MockServices.swift
@@ -401,6 +401,26 @@ final class MockTextInjector: TextInjecting {
     }
 }
 
+// MARK: - MockTextPostProcessor
+
+final class MockTextPostProcessor: TextPostProcessing {
+    var improveCallCount = 0
+    var lastText: String?
+    var lastConfiguration: TextPostProcessingConfiguration?
+    var result = "processed text"
+    var error: Error?
+
+    func improve(_ text: String, configuration: TextPostProcessingConfiguration) async throws -> String {
+        improveCallCount += 1
+        lastText = text
+        lastConfiguration = configuration
+        if let error {
+            throw error
+        }
+        return result
+    }
+}
+
 // MARK: - MockStatsManager
 
 @MainActor
@@ -429,10 +449,15 @@ extension AppState {
     @MainActor
     static func makeTestState(
         modelManager: MockModelManager = MockModelManager(),
-        whisperService: MockWhisperService = MockWhisperService()
+        whisperService: MockWhisperService = MockWhisperService(),
+        textPostProcessor: MockTextPostProcessor = MockTextPostProcessor()
     ) -> (appState: AppState, mocks: TestMocks) {
         UserDefaults.standard.removeObject(forKey: "vocamac.selectedAudioDeviceID")
         UserDefaults.standard.removeObject(forKey: "vocamac.selectedAudioDeviceName")
+        UserDefaults.standard.removeObject(forKey: "vocamac.postProcessingEnabled")
+        UserDefaults.standard.removeObject(forKey: "vocamac.postProcessingRunnerPath")
+        UserDefaults.standard.removeObject(forKey: "vocamac.postProcessingModelPath")
+        UserDefaults.standard.removeObject(forKey: "vocamac.postProcessingInstructions")
 
         let audioEngine = MockAudioEngine()
         let soundManager = MockSoundManager()
@@ -451,12 +476,14 @@ extension AppState {
             modelManager: modelManager,
             whisperService: whisperService,
             textInjector: textInjector,
+            textPostProcessor: textPostProcessor,
             statsManager: statsManager
         )
         let appState = AppState(
             audioEngine: audioEngine,
             whisperService: whisperService,
             textInjector: textInjector,
+            textPostProcessor: textPostProcessor,
             hotKeyManager: hotKeyManager,
             modelManager: modelManager,
             soundManager: soundManager,
@@ -478,5 +505,6 @@ struct TestMocks {
     let modelManager: MockModelManager
     let whisperService: MockWhisperService
     let textInjector: MockTextInjector
+    let textPostProcessor: MockTextPostProcessor
     let statsManager: MockStatsManager
 }

--- a/Tests/VocaMacTests/Mocks/MockServices.swift
+++ b/Tests/VocaMacTests/Mocks/MockServices.swift
@@ -404,11 +404,22 @@ final class MockTextInjector: TextInjecting {
 // MARK: - MockTextPostProcessor
 
 final class MockTextPostProcessor: TextPostProcessing {
+    var prepareCallCount = 0
     var improveCallCount = 0
+    var lastPrepareConfiguration: TextPostProcessingConfiguration?
     var lastText: String?
     var lastConfiguration: TextPostProcessingConfiguration?
     var result = "processed text"
     var error: Error?
+    var prepareError: Error?
+
+    func prepare(configuration: TextPostProcessingConfiguration) async throws {
+        prepareCallCount += 1
+        lastPrepareConfiguration = configuration
+        if let prepareError {
+            throw prepareError
+        }
+    }
 
     func improve(_ text: String, configuration: TextPostProcessingConfiguration) async throws -> String {
         improveCallCount += 1
@@ -456,6 +467,7 @@ extension AppState {
         UserDefaults.standard.removeObject(forKey: "vocamac.selectedAudioDeviceName")
         UserDefaults.standard.removeObject(forKey: "vocamac.postProcessingEnabled")
         UserDefaults.standard.removeObject(forKey: "vocamac.postProcessingRunnerPath")
+        UserDefaults.standard.removeObject(forKey: "vocamac.postProcessingModelID")
         UserDefaults.standard.removeObject(forKey: "vocamac.postProcessingModelPath")
         UserDefaults.standard.removeObject(forKey: "vocamac.postProcessingInstructions")
 


### PR DESCRIPTION
## Summary

Adds an opt-in local AI post-processing pass after Whisper transcription and before text insertion.

- adds a dedicated Text settings tab for language, vocabulary, AI rewrite, and insertion settings
- adds a curated local model picker with Gemma 3 1B as the default conservative choice, Qwen3 1.7B as the larger alternative, and custom GGUF support
- installs and detects Homebrew's `llama-server` runtime, including migration from previously stored `llama` or `llama-cli` paths
- prepares catalog models through llama.cpp's Hugging Face cache via `-hf`, then enables rewrite only after a valid probe response
- falls back to raw Whisper text if post-processing fails, while surfacing a non-blocking warning

## Runtime design

VocaMac starts `llama-server` for each post-processing request on a unique private Unix socket under `/tmp`. It waits for the health endpoint, sends separate system and user messages to the OpenAI-compatible `/v1/chat/completions` endpoint, decodes `choices[0].message.content`, and shuts the server down after the response.

This replaces the earlier `llama-cli` transcript parsing approach entirely:

- no interactive CLI mode or hanging prompt loop
- no parsing of banners, prompt echoes, timing lines, or terminal control sequences
- no TCP port selection or collision risk
- structured JSON errors and response validation
- server subprocess output is drained to avoid pipe backpressure

## Production notes

- No silent external installs: llama.cpp installation is user-initiated.
- No custom model downloader: llama.cpp owns Hugging Face downloads and caching.
- The first guided model setup can take time because the selected GGUF is downloaded locally.
- Existing custom GGUF workflows continue through the Custom GGUF option.
- Existing saved `llama` and `llama-cli` paths resolve the adjacent `llama-server` binary automatically.

## Model choice

In local tests for conservative transcript cleanup, Gemma 3 1B followed the rewrite instructions more reliably than Qwen3 1.7B, so Gemma is now the default. Qwen remains available as an explicit larger option.

Related Linux issue: https://github.com/jatinkrmalik/vocalinux/issues/408

## Validation

- `swift test` (236 tests, 2 skipped, 0 failures)
- `VOCAMAC_RUN_LOCAL_LLM_TEST=1 swift test --filter LocalLLMPostProcessorTests/testLocalLlamaServerIntegrationWhenEnabled`
- real-model integration passed against cached `ggml-org/gemma-3-1b-it-GGUF:Q4_K_M`
- manual structured API probe against cached `Qwen/Qwen3-1.7B-GGUF:Q8_0`
- verified the integration leaves no `llama-server` process running