### PR TITLE
Fix flaky nightly CI: bump main-actor blocking threshold

### DIFF
--- a/Tests/VocaMacTests/AppStateRecordingTests.swift
+++ b/Tests/VocaMacTests/AppStateRecordingTests.swift
@@ -46,7 +46,7 @@ final class AppStateRecordingTests: XCTestCase {
         await Task.yield()
         try await Task.sleep(nanoseconds: 50_000_000)
 
-        XCTAssertLessThan(Date().timeIntervalSince(start), 0.2,
+        XCTAssertLessThan(Date().timeIntervalSince(start), 0.3,
                           "Core Audio startup should not block the main actor")
 
         await task.value


### PR DESCRIPTION
## What

`testStartRecordingDoesNotBlockMainActorDuringAudioStart` fails intermittently on CI runners (0.204s > 0.2s threshold).

## Why

The mock audio engine has `startRecordingDelay = 0.3` — the test is verifying the main actor doesn't synchronously block for the full audio start duration. The 0.2 threshold was too tight: initial main-actor work (guard checks, state mutation, cursor overlay) can creep past 0.2 on slower runners.

## Fix

Bumped the assertion threshold from **0.2 → 0.3**, matching the mock's `startRecordingDelay`. The assertion remains meaningful — it still catches actual synchronous blocking (which would be ≥0.3) — while eliminating the timing flake.