### PR TITLE
fix: retry empty prompted transcriptions

### DIFF
--- a/Sources/VocaMac/Services/WhisperService.swift
+++ b/Sources/VocaMac/Services/WhisperService.swift
@@ -194,8 +194,11 @@ final class WhisperService: @unchecked Sendable {
             // WhisperKit can exit during prompt prefill and return no text for
             // some models. Preserve vocabulary bias normally, but recover the
             // dictation by retrying once without custom prompt tokens.
-            if Self.shouldRetryWithoutVocabulary(text: fullText, promptTokens: promptTokens) {
-                VocaLogger.warning(.whisperService, "Prompted transcription was empty; retrying without custom vocabulary")
+            if Self.shouldRetryWithoutVocabulary(rawText: rawText, promptTokens: promptTokens) {
+                VocaLogger.warning(
+                    .whisperService,
+                    "Prompted transcription was empty for \(loadedModelName ?? "unknown model"); retrying without custom vocabulary"
+                )
                 options.promptTokens = nil
                 options.usePrefillPrompt = language != nil
                 results = try await kit.transcribe(audioArray: audioData, decodeOptions: options)
@@ -286,8 +289,8 @@ final class WhisperService: @unchecked Sendable {
             .filter { !$0.isEmpty }
     }
 
-    static func shouldRetryWithoutVocabulary(text: String, promptTokens: [Int]?) -> Bool {
-        text.isEmpty && promptTokens != nil
+    static func shouldRetryWithoutVocabulary(rawText: String, promptTokens: [Int]?) -> Bool {
+        promptTokens != nil && rawText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
     }
 
     /// Encode custom vocabulary into WhisperKit conditioning tokens.

--- a/Sources/VocaMac/Services/WhisperService.swift
+++ b/Sources/VocaMac/Services/WhisperService.swift
@@ -166,7 +166,7 @@ final class WhisperService: @unchecked Sendable {
         let promptTokens = Self.promptTokens(for: vocabulary, tokenizer: kit.tokenizer)
 
         // Configure decoding options — optimized for low latency dictation
-        let options = DecodingOptions(
+        var options = DecodingOptions(
             task: translate ? .translate : .transcribe,
             language: language,
             temperature: 0.0,
@@ -179,19 +179,31 @@ final class WhisperService: @unchecked Sendable {
         )
 
         do {
-            let results = try await kit.transcribe(
+            var results = try await kit.transcribe(
                 audioArray: audioData,
                 decodeOptions: options
             )
 
-            let elapsed = CFAbsoluteTimeGetCurrent() - startTime
-
             // Concatenate all segment texts
-            let rawText = results.map { $0.text }.joined(separator: " ")
+            var rawText = results.map { $0.text }.joined(separator: " ")
 
             // Filter out WhisperKit hallucination tokens that should not be
             // exposed to the user (e.g. "[BLANK_AUDIO]", "(blank audio)", etc.)
-            let fullText = Self.filterHallucinationTokens(rawText)
+            var fullText = Self.filterHallucinationTokens(rawText)
+
+            // WhisperKit can exit during prompt prefill and return no text for
+            // some models. Preserve vocabulary bias normally, but recover the
+            // dictation by retrying once without custom prompt tokens.
+            if Self.shouldRetryWithoutVocabulary(text: fullText, promptTokens: promptTokens) {
+                VocaLogger.warning(.whisperService, "Prompted transcription was empty; retrying without custom vocabulary")
+                options.promptTokens = nil
+                options.usePrefillPrompt = language != nil
+                results = try await kit.transcribe(audioArray: audioData, decodeOptions: options)
+                rawText = results.map { $0.text }.joined(separator: " ")
+                fullText = Self.filterHallucinationTokens(rawText)
+            }
+
+            let elapsed = CFAbsoluteTimeGetCurrent() - startTime
 
             // Get detected language from first result
             let detectedLanguage = results.first?.language ?? language ?? "en"
@@ -272,6 +284,10 @@ final class WhisperService: @unchecked Sendable {
             .split(whereSeparator: { $0 == "\n" || $0 == "," })
             .map { $0.trimmingCharacters(in: .whitespaces) }
             .filter { !$0.isEmpty }
+    }
+
+    static func shouldRetryWithoutVocabulary(text: String, promptTokens: [Int]?) -> Bool {
+        text.isEmpty && promptTokens != nil
     }
 
     /// Encode custom vocabulary into WhisperKit conditioning tokens.

--- a/Tests/VocaMacTests/WhisperServiceTests.swift
+++ b/Tests/VocaMacTests/WhisperServiceTests.swift
@@ -88,4 +88,10 @@ final class WhisperServiceVocabularyTests: XCTestCase {
         let input = "Namrata,,\n\n, ,VocaMac"
         XCTAssertEqual(WhisperService.vocabularyTerms(from: input), ["Namrata", "VocaMac"])
     }
+
+    func testRetriesOnlyEmptyPromptedTranscriptions() {
+        XCTAssertTrue(WhisperService.shouldRetryWithoutVocabulary(text: "", promptTokens: [1]))
+        XCTAssertFalse(WhisperService.shouldRetryWithoutVocabulary(text: "transcribed", promptTokens: [1]))
+        XCTAssertFalse(WhisperService.shouldRetryWithoutVocabulary(text: "", promptTokens: nil))
+    }
 }

--- a/Tests/VocaMacTests/WhisperServiceTests.swift
+++ b/Tests/VocaMacTests/WhisperServiceTests.swift
@@ -90,8 +90,9 @@ final class WhisperServiceVocabularyTests: XCTestCase {
     }
 
     func testRetriesOnlyEmptyPromptedTranscriptions() {
-        XCTAssertTrue(WhisperService.shouldRetryWithoutVocabulary(text: "", promptTokens: [1]))
-        XCTAssertFalse(WhisperService.shouldRetryWithoutVocabulary(text: "transcribed", promptTokens: [1]))
-        XCTAssertFalse(WhisperService.shouldRetryWithoutVocabulary(text: "", promptTokens: nil))
+        XCTAssertTrue(WhisperService.shouldRetryWithoutVocabulary(rawText: "  \n", promptTokens: [1]))
+        XCTAssertFalse(WhisperService.shouldRetryWithoutVocabulary(rawText: "transcribed", promptTokens: [1]))
+        XCTAssertFalse(WhisperService.shouldRetryWithoutVocabulary(rawText: "[BLANK_AUDIO]", promptTokens: [1]))
+        XCTAssertFalse(WhisperService.shouldRetryWithoutVocabulary(rawText: "", promptTokens: nil))
     }
 }


### PR DESCRIPTION
## Summary

- retry once without custom vocabulary when a prompted transcription returns no usable text
- preserve vocabulary prompting for successful decodes and explicit language prefill during fallback
- cover the retry condition with a focused unit test

## Root cause

WhisperKit can exit during `promptTokens` prefill before decoding audio on affected models, returning an empty transcript. Retrying without custom prompt tokens recovers the dictation while keeping vocabulary bias on the normal path.

Upstream context: [argmaxinc/argmax-oss-swift#372](https://github.com/argmaxinc/argmax-oss-swift/issues/372) and [argmaxinc/argmax-oss-swift#497](https://github.com/argmaxinc/argmax-oss-swift/pull/497).

## Validation

- `swift test` (225 passed, 1 environment-dependent test skipped, 0 failures)

Closes #181