### PR TITLE
docs: add Cursor Cloud specific instructions for Linux VM setup

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -227,3 +227,14 @@ Keep dependencies minimal. This app values being lightweight and self-contained.
 3. **Browser caches SVG/PNG aggressively** — When testing website changes, always hard refresh (`Cmd+Shift+R`)
 4. **Accessibility permission resets on rebuild** — Expected with ad-hoc signing; release builds are Developer ID signed so permissions persist
 5. **WhisperKit model download** — First run requires internet to download the whisper model; all subsequent runs are offline
+
+---
+
+## Cursor Cloud specific instructions
+
+Cloud agents run on a **Linux x86_64** VM. This constrains what is runnable:
+
+- **The Swift macOS app (`Sources/VocaMac/`) cannot be built or run here.** It depends on macOS-only frameworks (AppKit, CoreML, AVFoundation) and WhisperKit, targets `arm64` Apple Silicon, and there is no Swift toolchain on the VM. `make build/install/run` and `swift build/test` only work on macOS — CI runs them on `macos-15` (`.github/workflows/ci.yml`). For app changes, rely on that macOS CI job rather than trying to build locally.
+- **The runnable component on Linux is the website in `web/`.** Note: the "Website" section above is outdated — the site is a **Hugo** project (extended edition), not hand-written static HTML, and there is no `python3 -m http.server` workflow. Build with `cd web && hugo --minify` (output in `web/public/`); run the dev server with `cd web && hugo server`. Both CI (`build-website`) and deploy (`deploy-website.yml`) use `hugo --minify` with the extended edition.
+- **Hugo extended is required** (the site uses features that need the extended build). The startup update script installs it if missing. If `hugo version` doesn't report `+extended`, reinstall the extended edition.
+- Content lives in `web/content/` (Markdown) and templates in `web/layouts/`. Adding a feature page means adding a Markdown file under `web/content/features/`.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up the Cloud Agent development environment for this repo and documents what is runnable on the Linux VM.

VocaMac has two components:
- **Swift macOS app** (`Sources/VocaMac/`) — macOS-only (AppKit, CoreML, AVFoundation, WhisperKit, arm64). It **cannot be built or run on the Linux Cloud VM**; that path is covered by macOS CI (`macos-15`).
- **Hugo website** (`web/`) — the component that builds and runs on Linux. This is what I set up and demonstrated.

## Changes

- Added a `## Cursor Cloud specific instructions` section to `AGENTS.md` documenting:
  - Why the Swift app can't run on the Linux VM (rely on macOS CI instead).
  - That `web/` is a **Hugo (extended)** project — correcting the outdated "pure HTML / python http.server" note — with `hugo --minify` to build and `hugo server` to run.
  - Hugo extended is required and is installed by the startup update script if missing.

## Environment setup

- Installed **Hugo extended v0.148.2** (matching CI's extended requirement).
- Update script (guarded/idempotent) installs Hugo extended only if missing.

## Verification

- `cd web && hugo --minify` builds successfully (22 pages).
- `hugo server` serves the site (HTTP 200); homepage, `/features/`, and feature detail pages all render.
- Interactive "Quick Install" CTA expands to show brew install commands.

[vocamac_website_hugo_dev_server_demo.mp4](https://cursor.com/agents/bc-20d6180b-1f08-46f8-85ef-a741cf5f8a5f/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fvocamac_website_hugo_dev_server_demo.mp4)

[Homepage](https://cursor.com/agents/bc-20d6180b-1f08-46f8-85ef-a741cf5f8a5f/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fwebsite_homepage.webp)
[Quick Install expanded](https://cursor.com/agents/bc-20d6180b-1f08-46f8-85ef-a741cf5f8a5f/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fwebsite_quick_install_expanded.webp)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-20d6180b-1f08-46f8-85ef-a741cf5f8a5f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-20d6180b-1f08-46f8-85ef-a741cf5f8a5f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

