### PR TITLE
chore: bump version to 0.7.1

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -8,8 +8,8 @@
 # 3. Code signs — Developer ID if CODE_SIGN_IDENTITY is set, ad-hoc otherwise
 #
 # Environment variables:
-#   APP_VERSION         — Version string to embed in Info.plist. Defaults to 0.7.0.
-#                         Set by CI for nightly builds (e.g., 0.7.0-nightly.20260512+abc1234).
+#   APP_VERSION         — Version string to embed in Info.plist. Defaults to 0.7.1.
+#                         Set by CI for nightly builds (e.g., 0.7.1-nightly.20260512+abc1234).
 #   CODE_SIGN_IDENTITY  — Signing identity to use. Defaults to auto-detect
 #                         Developer ID Application in the login keychain.
 #                         Set to "-" to force ad-hoc signing.
@@ -29,7 +29,7 @@ BUNDLE_ID="com.vocamac.app"
 APP_NAME="VocaMac"
 APP_DIR="${APP_NAME}.app"
 ENTITLEMENTS="VocaMac.entitlements"
-APP_VERSION="${APP_VERSION:-0.7.0}"
+APP_VERSION="${APP_VERSION:-0.7.1}"
 
 # Resolve signing identity:
 # 1. Use CODE_SIGN_IDENTITY env var if set

--- a/web/layouts/index.html
+++ b/web/layouts/index.html
@@ -39,7 +39,7 @@
             "Open source (AGPL-3.0 license)"
         ],
         "screenshot": "https://vocamac.com/og-image.png",
-        "softwareVersion": "0.7.0",
+        "softwareVersion": "0.7.1",
         "softwareRequirements": "macOS 13 (Ventura) or later, Apple Silicon (M1 or later), 8 GB RAM minimum"
     }
     </script>
@@ -52,7 +52,7 @@
             <div class="hero__content">
                 <div class="hero__badges">
                     <span class="badge badge--beta">BETA RELEASE</span>
-                    <span class="badge badge--outline" id="version-badge">v0.7.0</span>
+                    <span class="badge badge--outline" id="version-badge">v0.7.1</span>
                 </div>
                 <h1 class="hero__headline">
                     Your Voice,<br>


### PR DESCRIPTION
## Summary

Prepares the **v0.7.1** patch release, focused on push-to-talk, microphone-route, and transcription reliability.

### Changes since v0.7.0

| PR | Type | Summary |
|---|---|---|
| #173 | fix | Prevent hotkey recording hangs and recover cleanly from slow audio startup |
| #175 | fix | Tolerate headset input route churn during recording startup |
| #182 | fix | Retry empty custom-vocabulary transcriptions without the prompt |
| #180 | fix | Restore Settings window resizing |
| #184 | fix | Reject silent microphone captures and show actionable input guidance |
| #178 | fix | Keep the audio engine warm briefly and reset silent input routes |
| #179 | ci | Add automated issue and pull-request classification |
| #185 | ci | Relax the flaky main-actor blocking test threshold |
| — | docs | Update README Star History chart links |

### Files updated

- `scripts/build.sh` — default app and Info.plist version is now 0.7.1
- `web/layouts/index.html` — JSON-LD and hero badge versions are now 0.7.1

### Validation

- `swift test` — 227 tests passed, 1 environment-dependent accessibility test skipped
- `./scripts/build.sh release` — release app bundle built successfully
- Verified `CFBundleVersion` and `CFBundleShortVersionString` are both `0.7.1`
- The affected users confirmed the audio-route fix works in the current nightly

### Release plan after merge

- Tag `v0.7.1` and push the tag; `release.yml` will build, sign, notarize, and create the draft GitHub Release
- Paste the polished out-of-tree release notes into the draft and review the generated artifacts
- Publish the release after final review, then remove the local scratch notes
