### PR TITLE
fix: stabilize selected audio input routes

### DIFF
--- a/Sources/VocaMac/Models/AppState.swift
+++ b/Sources/VocaMac/Models/AppState.swift
@@ -605,17 +605,12 @@ final class AppState: ObservableObject {
         // Keeps the overlay visible so the user knows text is on its way
         cursorOverlay.transitionToProcessing()
 
-        guard !audioData.isEmpty else {
+        guard !audioData.isEmpty,
+              audioData.contains(where: { abs($0) >= 0.0001 }) else {
             cursorOverlay.hide()
-            appStatus = .idle
-            return
-        }
-
-        guard audioData.contains(where: { abs($0) >= 0.0001 }) else {
-            cursorOverlay.hide()
-            // Don't keep a capture route that only produced silence warm.
+            // Don't keep a route warm when it produced no buffers or only silence.
             audioEngine.forceReset()
-            let message = "No microphone audio detected. If your MacBook lid is closed, select an external microphone in Settings → Audio."
+            let message = "No microphone audio detected. Check that the selected microphone is connected and available in Settings → Audio."
             VocaLogger.warning(.appState, message)
             showTemporaryError(message)
             return

--- a/Sources/VocaMac/Models/AppState.swift
+++ b/Sources/VocaMac/Models/AppState.swift
@@ -605,10 +605,15 @@ final class AppState: ObservableObject {
         // Keeps the overlay visible so the user knows text is on its way
         cursorOverlay.transitionToProcessing()
 
-        guard !audioData.isEmpty,
-              audioData.contains(where: { abs($0) >= 0.0001 }) else {
+        guard !audioData.isEmpty else {
             cursorOverlay.hide()
-            // Don't keep a route warm when it produced no buffers or only silence.
+            appStatus = .idle
+            return
+        }
+
+        guard audioData.contains(where: { abs($0) >= 0.0001 }) else {
+            cursorOverlay.hide()
+            // Don't keep a route warm when it produced only silence.
             audioEngine.forceReset()
             let message = "No microphone audio detected. Check that the selected microphone is connected and available in Settings → Audio."
             VocaLogger.warning(.appState, message)

--- a/Sources/VocaMac/Services/AudioEngine.swift
+++ b/Sources/VocaMac/Services/AudioEngine.swift
@@ -29,6 +29,7 @@ final class AudioEngine {
     private var _isPreparingRecording = false
 
     static let inputRouteConfigurationTimeout: TimeInterval = 0.25
+    static let startupConfigurationChangeRecoveryWindow: TimeInterval = 1.0
     static let idleEngineReleaseDelay: TimeInterval = 3.0
 
     var isCurrentlyRecording: Bool {
@@ -171,12 +172,17 @@ final class AudioEngine {
             guard let self = self else { return }
             VocaLogger.info(.audioEngine, "Audio configuration changed (device plug/unplug or route change)")
 
-            if occurredDuringRecordingPreparation {
+            let wasRecording = self._isCurrentlyRecording
+            let elapsedSinceRecordingStart = Date().timeIntervalSince(self.recordingStartTime)
+            if Self.shouldIgnoreConfigurationChange(
+                occurredDuringRecordingPreparation: occurredDuringRecordingPreparation,
+                isRecording: wasRecording,
+                engineIsRunning: self.engine?.isRunning == true,
+                elapsedSinceRecordingStart: elapsedSinceRecordingStart
+            ) {
                 VocaLogger.info(.audioEngine, "Configuration change was part of recording route preparation")
                 return
             }
-
-            let wasRecording = self._isCurrentlyRecording
 
             if wasRecording {
                 VocaLogger.warning(.audioEngine, "Configuration changed while recording — forcing stop and reset")
@@ -257,11 +263,14 @@ final class AudioEngine {
             for attempt in 1...2 {
                 let engine = acquireEngine()
                 let inputNode = engine.inputNode
-                configureInputRoute(
+                guard configureInputRoute(
                     preferredInputDeviceID: preferredInputDeviceID,
                     engine: engine,
                     inputNode: inputNode
-                )
+                ) else {
+                    recoverFromStartFailure(notifyAppState: false)
+                    return false
+                }
                 let inputFormat = inputNode.outputFormat(forBus: 0)
 
                 guard isValidInputFormat(inputFormat) else {
@@ -458,6 +467,20 @@ final class AudioEngine {
         return OSStatus(truncatingIfNeeded: (error as NSError).code) == kAudioHardwareNotRunningError
     }
 
+    static func shouldIgnoreConfigurationChange(
+        occurredDuringRecordingPreparation: Bool,
+        isRecording: Bool,
+        engineIsRunning: Bool,
+        elapsedSinceRecordingStart: TimeInterval,
+        recoveryWindow: TimeInterval = startupConfigurationChangeRecoveryWindow
+    ) -> Bool {
+        occurredDuringRecordingPreparation
+            || (isRecording
+                && engineIsRunning
+                && elapsedSinceRecordingStart >= 0
+                && elapsedSinceRecordingStart <= recoveryWindow)
+    }
+
     static func describeCoreAudioError(_ error: Error) -> String {
         let nsError = error as NSError
         var parts = [nsError.localizedDescription, "domain=\(nsError.domain)", "code=\(nsError.code)"]
@@ -645,7 +668,7 @@ final class AudioEngine {
         preferredInputDeviceID: String?,
         engine: AVAudioEngine,
         inputNode: AVAudioInputNode
-    ) {
+    ) -> Bool {
         let requestedUID = preferredInputDeviceID?
             .trimmingCharacters(in: .whitespacesAndNewlines)
         let requestedDeviceID = requestedUID.flatMap(Self.inputAudioDeviceID(forUID:))
@@ -657,12 +680,12 @@ final class AudioEngine {
 
         guard let targetDeviceID = requestedDeviceID ?? defaultDeviceID else {
             VocaLogger.warning(.audioEngine, "No input device is available; retaining the current AudioUnit route")
-            return
+            return true
         }
 
         guard let audioUnit = inputNode.audioUnit else {
             VocaLogger.warning(.audioEngine, "Input node has no AudioUnit; falling back to system default input")
-            return
+            return requestedDeviceID == nil
         }
 
         let currentDeviceID = Self.currentInputDeviceID(for: audioUnit)
@@ -672,7 +695,7 @@ final class AudioEngine {
         ) else {
             let deviceName = Self.audioDeviceName(for: targetDeviceID) ?? requestedUID ?? "system default"
             VocaLogger.debug(.audioEngine, "Input device already configured: \(deviceName)")
-            return
+            return true
         }
 
         // Observe directly on Core Audio's posting queue. startRecording holds
@@ -699,7 +722,7 @@ final class AudioEngine {
 
         guard status == noErr else {
             VocaLogger.warning(.audioEngine, "Failed to set input device: OSStatus \(status); retaining the current route")
-            return
+            return requestedDeviceID == nil
         }
 
         let deviceIDImmediatelyAfterSet = Self.currentInputDeviceID(for: audioUnit)
@@ -716,14 +739,19 @@ final class AudioEngine {
         engine.reset()
 
         let deviceIDAfterReset = Self.currentInputDeviceID(for: audioUnit)
-        guard deviceIDImmediatelyAfterSet == targetDeviceID,
-              deviceIDAfterReset == targetDeviceID else {
+        if deviceIDImmediatelyAfterSet != targetDeviceID || deviceIDAfterReset != targetDeviceID {
             VocaLogger.warning(.audioEngine, "Core Audio did not apply the requested input device; rebuilt the graph using the active fallback route")
-            return
+            return Self.shouldAcceptConfiguredInputRoute(
+                requestedDeviceID: requestedDeviceID,
+                targetDeviceID: targetDeviceID,
+                deviceIDImmediatelyAfterSet: deviceIDImmediatelyAfterSet,
+                deviceIDAfterReset: deviceIDAfterReset
+            )
         }
 
         let deviceName = Self.audioDeviceName(for: targetDeviceID) ?? requestedUID ?? "system default"
         VocaLogger.info(.audioEngine, "Using input device: \(deviceName)")
+        return true
     }
 
     static func shouldReconfigureInputDevice(
@@ -731,6 +759,17 @@ final class AudioEngine {
         targetDeviceID: AudioDeviceID
     ) -> Bool {
         currentDeviceID != targetDeviceID
+    }
+
+    static func shouldAcceptConfiguredInputRoute(
+        requestedDeviceID: AudioDeviceID?,
+        targetDeviceID: AudioDeviceID,
+        deviceIDImmediatelyAfterSet: AudioDeviceID?,
+        deviceIDAfterReset: AudioDeviceID?
+    ) -> Bool {
+        requestedDeviceID == nil
+            || (deviceIDImmediatelyAfterSet == targetDeviceID
+                && deviceIDAfterReset == targetDeviceID)
     }
 
     private static func currentInputDeviceID(for audioUnit: AudioUnit) -> AudioDeviceID? {

--- a/Sources/VocaMac/Services/AudioEngine.swift
+++ b/Sources/VocaMac/Services/AudioEngine.swift
@@ -25,8 +25,10 @@ final class AudioEngine {
     private var _isCurrentlyRecording = false
     private let bufferQueue = DispatchQueue(label: "com.vocamac.audio-buffer", qos: .userInteractive)
     private let lifecycleQueue = DispatchQueue(label: "com.vocamac.audio-engine.lifecycle", qos: .userInitiated)
+    private let recordingPreparationLock = NSLock()
+    private var _isPreparingRecording = false
 
-    static let startupConfigurationChangeRecoveryWindow: TimeInterval = 1.0
+    static let inputRouteConfigurationTimeout: TimeInterval = 0.25
     static let idleEngineReleaseDelay: TimeInterval = 3.0
 
     var isCurrentlyRecording: Bool {
@@ -35,6 +37,12 @@ final class AudioEngine {
 
     var isEngineAllocatedForTesting: Bool {
         lifecycleQueue.sync { engine != nil }
+    }
+
+    private var isPreparingRecording: Bool {
+        recordingPreparationLock.lock()
+        defer { recordingPreparationLock.unlock() }
+        return _isPreparingRecording
     }
 
     // Silence detection
@@ -154,19 +162,21 @@ final class AudioEngine {
     /// is invalidated — the installed tap references a stale format and no audio
     /// flows. We must stop, reset, and notify AppState so it can recover.
     @objc private func handleAudioConfigurationChange(_ notification: Notification) {
+        // The notification itself can arrive on Core Audio's internal queue while
+        // startRecording owns lifecycleQueue. Capture this state here rather than
+        // reading it later in the queued work, after startup has completed.
+        let occurredDuringRecordingPreparation = isPreparingRecording
+
         lifecycleQueue.async { [weak self] in
             guard let self = self else { return }
             VocaLogger.info(.audioEngine, "Audio configuration changed (device plug/unplug or route change)")
 
-            let wasRecording = self._isCurrentlyRecording
-
-            let elapsedSinceRecordingStart = Date().timeIntervalSince(self.recordingStartTime)
-            if wasRecording,
-               self.engine?.isRunning == true,
-               Self.shouldTreatAsStartupConfigurationChange(elapsedSinceRecordingStart: elapsedSinceRecordingStart) {
-                VocaLogger.info(.audioEngine, "Ignoring startup audio configuration change because the engine is still running")
+            if occurredDuringRecordingPreparation {
+                VocaLogger.info(.audioEngine, "Configuration change was part of recording route preparation")
                 return
             }
+
+            let wasRecording = self._isCurrentlyRecording
 
             if wasRecording {
                 VocaLogger.warning(.audioEngine, "Configuration changed while recording — forcing stop and reset")
@@ -235,6 +245,9 @@ final class AudioEngine {
         lifecycleQueue.sync {
             guard !self._isCurrentlyRecording else { return true }
 
+            self.setIsPreparingRecording(true)
+            defer { self.setIsPreparingRecording(false) }
+
             self.silenceThreshold = silenceThreshold
             self.silenceDuration = silenceDuration
             self.maxDuration = maxDuration
@@ -244,7 +257,11 @@ final class AudioEngine {
             for attempt in 1...2 {
                 let engine = acquireEngine()
                 let inputNode = engine.inputNode
-                configurePreferredInputDevice(preferredInputDeviceID, on: inputNode)
+                configureInputRoute(
+                    preferredInputDeviceID: preferredInputDeviceID,
+                    engine: engine,
+                    inputNode: inputNode
+                )
                 let inputFormat = inputNode.outputFormat(forBus: 0)
 
                 guard isValidInputFormat(inputFormat) else {
@@ -293,6 +310,15 @@ final class AudioEngine {
 
                     if Self.shouldRetryStart(after: startError, attempt: attempt) {
                         VocaLogger.warning(.audioEngine, "Retrying audio engine start after hardware-not-running error")
+                        continue
+                    }
+                    return false
+                }
+
+                guard engine.isRunning else {
+                    VocaLogger.warning(.audioEngine, "Audio engine stopped during route configuration (attempt \(attempt))")
+                    recoverFromStartFailure(notifyAppState: false)
+                    if attempt == 1 {
                         continue
                     }
                     return false
@@ -379,6 +405,12 @@ final class AudioEngine {
         }
     }
 
+    private func setIsPreparingRecording(_ isPreparing: Bool) {
+        recordingPreparationLock.lock()
+        _isPreparingRecording = isPreparing
+        recordingPreparationLock.unlock()
+    }
+
     /// Checks whether a hardware input format is safe to pass to AVAudioEngine.
     /// Invalid or transient formats can cause installTap to raise NSException.
     private func isValidInputFormat(_ format: AVAudioFormat) -> Bool {
@@ -419,17 +451,6 @@ final class AudioEngine {
                 self?.onAudioDeviceChanged?()
             }
         }
-    }
-
-    /// Returns whether a configuration notification is close enough to recording
-    /// startup to be treated as device/profile setup churn instead of a live
-    /// device interruption.
-    static func shouldTreatAsStartupConfigurationChange(
-        elapsedSinceRecordingStart: TimeInterval,
-        recoveryWindow: TimeInterval = startupConfigurationChangeRecoveryWindow
-    ) -> Bool {
-        elapsedSinceRecordingStart >= 0
-            && elapsedSinceRecordingStart <= recoveryWindow
     }
 
     static func shouldRetryStart(after error: Error, attempt: Int) -> Bool {
@@ -616,17 +637,26 @@ final class AudioEngine {
         }
     }
 
-    /// Configure this engine's input unit to use a specific Core Audio device.
-    /// This is scoped to VocaMac's AudioUnit and does not change macOS' global default input.
-    private func configurePreferredInputDevice(_ preferredInputDeviceID: String?, on inputNode: AVAudioInputNode) {
-        guard let preferredInputDeviceID,
-              !preferredInputDeviceID.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
-            VocaLogger.debug(.audioEngine, "Using system default input device")
-            return
+    /// Configure this engine's input unit before building the recording graph.
+    /// Setting CurrentDevice can asynchronously invalidate AVAudioEngine's formats,
+    /// so a real route change is allowed to settle and the graph is reset before
+    /// the tap's format is queried.
+    private func configureInputRoute(
+        preferredInputDeviceID: String?,
+        engine: AVAudioEngine,
+        inputNode: AVAudioInputNode
+    ) {
+        let requestedUID = preferredInputDeviceID?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        let requestedDeviceID = requestedUID.flatMap(Self.inputAudioDeviceID(forUID:))
+        let defaultDeviceID = Self.defaultInputAudioDeviceID()
+
+        if let requestedUID, !requestedUID.isEmpty, requestedDeviceID == nil {
+            VocaLogger.warning(.audioEngine, "Preferred input device unavailable, falling back to system default: \(requestedUID)")
         }
 
-        guard let deviceID = Self.inputAudioDeviceID(forUID: preferredInputDeviceID) else {
-            VocaLogger.warning(.audioEngine, "Preferred input device unavailable, falling back to system default: \(preferredInputDeviceID)")
+        guard let targetDeviceID = requestedDeviceID ?? defaultDeviceID else {
+            VocaLogger.warning(.audioEngine, "No input device is available; retaining the current AudioUnit route")
             return
         }
 
@@ -635,7 +665,29 @@ final class AudioEngine {
             return
         }
 
-        var mutableDeviceID = deviceID
+        let currentDeviceID = Self.currentInputDeviceID(for: audioUnit)
+        guard Self.shouldReconfigureInputDevice(
+            currentDeviceID: currentDeviceID,
+            targetDeviceID: targetDeviceID
+        ) else {
+            let deviceName = Self.audioDeviceName(for: targetDeviceID) ?? requestedUID ?? "system default"
+            VocaLogger.debug(.audioEngine, "Input device already configured: \(deviceName)")
+            return
+        }
+
+        // Observe directly on Core Audio's posting queue. startRecording holds
+        // lifecycleQueue, so waiting for the normal handler would deadlock.
+        let routeChangeSignal = DispatchSemaphore(value: 0)
+        let observer = NotificationCenter.default.addObserver(
+            forName: .AVAudioEngineConfigurationChange,
+            object: engine,
+            queue: nil
+        ) { _ in
+            routeChangeSignal.signal()
+        }
+        defer { NotificationCenter.default.removeObserver(observer) }
+
+        var mutableDeviceID = targetDeviceID
         let status = AudioUnitSetProperty(
             audioUnit,
             kAudioOutputUnitProperty_CurrentDevice,
@@ -646,12 +698,57 @@ final class AudioEngine {
         )
 
         guard status == noErr else {
-            VocaLogger.warning(.audioEngine, "Failed to set preferred input device \(preferredInputDeviceID): OSStatus \(status)")
+            VocaLogger.warning(.audioEngine, "Failed to set input device: OSStatus \(status); retaining the current route")
             return
         }
 
-        let deviceName = Self.audioDeviceName(for: deviceID) ?? preferredInputDeviceID
-        VocaLogger.info(.audioEngine, "Using preferred input device: \(deviceName)")
+        let deviceIDImmediatelyAfterSet = Self.currentInputDeviceID(for: audioUnit)
+
+        let waitResult = routeChangeSignal.wait(timeout: .now() + Self.inputRouteConfigurationTimeout)
+        if waitResult == .timedOut {
+            VocaLogger.debug(.audioEngine, "No configuration notification received after input route change; rebuilding graph after timeout")
+        }
+
+        // Apple documents that configuration changes stop and uninitialize the
+        // engine while leaving connections with their previous formats. There is
+        // no tap yet, so reset now and query the new hardware format afterwards.
+        engine.stop()
+        engine.reset()
+
+        let deviceIDAfterReset = Self.currentInputDeviceID(for: audioUnit)
+        guard deviceIDImmediatelyAfterSet == targetDeviceID,
+              deviceIDAfterReset == targetDeviceID else {
+            VocaLogger.warning(.audioEngine, "Core Audio did not apply the requested input device; rebuilt the graph using the active fallback route")
+            return
+        }
+
+        let deviceName = Self.audioDeviceName(for: targetDeviceID) ?? requestedUID ?? "system default"
+        VocaLogger.info(.audioEngine, "Using input device: \(deviceName)")
+    }
+
+    static func shouldReconfigureInputDevice(
+        currentDeviceID: AudioDeviceID?,
+        targetDeviceID: AudioDeviceID
+    ) -> Bool {
+        currentDeviceID != targetDeviceID
+    }
+
+    private static func currentInputDeviceID(for audioUnit: AudioUnit) -> AudioDeviceID? {
+        var deviceID = AudioDeviceID(kAudioObjectUnknown)
+        var dataSize = UInt32(MemoryLayout<AudioDeviceID>.size)
+        let status = AudioUnitGetProperty(
+            audioUnit,
+            kAudioOutputUnitProperty_CurrentDevice,
+            kAudioUnitScope_Global,
+            0,
+            &deviceID,
+            &dataSize
+        )
+
+        guard status == noErr, deviceID != AudioDeviceID(kAudioObjectUnknown) else {
+            return nil
+        }
+        return deviceID
     }
 
     private static func inputAudioDeviceID(forUID uid: String) -> AudioDeviceID? {

--- a/Sources/VocaMac/Services/AudioEngine.swift
+++ b/Sources/VocaMac/Services/AudioEngine.swift
@@ -23,10 +23,9 @@ final class AudioEngine {
     private var pendingEngineRelease: DispatchWorkItem?
     private var audioBuffer: [Float] = []
     private var _isCurrentlyRecording = false
+    private var configuredInputDeviceID: AudioDeviceID?
     private let bufferQueue = DispatchQueue(label: "com.vocamac.audio-buffer", qos: .userInteractive)
     private let lifecycleQueue = DispatchQueue(label: "com.vocamac.audio-engine.lifecycle", qos: .userInitiated)
-    private let recordingPreparationLock = NSLock()
-    private var _isPreparingRecording = false
 
     static let inputRouteConfigurationTimeout: TimeInterval = 0.25
     static let startupConfigurationChangeRecoveryWindow: TimeInterval = 1.0
@@ -38,12 +37,6 @@ final class AudioEngine {
 
     var isEngineAllocatedForTesting: Bool {
         lifecycleQueue.sync { engine != nil }
-    }
-
-    private var isPreparingRecording: Bool {
-        recordingPreparationLock.lock()
-        defer { recordingPreparationLock.unlock() }
-        return _isPreparingRecording
     }
 
     // Silence detection
@@ -131,6 +124,7 @@ final class AudioEngine {
         pendingEngineRelease?.cancel()
         pendingEngineRelease = nil
 
+        configuredInputDeviceID = nil
         guard let engine else { return }
         NotificationCenter.default.removeObserver(self, name: .AVAudioEngineConfigurationChange, object: engine)
         self.engine = nil
@@ -163,24 +157,23 @@ final class AudioEngine {
     /// is invalidated — the installed tap references a stale format and no audio
     /// flows. We must stop, reset, and notify AppState so it can recover.
     @objc private func handleAudioConfigurationChange(_ notification: Notification) {
-        // The notification itself can arrive on Core Audio's internal queue while
-        // startRecording owns lifecycleQueue. Capture this state here rather than
-        // reading it later in the queued work, after startup has completed.
-        let occurredDuringRecordingPreparation = isPreparingRecording
-
         lifecycleQueue.async { [weak self] in
             guard let self = self else { return }
             VocaLogger.info(.audioEngine, "Audio configuration changed (device plug/unplug or route change)")
 
             let wasRecording = self._isCurrentlyRecording
             let elapsedSinceRecordingStart = Date().timeIntervalSince(self.recordingStartTime)
+            let currentInputDeviceID = self.engine?.inputNode.audioUnit.flatMap {
+                Self.currentInputDeviceID(for: $0)
+            }
             if Self.shouldIgnoreConfigurationChange(
-                occurredDuringRecordingPreparation: occurredDuringRecordingPreparation,
                 isRecording: wasRecording,
                 engineIsRunning: self.engine?.isRunning == true,
-                elapsedSinceRecordingStart: elapsedSinceRecordingStart
+                elapsedSinceRecordingStart: elapsedSinceRecordingStart,
+                configuredInputDeviceID: self.configuredInputDeviceID,
+                currentInputDeviceID: currentInputDeviceID
             ) {
-                VocaLogger.info(.audioEngine, "Configuration change was part of recording route preparation")
+                VocaLogger.info(.audioEngine, "Configuration change did not disrupt the configured recording route")
                 return
             }
 
@@ -251,9 +244,6 @@ final class AudioEngine {
         lifecycleQueue.sync {
             guard !self._isCurrentlyRecording else { return true }
 
-            self.setIsPreparingRecording(true)
-            defer { self.setIsPreparingRecording(false) }
-
             self.silenceThreshold = silenceThreshold
             self.silenceDuration = silenceDuration
             self.maxDuration = maxDuration
@@ -263,7 +253,7 @@ final class AudioEngine {
             for attempt in 1...2 {
                 let engine = acquireEngine()
                 let inputNode = engine.inputNode
-                guard configureInputRoute(
+                guard let configuredInputDeviceID = configureInputRoute(
                     preferredInputDeviceID: preferredInputDeviceID,
                     engine: engine,
                     inputNode: inputNode
@@ -271,6 +261,7 @@ final class AudioEngine {
                     recoverFromStartFailure(notifyAppState: false)
                     return false
                 }
+                self.configuredInputDeviceID = configuredInputDeviceID
                 let inputFormat = inputNode.outputFormat(forBus: 0)
 
                 guard isValidInputFormat(inputFormat) else {
@@ -414,12 +405,6 @@ final class AudioEngine {
         }
     }
 
-    private func setIsPreparingRecording(_ isPreparing: Bool) {
-        recordingPreparationLock.lock()
-        _isPreparingRecording = isPreparing
-        recordingPreparationLock.unlock()
-    }
-
     /// Checks whether a hardware input format is safe to pass to AVAudioEngine.
     /// Invalid or transient formats can cause installTap to raise NSException.
     private func isValidInputFormat(_ format: AVAudioFormat) -> Bool {
@@ -468,17 +453,19 @@ final class AudioEngine {
     }
 
     static func shouldIgnoreConfigurationChange(
-        occurredDuringRecordingPreparation: Bool,
         isRecording: Bool,
         engineIsRunning: Bool,
         elapsedSinceRecordingStart: TimeInterval,
+        configuredInputDeviceID: AudioDeviceID?,
+        currentInputDeviceID: AudioDeviceID?,
         recoveryWindow: TimeInterval = startupConfigurationChangeRecoveryWindow
     ) -> Bool {
-        occurredDuringRecordingPreparation
-            || (isRecording
-                && engineIsRunning
-                && elapsedSinceRecordingStart >= 0
-                && elapsedSinceRecordingStart <= recoveryWindow)
+        isRecording
+            && engineIsRunning
+            && elapsedSinceRecordingStart >= 0
+            && elapsedSinceRecordingStart <= recoveryWindow
+            && configuredInputDeviceID != nil
+            && currentInputDeviceID == configuredInputDeviceID
     }
 
     static func describeCoreAudioError(_ error: Error) -> String {
@@ -668,7 +655,7 @@ final class AudioEngine {
         preferredInputDeviceID: String?,
         engine: AVAudioEngine,
         inputNode: AVAudioInputNode
-    ) -> Bool {
+    ) -> AudioDeviceID? {
         let requestedUID = preferredInputDeviceID?
             .trimmingCharacters(in: .whitespacesAndNewlines)
         let requestedDeviceID = requestedUID.flatMap(Self.inputAudioDeviceID(forUID:))
@@ -679,13 +666,13 @@ final class AudioEngine {
         }
 
         guard let targetDeviceID = requestedDeviceID ?? defaultDeviceID else {
-            VocaLogger.warning(.audioEngine, "No input device is available; retaining the current AudioUnit route")
-            return true
+            VocaLogger.warning(.audioEngine, "No input device is available")
+            return nil
         }
 
         guard let audioUnit = inputNode.audioUnit else {
-            VocaLogger.warning(.audioEngine, "Input node has no AudioUnit; falling back to system default input")
-            return requestedDeviceID == nil
+            VocaLogger.warning(.audioEngine, "Input node has no AudioUnit; unable to verify the requested input route")
+            return nil
         }
 
         let currentDeviceID = Self.currentInputDeviceID(for: audioUnit)
@@ -695,7 +682,7 @@ final class AudioEngine {
         ) else {
             let deviceName = Self.audioDeviceName(for: targetDeviceID) ?? requestedUID ?? "system default"
             VocaLogger.debug(.audioEngine, "Input device already configured: \(deviceName)")
-            return true
+            return targetDeviceID
         }
 
         // Observe directly on Core Audio's posting queue. startRecording holds
@@ -721,11 +708,14 @@ final class AudioEngine {
         )
 
         guard status == noErr else {
-            VocaLogger.warning(.audioEngine, "Failed to set input device: OSStatus \(status); retaining the current route")
-            return requestedDeviceID == nil
+            VocaLogger.warning(.audioEngine, "Failed to set input device: OSStatus \(status)")
+            return nil
         }
 
         let deviceIDImmediatelyAfterSet = Self.currentInputDeviceID(for: audioUnit)
+        if deviceIDImmediatelyAfterSet != targetDeviceID {
+            VocaLogger.debug(.audioEngine, "Input route change is still pending after AudioUnitSetProperty")
+        }
 
         let waitResult = routeChangeSignal.wait(timeout: .now() + Self.inputRouteConfigurationTimeout)
         if waitResult == .timedOut {
@@ -739,19 +729,17 @@ final class AudioEngine {
         engine.reset()
 
         let deviceIDAfterReset = Self.currentInputDeviceID(for: audioUnit)
-        if deviceIDImmediatelyAfterSet != targetDeviceID || deviceIDAfterReset != targetDeviceID {
-            VocaLogger.warning(.audioEngine, "Core Audio did not apply the requested input device; rebuilt the graph using the active fallback route")
-            return Self.shouldAcceptConfiguredInputRoute(
-                requestedDeviceID: requestedDeviceID,
-                targetDeviceID: targetDeviceID,
-                deviceIDImmediatelyAfterSet: deviceIDImmediatelyAfterSet,
-                deviceIDAfterReset: deviceIDAfterReset
-            )
+        guard Self.shouldAcceptConfiguredInputRoute(
+            targetDeviceID: targetDeviceID,
+            deviceIDAfterReset: deviceIDAfterReset
+        ) else {
+            VocaLogger.warning(.audioEngine, "Core Audio did not apply the requested input device after rebuilding the graph")
+            return nil
         }
 
         let deviceName = Self.audioDeviceName(for: targetDeviceID) ?? requestedUID ?? "system default"
         VocaLogger.info(.audioEngine, "Using input device: \(deviceName)")
-        return true
+        return targetDeviceID
     }
 
     static func shouldReconfigureInputDevice(
@@ -762,14 +750,10 @@ final class AudioEngine {
     }
 
     static func shouldAcceptConfiguredInputRoute(
-        requestedDeviceID: AudioDeviceID?,
         targetDeviceID: AudioDeviceID,
-        deviceIDImmediatelyAfterSet: AudioDeviceID?,
         deviceIDAfterReset: AudioDeviceID?
     ) -> Bool {
-        requestedDeviceID == nil
-            || (deviceIDImmediatelyAfterSet == targetDeviceID
-                && deviceIDAfterReset == targetDeviceID)
+        deviceIDAfterReset == targetDeviceID
     }
 
     private static func currentInputDeviceID(for audioUnit: AudioUnit) -> AudioDeviceID? {

--- a/Tests/VocaMacTests/AppStateRecordingTests.swift
+++ b/Tests/VocaMacTests/AppStateRecordingTests.swift
@@ -68,7 +68,8 @@ final class AppStateRecordingTests: XCTestCase {
 
         XCTAssertEqual(mocks.soundManager.startSoundCallCount, 0)
         XCTAssertEqual(mocks.soundManager.stopSoundCallCount, 1)
-        XCTAssertEqual(appState.appStatus, .idle)
+        XCTAssertEqual(appState.appStatus, .error)
+        XCTAssertEqual(mocks.audioEngine.forceResetCallCount, 1)
     }
 
     func testStartRecordingInProcessingStateForceRecovers() async {
@@ -107,15 +108,19 @@ final class AppStateRecordingTests: XCTestCase {
                       "Stop sound should be played once")
     }
 
-    func testStopRecordingWithEmptyAudioReturnsToIdle() async {
-        let (appState, _) = AppState.makeTestState()
+    func testStopRecordingWithEmptyAudioShowsInputErrorAndResetsRoute() async {
+        let (appState, mocks) = AppState.makeTestState()
         appState.isRecording = true
         appState.appStatus = .recording
 
         await appState.stopRecordingAndTranscribe()
 
-        XCTAssertEqual(appState.appStatus, .idle,
-                      "Should return to idle when audio data is empty")
+        XCTAssertEqual(appState.appStatus, .error)
+        XCTAssertTrue(appState.errorMessage?.contains("selected microphone") == true)
+        XCTAssertNil(mocks.whisperService.lastTranscribedAudioData)
+        XCTAssertEqual(mocks.textInjector.injectCallCount, 0)
+        XCTAssertEqual(mocks.audioEngine.forceResetCallCount, 1,
+                       "Empty capture should force-reset the engine so a dead route is not kept warm")
     }
 
     func testStopRecordingWithSilentAudioShowsInputError() async {
@@ -127,7 +132,7 @@ final class AppStateRecordingTests: XCTestCase {
         await appState.stopRecordingAndTranscribe()
 
         XCTAssertEqual(appState.appStatus, .error)
-        XCTAssertTrue(appState.errorMessage?.contains("external microphone") == true)
+        XCTAssertTrue(appState.errorMessage?.contains("selected microphone") == true)
         XCTAssertNil(mocks.whisperService.lastTranscribedAudioData)
         XCTAssertEqual(mocks.textInjector.injectCallCount, 0)
         XCTAssertEqual(mocks.audioEngine.forceResetCallCount, 1,

--- a/Tests/VocaMacTests/AppStateRecordingTests.swift
+++ b/Tests/VocaMacTests/AppStateRecordingTests.swift
@@ -68,8 +68,8 @@ final class AppStateRecordingTests: XCTestCase {
 
         XCTAssertEqual(mocks.soundManager.startSoundCallCount, 0)
         XCTAssertEqual(mocks.soundManager.stopSoundCallCount, 1)
-        XCTAssertEqual(appState.appStatus, .error)
-        XCTAssertEqual(mocks.audioEngine.forceResetCallCount, 1)
+        XCTAssertEqual(appState.appStatus, .idle)
+        XCTAssertEqual(mocks.audioEngine.forceResetCallCount, 0)
     }
 
     func testStartRecordingInProcessingStateForceRecovers() async {
@@ -108,19 +108,19 @@ final class AppStateRecordingTests: XCTestCase {
                       "Stop sound should be played once")
     }
 
-    func testStopRecordingWithEmptyAudioShowsInputErrorAndResetsRoute() async {
+    func testStopRecordingWithEmptyAudioReturnsToIdle() async {
         let (appState, mocks) = AppState.makeTestState()
         appState.isRecording = true
         appState.appStatus = .recording
 
         await appState.stopRecordingAndTranscribe()
 
-        XCTAssertEqual(appState.appStatus, .error)
-        XCTAssertTrue(appState.errorMessage?.contains("selected microphone") == true)
+        XCTAssertEqual(appState.appStatus, .idle)
+        XCTAssertNil(appState.errorMessage)
         XCTAssertNil(mocks.whisperService.lastTranscribedAudioData)
         XCTAssertEqual(mocks.textInjector.injectCallCount, 0)
-        XCTAssertEqual(mocks.audioEngine.forceResetCallCount, 1,
-                       "Empty capture should force-reset the engine so a dead route is not kept warm")
+        XCTAssertEqual(mocks.audioEngine.forceResetCallCount, 0,
+                       "Cancelling before the first buffer should not be reported as a broken route")
     }
 
     func testStopRecordingWithSilentAudioShowsInputError() async {

--- a/Tests/VocaMacTests/ServiceTests.swift
+++ b/Tests/VocaMacTests/ServiceTests.swift
@@ -659,19 +659,19 @@ final class AudioEngineForceResetTests: XCTestCase {
 
 final class AudioEngineDeviceChangeTests: XCTestCase {
 
-    func testStartupConfigurationChangeWindow() {
-        let cases: [(elapsed: TimeInterval, expected: Bool)] = [
-            (0.10, true),
-            (AudioEngine.startupConfigurationChangeRecoveryWindow + 0.01, false),
-            (-0.01, false)
-        ]
-
-        for testCase in cases {
-            XCTAssertEqual(
-                AudioEngine.shouldTreatAsStartupConfigurationChange(elapsedSinceRecordingStart: testCase.elapsed),
-                testCase.expected
-            )
-        }
+    func testInputRouteReconfigurationDecision() {
+        XCTAssertFalse(
+            AudioEngine.shouldReconfigureInputDevice(currentDeviceID: 42, targetDeviceID: 42),
+            "An AudioUnit already bound to the target device should not rebuild its graph"
+        )
+        XCTAssertTrue(
+            AudioEngine.shouldReconfigureInputDevice(currentDeviceID: 41, targetDeviceID: 42),
+            "Switching devices must rebuild the graph"
+        )
+        XCTAssertTrue(
+            AudioEngine.shouldReconfigureInputDevice(currentDeviceID: nil, targetDeviceID: 42),
+            "An unreadable current route must be treated as needing configuration"
+        )
     }
 
     func testOnAudioDeviceChangedCallbackExists() {

--- a/Tests/VocaMacTests/ServiceTests.swift
+++ b/Tests/VocaMacTests/ServiceTests.swift
@@ -674,6 +674,65 @@ final class AudioEngineDeviceChangeTests: XCTestCase {
         )
     }
 
+    func testExplicitInputRouteMustBeVerified() {
+        XCTAssertTrue(
+            AudioEngine.shouldAcceptConfiguredInputRoute(
+                requestedDeviceID: 42,
+                targetDeviceID: 42,
+                deviceIDImmediatelyAfterSet: 42,
+                deviceIDAfterReset: 42
+            )
+        )
+        XCTAssertFalse(
+            AudioEngine.shouldAcceptConfiguredInputRoute(
+                requestedDeviceID: 42,
+                targetDeviceID: 42,
+                deviceIDImmediatelyAfterSet: 41,
+                deviceIDAfterReset: 41
+            ),
+            "An explicit selection must not silently record from a fallback device"
+        )
+        XCTAssertTrue(
+            AudioEngine.shouldAcceptConfiguredInputRoute(
+                requestedDeviceID: nil,
+                targetDeviceID: 42,
+                deviceIDImmediatelyAfterSet: 41,
+                deviceIDAfterReset: 41
+            ),
+            "System Default may continue on Core Audio's active fallback route"
+        )
+    }
+
+    func testDelayedHealthyStartupConfigurationChangeIsIgnored() {
+        XCTAssertTrue(
+            AudioEngine.shouldIgnoreConfigurationChange(
+                occurredDuringRecordingPreparation: false,
+                isRecording: true,
+                engineIsRunning: true,
+                elapsedSinceRecordingStart: 0.5
+            ),
+            "A delayed startup notification must not tear down a healthy recording"
+        )
+        XCTAssertFalse(
+            AudioEngine.shouldIgnoreConfigurationChange(
+                occurredDuringRecordingPreparation: false,
+                isRecording: true,
+                engineIsRunning: false,
+                elapsedSinceRecordingStart: 0.5
+            ),
+            "A stopped engine still requires route-change recovery"
+        )
+        XCTAssertFalse(
+            AudioEngine.shouldIgnoreConfigurationChange(
+                occurredDuringRecordingPreparation: false,
+                isRecording: true,
+                engineIsRunning: true,
+                elapsedSinceRecordingStart: 1.01
+            ),
+            "Live route changes after startup must still interrupt recording"
+        )
+    }
+
     func testOnAudioDeviceChangedCallbackExists() {
         // Verify the callback property can be set
         let engine = AudioEngine()

--- a/Tests/VocaMacTests/ServiceTests.swift
+++ b/Tests/VocaMacTests/ServiceTests.swift
@@ -674,62 +674,79 @@ final class AudioEngineDeviceChangeTests: XCTestCase {
         )
     }
 
-    func testExplicitInputRouteMustBeVerified() {
+    func testConfiguredInputRouteMustMatchTargetAfterReset() {
         XCTAssertTrue(
             AudioEngine.shouldAcceptConfiguredInputRoute(
-                requestedDeviceID: 42,
                 targetDeviceID: 42,
-                deviceIDImmediatelyAfterSet: 42,
                 deviceIDAfterReset: 42
             )
         )
         XCTAssertFalse(
             AudioEngine.shouldAcceptConfiguredInputRoute(
-                requestedDeviceID: 42,
                 targetDeviceID: 42,
-                deviceIDImmediatelyAfterSet: 41,
                 deviceIDAfterReset: 41
             ),
-            "An explicit selection must not silently record from a fallback device"
+            "A route mismatch must not silently record from a fallback device"
         )
-        XCTAssertTrue(
+        XCTAssertFalse(
             AudioEngine.shouldAcceptConfiguredInputRoute(
-                requestedDeviceID: nil,
                 targetDeviceID: 42,
-                deviceIDImmediatelyAfterSet: 41,
-                deviceIDAfterReset: 41
+                deviceIDAfterReset: nil
             ),
-            "System Default may continue on Core Audio's active fallback route"
+            "An unreadable route must fail verification"
         )
     }
 
-    func testDelayedHealthyStartupConfigurationChangeIsIgnored() {
+    func testStartupConfigurationChangeIsIgnoredOnlyForStableConfiguredRoute() {
         XCTAssertTrue(
             AudioEngine.shouldIgnoreConfigurationChange(
-                occurredDuringRecordingPreparation: false,
                 isRecording: true,
                 engineIsRunning: true,
-                elapsedSinceRecordingStart: 0.5
+                elapsedSinceRecordingStart: 0.5,
+                configuredInputDeviceID: 42,
+                currentInputDeviceID: 42
             ),
-            "A delayed startup notification must not tear down a healthy recording"
+            "A delayed startup notification may be ignored when the configured route is still healthy"
         )
         XCTAssertFalse(
             AudioEngine.shouldIgnoreConfigurationChange(
-                occurredDuringRecordingPreparation: false,
+                isRecording: true,
+                engineIsRunning: true,
+                elapsedSinceRecordingStart: 0.5,
+                configuredInputDeviceID: 42,
+                currentInputDeviceID: 41
+            ),
+            "A live route change must interrupt recording even during startup"
+        )
+        XCTAssertFalse(
+            AudioEngine.shouldIgnoreConfigurationChange(
                 isRecording: true,
                 engineIsRunning: false,
-                elapsedSinceRecordingStart: 0.5
+                elapsedSinceRecordingStart: 0.5,
+                configuredInputDeviceID: 42,
+                currentInputDeviceID: 42
             ),
             "A stopped engine still requires route-change recovery"
         )
         XCTAssertFalse(
             AudioEngine.shouldIgnoreConfigurationChange(
-                occurredDuringRecordingPreparation: false,
                 isRecording: true,
                 engineIsRunning: true,
-                elapsedSinceRecordingStart: 1.01
+                elapsedSinceRecordingStart: 1.01,
+                configuredInputDeviceID: 42,
+                currentInputDeviceID: 42
             ),
             "Live route changes after startup must still interrupt recording"
+        )
+        XCTAssertFalse(
+            AudioEngine.shouldIgnoreConfigurationChange(
+                isRecording: true,
+                engineIsRunning: true,
+                elapsedSinceRecordingStart: 0.5,
+                configuredInputDeviceID: nil,
+                currentInputDeviceID: nil
+            ),
+            "A notification cannot be ignored when the configured route is unknown"
         )
     }
 


### PR DESCRIPTION
## Summary

- rebuild the AVAudioEngine input graph after an intentional Core Audio device switch
- verify the requested `CurrentDevice` before installing the input tap
- restore System Default correctly when a warm engine was previously pinned to another microphone
- force-reset and report both empty and all-zero captures instead of failing silently

## Root cause

VocaMac set `kAudioOutputUnitProperty_CurrentDevice` and immediately queried the input format, installed a tap, and started the engine. Switching to a microphone other than the macOS default can asynchronously reconfigure and uninitialize AVAudioEngine while its existing connections retain their previous formats. The one-second startup configuration-change suppression could then leave the app in a recording state with a stale tap and no incoming samples.

This change scopes startup notification handling to the active preparation phase, waits briefly for an intentional route change, resets the graph, verifies the selected device again, and only then reads the format and installs the tap.

Apple references:

- https://developer.apple.com/documentation/foundation/nsnotification/name-swift.struct/avaudioengineconfigurationchange
- https://developer.apple.com/library/archive/technotes/tn2091/_index.html

## Validation

- `swift test`: 227 passed, 1 skipped, 0 failures
- `git diff --check`: clean
- hardware confirmation with the reporter's non-default microphone is pending a CI-built DMG