### PR TITLE
fix: restore settings window resizing

### DIFF
--- a/Sources/VocaMac/App/VocaMacApp.swift
+++ b/Sources/VocaMac/App/VocaMacApp.swift
@@ -24,8 +24,8 @@ final class SettingsWindowManager: ObservableObject {
 
         // Create a new window
         let window = NSWindow(
-            contentRect: NSRect(x: 0, y: 0, width: 560, height: 480),
-            styleMask: [.titled, .closable, .miniaturizable],
+            contentRect: NSRect(x: 0, y: 0, width: 560, height: 520),
+            styleMask: [.titled, .closable, .miniaturizable, .resizable],
             backing: .buffered,
             defer: false
         )

--- a/Sources/VocaMac/Views/SettingsView.swift
+++ b/Sources/VocaMac/Views/SettingsView.swift
@@ -43,7 +43,7 @@ struct SettingsView: View {
                     Label("About", systemImage: "info.circle")
                 }
         }
-        .frame(width: 560, height: 520)
+        .frame(minWidth: 560, minHeight: 520)
     }
 }
 


### PR DESCRIPTION
## Summary

- Restore the Settings window's AppKit resizable style mask.
- Let the SwiftUI settings content grow from its existing minimum size instead of forcing an exact size.
- Align the initial window content height with the settings view's minimum height.

## Root cause

The custom settings `NSWindow` was created without `.resizable`, and the root `SettingsView` used an exact fixed frame. Together, that removed the resize affordance and prevented the settings content from expanding.

## Validation

- `swift build`
- `swift test` (224 tests, 1 skipped, 0 failures)