### PR TITLE
chore: bump version to 0.7.2

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -8,8 +8,8 @@
 # 3. Code signs — Developer ID if CODE_SIGN_IDENTITY is set, ad-hoc otherwise
 #
 # Environment variables:
-#   APP_VERSION         — Version string to embed in Info.plist. Defaults to 0.7.1.
-#                         Set by CI for nightly builds (e.g., 0.7.1-nightly.20260512+abc1234).
+#   APP_VERSION         — Version string to embed in Info.plist. Defaults to 0.7.2.
+#                         Set by CI for nightly builds (e.g., 0.7.2-nightly.20260512+abc1234).
 #   CODE_SIGN_IDENTITY  — Signing identity to use. Defaults to auto-detect
 #                         Developer ID Application in the login keychain.
 #                         Set to "-" to force ad-hoc signing.
@@ -29,7 +29,7 @@ BUNDLE_ID="com.vocamac.app"
 APP_NAME="VocaMac"
 APP_DIR="${APP_NAME}.app"
 ENTITLEMENTS="VocaMac.entitlements"
-APP_VERSION="${APP_VERSION:-0.7.1}"
+APP_VERSION="${APP_VERSION:-0.7.2}"
 
 # Resolve signing identity:
 # 1. Use CODE_SIGN_IDENTITY env var if set

--- a/web/layouts/index.html
+++ b/web/layouts/index.html
@@ -39,7 +39,7 @@
             "Open source (AGPL-3.0 license)"
         ],
         "screenshot": "https://vocamac.com/og-image.png",
-        "softwareVersion": "0.7.1",
+        "softwareVersion": "0.7.2",
         "softwareRequirements": "macOS 13 (Ventura) or later, Apple Silicon (M1 or later), 8 GB RAM minimum"
     }
     </script>
@@ -52,7 +52,7 @@
             <div class="hero__content">
                 <div class="hero__badges">
                     <span class="badge badge--beta">BETA RELEASE</span>
-                    <span class="badge badge--outline" id="version-badge">v0.7.1</span>
+                    <span class="badge badge--outline" id="version-badge">v0.7.2</span>
                 </div>
                 <h1 class="hero__headline">
                     Your Voice,<br>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Prepares the **v0.7.2** patch release for selected-microphone route reliability.

### Changes since v0.7.1

| PR | Type | Summary |
|---|---|---|
| #187 | fix | Stabilize selected audio input routes: wait for intentional Core Audio device switches, rebuild the input graph, verify `CurrentDevice`, and recover System Default / silent captures cleanly |

### Files updated

- `scripts/build.sh` — default app and Info.plist version is now 0.7.2
- `web/layouts/index.html` — JSON-LD and hero badge versions are now 0.7.2

### Release readiness

- Latest stable: **v0.7.1** (2026-07-17)
- Diff on `main` since tag: **1 commit** (`#187` only) — patch-sized, no features
- CI on latest `main`: green (CI push + subsequent nightlies)
- Open PRs (`#177` draft local LLM, `#150` snippets, `#143` SwiftLint) are unrelated and do **not** need to land for this patch

### Release plan after merge

- Tag `v0.7.2` and push the tag; `release.yml` will build, sign, notarize, and create the draft GitHub Release
- Paste the polished out-of-tree release notes from `/tmp/RELEASE_NOTES_v0.7.2.md` into the draft and review artifacts
- Publish the release after final review, then remove the local scratch notes

### Draft release notes (out-of-tree)

```markdown
## VocaMac 0.7.2 🎙️

Hold the hotkey, speak, get your words back — now with a more reliable selected mic.

If recording looked active but captured nothing after switching to a non-default microphone (or after the warm engine was pinned to another input), this patch is for you. VocaMac waits for intentional Core Audio route changes to settle, rebuilds the input graph, and verifies the requested device before installing the tap.

## 🎙️ Dictation reliability

- **Selected microphones stay on the right route.** Switching away from the macOS default input no longer leaves a stale tap with no samples. The engine waits briefly for the route change, resets the graph, and confirms `CurrentDevice` before recording starts. (#187)
- **System Default recovers correctly.** When a warm engine was previously pinned to another microphone, restoring System Default reapplies the correct input instead of silently staying on the old device. (#187)
- **Clearer silent-capture guidance.** Empty or all-zero captures force-reset the route and point you at Settings → Audio to check the selected mic. (#187)
```

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6d797334-6d0d-4381-b0f8-b392ca3f268d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6d797334-6d0d-4381-b0f8-b392ca3f268d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

