### PR TITLE
fix: reject silent microphone captures in clamshell mode

### DIFF
--- a/Sources/VocaMac/Models/AppState.swift
+++ b/Sources/VocaMac/Models/AppState.swift
@@ -611,6 +611,14 @@ final class AppState: ObservableObject {
             return
         }
 
+        guard audioData.contains(where: { abs($0) >= 0.0001 }) else {
+            cursorOverlay.hide()
+            let message = "No microphone audio detected. If your MacBook lid is closed, select an external microphone in Settings → Audio."
+            VocaLogger.warning(.appState, message)
+            showTemporaryError(message)
+            return
+        }
+
         appStatus = .processing
 
         do {

--- a/Sources/VocaMac/Views/SettingsView.swift
+++ b/Sources/VocaMac/Views/SettingsView.swift
@@ -652,7 +652,7 @@ struct AudioSettingsTab: View {
                         Text("\(selectedAudioDeviceDisplayName) (Unavailable)").tag(appState.selectedAudioDeviceID)
                     }
                     ForEach(audioDevices) { device in
-                        Text(audioDeviceLabel(for: device)).tag(device.id)
+                        Text(device.name).tag(device.id)
                     }
                 }
                 .onChange(of: appState.selectedAudioDeviceID) { _ in
@@ -719,10 +719,6 @@ struct AudioSettingsTab: View {
             return "VocaMac will follow macOS' system default input: \(defaultDevice.name)."
         }
         return "VocaMac will follow macOS' system default input."
-    }
-
-    private func audioDeviceLabel(for device: AudioDevice) -> String {
-        device.isDefault ? "\(device.name) (System Default)" : device.name
     }
 
     private func refreshAudioDevices() {

--- a/Tests/VocaMacTests/AppStateRecordingTests.swift
+++ b/Tests/VocaMacTests/AppStateRecordingTests.swift
@@ -118,6 +118,20 @@ final class AppStateRecordingTests: XCTestCase {
                       "Should return to idle when audio data is empty")
     }
 
+    func testStopRecordingWithSilentAudioShowsInputError() async {
+        let (appState, mocks) = AppState.makeTestState()
+        mocks.audioEngine.stopRecordingResult = Array(repeating: 0, count: 16_000)
+        appState.isRecording = true
+        appState.appStatus = .recording
+
+        await appState.stopRecordingAndTranscribe()
+
+        XCTAssertEqual(appState.appStatus, .error)
+        XCTAssertTrue(appState.errorMessage?.contains("external microphone") == true)
+        XCTAssertNil(mocks.whisperService.lastTranscribedAudioData)
+        XCTAssertEqual(mocks.textInjector.injectCallCount, 0)
+    }
+
     func testSelectedModelSizeDefault() {
         let (appState, _) = AppState.makeTestState()
 


### PR DESCRIPTION
## Summary

- Stop effectively silent microphone captures before they reach Whisper, preventing subtitle-style hallucinations from disconnected input.
- Show an actionable message directing clamshell users to select an external microphone.
- Remove the duplicate-looking `(System Default)` suffix from physical devices in the microphone picker.

## Root cause

Modern MacBooks hardware-disconnect the built-in microphone when the lid closes. macOS can continue reporting that microphone as the default input, so VocaMac receives a non-empty buffer containing digital silence. The existing empty-buffer check passes that audio to Whisper, which may generate phrases such as "thank you" or foreign-language subtitle text.

Explicitly selecting an external microphone works because VocaMac binds its AudioUnit directly to that Core Audio device.

## User impact

VocaMac now rejects disconnected digital silence instead of inserting hallucinated text and tells the user how to recover. It does not silently switch microphones; users retain control over which device records audio.

## Validation

- `swift test`
- 226 tests executed, 1 permission-dependent test skipped, 0 failures
- Added coverage confirming silent capture neither invokes Whisper nor injects text
- `git diff --check`