### PR TITLE
fix: harden multi-engine follow-ups after #191

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,18 +58,8 @@ jobs:
           restore-keys: |
             spm-${{ runner.os }}-
 
-      # SpeechAnalyzer / Apple Speech needs the Xcode 26 SDK (Swift 6.2+).
-      # macos-15 defaults to Xcode 16.4, which compiles that engine out.
       - name: Select Xcode 26
-        run: |
-          XCODE=$(ls -d /Applications/Xcode_26*.app 2>/dev/null | sort -V | tail -1)
-          if [ -z "$XCODE" ]; then
-            echo "Xcode 26 is required to build Apple Speech support" >&2
-            ls /Applications/Xcode*.app || true
-            exit 1
-          fi
-          sudo xcode-select -s "$XCODE"
-          xcodebuild -version
+        run: ./scripts/select-xcode-26.sh
 
       - name: Build (Debug)
         run: swift build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,6 +58,19 @@ jobs:
           restore-keys: |
             spm-${{ runner.os }}-
 
+      # SpeechAnalyzer / Apple Speech needs the Xcode 26 SDK (Swift 6.2+).
+      # macos-15 defaults to Xcode 16.4, which compiles that engine out.
+      - name: Select Xcode 26
+        run: |
+          XCODE=$(ls -d /Applications/Xcode_26*.app 2>/dev/null | sort -V | tail -1)
+          if [ -z "$XCODE" ]; then
+            echo "Xcode 26 is required to build Apple Speech support" >&2
+            ls /Applications/Xcode*.app || true
+            exit 1
+          fi
+          sudo xcode-select -s "$XCODE"
+          xcodebuild -version
+
       - name: Build (Debug)
         run: swift build
 

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -158,18 +158,8 @@ jobs:
           restore-keys: |
             spm-${{ runner.os }}-
 
-      # SpeechAnalyzer / Apple Speech needs the Xcode 26 SDK (Swift 6.2+).
-      # macos-15 defaults to Xcode 16.4, which compiles that engine out.
       - name: Select Xcode 26
-        run: |
-          XCODE=$(ls -d /Applications/Xcode_26*.app 2>/dev/null | sort -V | tail -1)
-          if [ -z "$XCODE" ]; then
-            echo "Xcode 26 is required to build Apple Speech support" >&2
-            ls /Applications/Xcode*.app || true
-            exit 1
-          fi
-          sudo xcode-select -s "$XCODE"
-          xcodebuild -version
+        run: ./scripts/select-xcode-26.sh
 
       - name: Run tests
         run: swift test

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -158,6 +158,19 @@ jobs:
           restore-keys: |
             spm-${{ runner.os }}-
 
+      # SpeechAnalyzer / Apple Speech needs the Xcode 26 SDK (Swift 6.2+).
+      # macos-15 defaults to Xcode 16.4, which compiles that engine out.
+      - name: Select Xcode 26
+        run: |
+          XCODE=$(ls -d /Applications/Xcode_26*.app 2>/dev/null | sort -V | tail -1)
+          if [ -z "$XCODE" ]; then
+            echo "Xcode 26 is required to build Apple Speech support" >&2
+            ls /Applications/Xcode*.app || true
+            exit 1
+          fi
+          sudo xcode-select -s "$XCODE"
+          xcodebuild -version
+
       - name: Run tests
         run: swift test
 

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -99,6 +99,19 @@ jobs:
           restore-keys: |
             spm-${{ runner.os }}-
 
+      # SpeechAnalyzer / Apple Speech needs the Xcode 26 SDK (Swift 6.2+).
+      # macos-15 defaults to Xcode 16.4, which compiles that engine out.
+      - name: Select Xcode 26
+        run: |
+          XCODE=$(ls -d /Applications/Xcode_26*.app 2>/dev/null | sort -V | tail -1)
+          if [ -z "$XCODE" ]; then
+            echo "Xcode 26 is required to build Apple Speech support" >&2
+            ls /Applications/Xcode*.app || true
+            exit 1
+          fi
+          sudo xcode-select -s "$XCODE"
+          xcodebuild -version
+
       # ── Test ──────────────────────────────────────────────────────────────
       - name: Run tests
         run: swift test

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -99,18 +99,8 @@ jobs:
           restore-keys: |
             spm-${{ runner.os }}-
 
-      # SpeechAnalyzer / Apple Speech needs the Xcode 26 SDK (Swift 6.2+).
-      # macos-15 defaults to Xcode 16.4, which compiles that engine out.
       - name: Select Xcode 26
-        run: |
-          XCODE=$(ls -d /Applications/Xcode_26*.app 2>/dev/null | sort -V | tail -1)
-          if [ -z "$XCODE" ]; then
-            echo "Xcode 26 is required to build Apple Speech support" >&2
-            ls /Applications/Xcode*.app || true
-            exit 1
-          fi
-          sudo xcode-select -s "$XCODE"
-          xcodebuild -version
+        run: ./scripts/select-xcode-26.sh
 
       # ── Test ──────────────────────────────────────────────────────────────
       - name: Run tests

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,6 +22,19 @@ jobs:
         id: version
         run: echo "VERSION=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
 
+      # SpeechAnalyzer / Apple Speech needs the Xcode 26 SDK (Swift 6.2+).
+      # macos-15 defaults to Xcode 16.4, which compiles that engine out.
+      - name: Select Xcode 26
+        run: |
+          XCODE=$(ls -d /Applications/Xcode_26*.app 2>/dev/null | sort -V | tail -1)
+          if [ -z "$XCODE" ]; then
+            echo "Xcode 26 is required to build Apple Speech support" >&2
+            ls /Applications/Xcode*.app || true
+            exit 1
+          fi
+          sudo xcode-select -s "$XCODE"
+          xcodebuild -version
+
       - name: Initialize Xcode tools
         run: sudo xcodebuild -runFirstLaunch
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,18 +22,8 @@ jobs:
         id: version
         run: echo "VERSION=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
 
-      # SpeechAnalyzer / Apple Speech needs the Xcode 26 SDK (Swift 6.2+).
-      # macos-15 defaults to Xcode 16.4, which compiles that engine out.
       - name: Select Xcode 26
-        run: |
-          XCODE=$(ls -d /Applications/Xcode_26*.app 2>/dev/null | sort -V | tail -1)
-          if [ -z "$XCODE" ]; then
-            echo "Xcode 26 is required to build Apple Speech support" >&2
-            ls /Applications/Xcode*.app || true
-            exit 1
-          fi
-          sudo xcode-select -s "$XCODE"
-          xcodebuild -version
+        run: ./scripts/select-xcode-26.sh
 
       - name: Initialize Xcode tools
         run: sudo xcodebuild -runFirstLaunch

--- a/README.md
+++ b/README.md
@@ -278,9 +278,9 @@ OpenAI Whisper models via WhisperKit's CoreML format. The only engine that suppo
 | **Medium** | 769M | ~2.5 GB | ⚡⚡ | Excellent | 24GB+ for high accuracy |
 | **Large v3** | 1550M | ~4.8 GB | ⚡ | Best | Maximum accuracy |
 
-### Apple Speech — no download (macOS 26+)
+### Apple Speech — managed by macOS (macOS 26+)
 
-Apple's on-device SpeechAnalyzer engine. Assets are managed by macOS, so there is nothing to download and nothing stored in VocaMac's model folder. Covers roughly 30 locales.
+Apple's on-device SpeechAnalyzer engine. Assets are managed by macOS (language packs may download on first use) and are not stored in VocaMac's model folder. Covers roughly 30 locales.
 
 ### Specialized (ONNX) — niche needs
 

--- a/Sources/VocaMac/Models/AppState.swift
+++ b/Sources/VocaMac/Models/AppState.swift
@@ -133,6 +133,11 @@ final class AppState: ObservableObject {
     private var cancellables = Set<AnyCancellable>()
     private var hasStarted = false
 
+    /// Bumped at the start of every `loadModel` call. Failure restores and
+    /// success UI updates only apply when the generation is still current, so
+    /// a stale failure cannot undo a newer successful load.
+    private var loadGeneration: UInt64 = 0
+
     /// AudioEngine serializes its own lifecycle internally; this wrapper makes
     /// the intentional background handoff explicit for Dispatch's @Sendable API.
     private struct AudioEngineWorker: @unchecked Sendable {
@@ -713,6 +718,9 @@ final class AppState: ObservableObject {
     // MARK: - Model Management
 
     func loadModel(_ size: ModelSize? = nil) async {
+        loadGeneration += 1
+        let generation = loadGeneration
+
         let previousLoadedModelName = whisperService.loadedModelName
         let previousModelSize = currentModel?.size
             ?? previousLoadedModelName.flatMap { modelManager.modelSize(from: $0) }
@@ -797,6 +805,12 @@ final class AppState: ObservableObject {
                 VocaLogger.info(.appState, "Auto-selected model resolved to: \(resolvedSize.displayName) (from '\(whisperService.loadedModelName ?? "unknown")')")
             }
 
+            // A newer loadModel started while we were waiting; leave UI to it.
+            guard generation == loadGeneration else {
+                clearLoadingFlag(for: targetSize)
+                return
+            }
+
             // Persist the resolved model as the user's preference
             selectedModelSize = resolvedSize.rawValue
 
@@ -815,6 +829,12 @@ final class AppState: ObservableObject {
 
             VocaLogger.info(.appState, "Model ready: \(resolvedSize.displayName)")
         } catch {
+            // A newer load superseded this one; do not restore over it.
+            guard generation == loadGeneration else {
+                clearLoadingFlag(for: targetSize)
+                return
+            }
+
             // Clear loading state on error for all models (covers auto-select case)
             for i in availableModels.indices {
                 availableModels[i].isLoading = false
@@ -834,6 +854,16 @@ final class AppState: ObservableObject {
                 originalFailureMessage: failureMessage
             )
         }
+    }
+
+    /// Clear the loading spinner on a superseded load without touching others.
+    private func clearLoadingFlag(for size: ModelSize?) {
+        guard let size,
+              let idx = availableModels.firstIndex(where: { $0.size == size }) else {
+            return
+        }
+        availableModels[idx].isLoading = false
+        availableModels[idx].loadingStatus = "Loading…"
     }
 
     /// Reload the active model when the transcription language changes and

--- a/Sources/VocaMac/Models/TranscriptionEngine.swift
+++ b/Sources/VocaMac/Models/TranscriptionEngine.swift
@@ -48,7 +48,7 @@ enum TranscriptionEngine: String, CaseIterable, Codable, Identifiable {
         case .whisperKit:
             return "OpenAI's Whisper models — widest language coverage (100+ languages) and translation to English."
         case .appleSpeech:
-            return "Built into macOS — no model to manage, though the system may download language assets the first time you use one."
+            return "Managed by macOS — no model files in VocaMac's folder, though the system may download language assets the first time you use one."
         case .sherpaOnnx:
             return "Community models for specific needs — tiny English models for low-RAM Macs, plus Chinese, Russian, and European language specialists. Runs on CPU."
         }

--- a/Sources/VocaMac/Services/FileDownloader.swift
+++ b/Sources/VocaMac/Services/FileDownloader.swift
@@ -73,6 +73,9 @@ final class FileDownloader: NSObject, URLSessionDownloadDelegate, @unchecked Sen
         stateLock.lock()
         if isCancelled {
             stateLock.unlock()
+            // Cancel the suspended task; finishTasksAndInvalidate alone would
+            // wait for it rather than drop it.
+            task.cancel()
             continuation.resume(throwing: CancellationError())
             return
         }

--- a/Sources/VocaMac/Services/LoadSerializer.swift
+++ b/Sources/VocaMac/Services/LoadSerializer.swift
@@ -7,8 +7,10 @@ import Foundation
 
 /// Serializes async work so a second request waits for the first to finish.
 ///
-/// Model loading suspends at several points, so two loads started close
-/// together would otherwise interleave and leave two models resident.
+/// Model loading and transcription both touch the active engine. Without a
+/// shared queue, a hotkey mid-switch can decode against an engine that load
+/// just unloaded, and two overlapping loads can leave more than one model
+/// resident. Both paths share this actor so only one runs at a time.
 actor LoadSerializer {
 
     /// The most recently queued operation, used to chain the next one behind it.
@@ -18,14 +20,15 @@ actor LoadSerializer {
     ///
     /// A failure in one operation does not prevent later ones from running;
     /// the error is delivered to whoever queued that operation.
-    func run(_ operation: @escaping @Sendable () async throws -> Void) async throws {
+    func run<T: Sendable>(
+        _ operation: @escaping @Sendable () async throws -> T
+    ) async throws -> T {
         let previous = tail
 
-        let task = Task<Result<Void, Error>, Never> {
+        let task = Task<Result<T, Error>, Never> {
             await previous?.value
             do {
-                try await operation()
-                return .success(())
+                return .success(try await operation())
             } catch {
                 return .failure(error)
             }
@@ -36,8 +39,8 @@ actor LoadSerializer {
         tail = Task { _ = await task.value }
 
         switch await task.value {
-        case .success:
-            return
+        case .success(let value):
+            return value
         case .failure(let error):
             throw error
         }

--- a/Sources/VocaMac/Services/ModelManager.swift
+++ b/Sources/VocaMac/Services/ModelManager.swift
@@ -569,10 +569,21 @@ final class ModelManager {
 
             // Written last: this marker is what makes the model count as
             // installed, so a crash before this point leaves it re-downloadable.
-            try SherpaService.markModelComplete(for: spec)
-
-            guard SherpaService.modelFilesExist(for: spec) else {
-                throw ModelManagerError.missingModelDirectory(destination.path)
+            // If marking or validation fails, restore the displaced install so
+            // the user keeps a working model instead of a half-finished one.
+            do {
+                try SherpaService.markModelComplete(for: spec)
+                guard SherpaService.modelFilesExist(for: spec) else {
+                    throw ModelManagerError.missingModelDirectory(destination.path)
+                }
+            } catch {
+                if let displaced {
+                    try? fileManager.removeItem(at: destination)
+                    try? fileManager.moveItem(at: displaced, to: destination)
+                } else {
+                    try? fileManager.removeItem(at: destination)
+                }
+                throw error
             }
 
             onProgress(1.0)

--- a/Sources/VocaMac/Services/SherpaService.swift
+++ b/Sources/VocaMac/Services/SherpaService.swift
@@ -298,28 +298,16 @@ final class SherpaService: @unchecked Sendable {
     }
 
     /// Join segment transcripts. CJK scripts do not use spaces between
-    /// phrases; Western languages do.
+    /// phrases; Western languages do. SenseVoice tags look like `zh` / `ja`
+    /// / `yue` / `ko` (sometimes wrapped in `<|…|>`).
     static func joinTranscriptPieces(_ pieces: [String], language: String) -> String {
-        let separator = usesIdeographicSpacing(language) ? "" : " "
-        return pieces.joined(separator: separator)
-    }
-
-    /// Whether transcript pieces should be concatenated without spaces.
-    static func usesIdeographicSpacing(_ language: String) -> Bool {
         let lang = language.lowercased()
             .replacingOccurrences(of: "<|", with: "")
             .replacingOccurrences(of: "|>", with: "")
             .trimmingCharacters(in: .whitespacesAndNewlines)
-        // SenseVoice tags: zh / ja / yue / ko. Also accept common names.
-        if lang.hasPrefix("zh") || lang.hasPrefix("ja") || lang.hasPrefix("yue") || lang.hasPrefix("ko") {
-            return true
-        }
-        switch lang {
-        case "chinese", "japanese", "cantonese", "korean":
-            return true
-        default:
-            return false
-        }
+        let cjk = lang.hasPrefix("zh") || lang.hasPrefix("ja")
+            || lang.hasPrefix("yue") || lang.hasPrefix("ko")
+        return pieces.joined(separator: cjk ? "" : " ")
     }
 
     /// Run one decode against the active recognizer. Returns nil if no model

--- a/Sources/VocaMac/Services/SherpaService.swift
+++ b/Sources/VocaMac/Services/SherpaService.swift
@@ -265,7 +265,12 @@ final class SherpaService: @unchecked Sendable {
                     if !piece.isEmpty { pieces.append(piece) }
                     if detected.isEmpty { detected = result.lang }
                 }
-                continuation.resume(returning: (pieces.joined(separator: " "), detected))
+                // Prefer the model's detected language; fall back to the caller's
+                // preference so CJK SenseVoice output is not space-joined.
+                let joinLanguage = detected.isEmpty ? (language ?? "") : detected
+                continuation.resume(
+                    returning: (Self.joinTranscriptPieces(pieces, language: joinLanguage), detected)
+                )
             }
         }
 
@@ -290,6 +295,31 @@ final class SherpaService: @unchecked Sendable {
             audioLengthSeconds: audioLengthSeconds,
             modelUsed: size
         )
+    }
+
+    /// Join segment transcripts. CJK scripts do not use spaces between
+    /// phrases; Western languages do.
+    static func joinTranscriptPieces(_ pieces: [String], language: String) -> String {
+        let separator = usesIdeographicSpacing(language) ? "" : " "
+        return pieces.joined(separator: separator)
+    }
+
+    /// Whether transcript pieces should be concatenated without spaces.
+    static func usesIdeographicSpacing(_ language: String) -> Bool {
+        let lang = language.lowercased()
+            .replacingOccurrences(of: "<|", with: "")
+            .replacingOccurrences(of: "|>", with: "")
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        // SenseVoice tags: zh / ja / yue / ko. Also accept common names.
+        if lang.hasPrefix("zh") || lang.hasPrefix("ja") || lang.hasPrefix("yue") || lang.hasPrefix("ko") {
+            return true
+        }
+        switch lang {
+        case "chinese", "japanese", "cantonese", "korean":
+            return true
+        default:
+            return false
+        }
     }
 
     /// Run one decode against the active recognizer. Returns nil if no model

--- a/Sources/VocaMac/Services/TranscriptionRouter.swift
+++ b/Sources/VocaMac/Services/TranscriptionRouter.swift
@@ -129,35 +129,21 @@ extension TranscriptionRouter: SpeechTranscribing {
         vocabulary: String
     ) async throws -> VocaTranscription {
         try await operationSerializer.run { [self] in
-            try await performTranscribe(
-                audioData: audioData,
-                language: language,
-                translate: translate,
-                vocabulary: vocabulary
-            )
-        }
-    }
-
-    private func performTranscribe(
-        audioData: [Float],
-        language: String?,
-        translate: Bool,
-        vocabulary: String
-    ) async throws -> VocaTranscription {
-        switch activeEngine {
-        case .whisperKit:
-            return try await whisper.transcribe(
-                audioData: audioData,
-                language: language,
-                translate: translate,
-                vocabulary: vocabulary
-            )
-        case .parakeet:
-            return try await parakeet.transcribe(audioData: audioData, language: language)
-        case .appleSpeech:
-            return try await appleSpeech.transcribe(audioData: audioData, language: language)
-        case .sherpaOnnx:
-            return try await sherpa.transcribe(audioData: audioData, language: language)
+            switch activeEngine {
+            case .whisperKit:
+                return try await whisper.transcribe(
+                    audioData: audioData,
+                    language: language,
+                    translate: translate,
+                    vocabulary: vocabulary
+                )
+            case .parakeet:
+                return try await parakeet.transcribe(audioData: audioData, language: language)
+            case .appleSpeech:
+                return try await appleSpeech.transcribe(audioData: audioData, language: language)
+            case .sherpaOnnx:
+                return try await sherpa.transcribe(audioData: audioData, language: language)
+            }
         }
     }
 }

--- a/Sources/VocaMac/Services/TranscriptionRouter.swift
+++ b/Sources/VocaMac/Services/TranscriptionRouter.swift
@@ -19,8 +19,9 @@ final class TranscriptionRouter: @unchecked Sendable {
     /// Engine that owns the currently loaded model.
     private(set) var activeEngine: TranscriptionEngine = .whisperKit
 
-    /// Runs model loads one at a time.
-    private let loadSerializer = LoadSerializer()
+    /// Shared queue for loads and transcriptions so a hotkey cannot decode
+    /// against an engine that a concurrent load just unloaded.
+    private let operationSerializer = LoadSerializer()
 
     // MARK: - Engine Resolution
 
@@ -62,16 +63,16 @@ final class TranscriptionRouter: @unchecked Sendable {
 
 extension TranscriptionRouter: SpeechTranscribing {
 
-    /// Load a model, waiting for any load already in flight to finish first.
+    /// Load a model, waiting for any load or transcription already in flight.
     ///
-    /// Loading suspends, so without serialization two loads — easy to trigger
+    /// Loading suspends, so without serialization two loads (easy to trigger
     /// by switching models or changing the language while one is still
-    /// running — can overlap. Both would then finish, the later one setting
-    /// `activeEngine`, while the other engine's model stayed resident in
-    /// memory. Running them one at a time keeps `activeEngine` and the
-    /// engine that actually holds a model in agreement.
+    /// running) can overlap. Both would then finish, the later one setting
+    /// `activeEngine`, while the other engine's model stayed resident.
+    /// Transcription shares the same queue so a hotkey mid-switch cannot
+    /// decode against an unloaded engine.
     func _loadModel(name: String?, folder: URL?, onPhaseChange: ((String) -> Void)?) async throws {
-        try await loadSerializer.run { [self] in
+        try await operationSerializer.run { [self] in
             try await performLoad(name: name, folder: folder, onPhaseChange: onPhaseChange)
         }
     }
@@ -122,6 +123,22 @@ extension TranscriptionRouter: SpeechTranscribing {
     }
 
     func transcribe(
+        audioData: [Float],
+        language: String?,
+        translate: Bool,
+        vocabulary: String
+    ) async throws -> VocaTranscription {
+        try await operationSerializer.run { [self] in
+            try await performTranscribe(
+                audioData: audioData,
+                language: language,
+                translate: translate,
+                vocabulary: vocabulary
+            )
+        }
+    }
+
+    private func performTranscribe(
         audioData: [Float],
         language: String?,
         translate: Bool,

--- a/Sources/VocaMac/Views/SettingsView.swift
+++ b/Sources/VocaMac/Views/SettingsView.swift
@@ -431,7 +431,7 @@ struct ModelSettingsTab: View {
                 HStack {
                     Image(systemName: "info.circle")
                         .foregroundStyle(.secondary)
-                    Text("Models are downloaded from HuggingFace and cached locally. Larger models produce better results but are slower and use more memory. Apple Speech uses assets built into macOS.")
+                    Text("Models are downloaded from HuggingFace and cached locally. Larger models produce better results but are slower and use more memory. Apple Speech assets are managed by macOS and may download language packs on first use.")
                         .font(.caption)
                         .foregroundStyle(.secondary)
                 }

--- a/Tests/VocaMacTests/LoadSerializerTests.swift
+++ b/Tests/VocaMacTests/LoadSerializerTests.swift
@@ -1,0 +1,59 @@
+// LoadSerializerTests.swift
+// VocaMac Tests
+//
+// Verifies that queued operations run one at a time and preserve order.
+
+import XCTest
+
+@testable import VocaMac
+
+final class LoadSerializerTests: XCTestCase {
+
+    func testOperationsRunSeriallyInOrder() async throws {
+        let serializer = LoadSerializer()
+        let lock = NSLock()
+        var events: [String] = []
+
+        func append(_ event: String) {
+            lock.lock()
+            events.append(event)
+            lock.unlock()
+        }
+
+        async let first: Void = serializer.run {
+            append("a-start")
+            try await Task.sleep(nanoseconds: 50_000_000)
+            append("a-end")
+        }
+
+        // Give the first operation a moment to claim the queue.
+        try await Task.sleep(nanoseconds: 5_000_000)
+
+        async let second: Int = serializer.run {
+            append("b-start")
+            return 42
+        }
+
+        try await first
+        let value = try await second
+
+        XCTAssertEqual(value, 42)
+        XCTAssertEqual(events, ["a-start", "a-end", "b-start"])
+    }
+
+    func testFailureDoesNotBlockLaterOperations() async throws {
+        let serializer = LoadSerializer()
+
+        do {
+            try await serializer.run {
+                throw NSError(domain: "LoadSerializerTests", code: 1)
+            }
+            XCTFail("Expected the first operation to throw")
+        } catch {
+            // Expected.
+        }
+
+        let value = try await serializer.run { 7 }
+        XCTAssertEqual(value, 7)
+    }
+}

--- a/Tests/VocaMacTests/ModelTests.swift
+++ b/Tests/VocaMacTests/ModelTests.swift
@@ -165,6 +165,13 @@ final class ModelSizeTests: XCTestCase {
         XCTAssertFalse(TranscriptionEngine.parakeet.supportsTranslation)
         XCTAssertFalse(TranscriptionEngine.appleSpeech.supportsTranslation)
     }
+
+    func testAppleSpeechEngineSummaryMentionsManagedAssets() {
+        let summary = TranscriptionEngine.appleSpeech.summary.lowercased()
+        XCTAssertTrue(summary.contains("managed by macos"))
+        XCTAssertTrue(summary.contains("download"))
+        XCTAssertFalse(summary.contains("built into"))
+    }
 }
 
 // MARK: - TranscriptionRouter Tests

--- a/Tests/VocaMacTests/ModelTests.swift
+++ b/Tests/VocaMacTests/ModelTests.swift
@@ -165,13 +165,6 @@ final class ModelSizeTests: XCTestCase {
         XCTAssertFalse(TranscriptionEngine.parakeet.supportsTranslation)
         XCTAssertFalse(TranscriptionEngine.appleSpeech.supportsTranslation)
     }
-
-    func testAppleSpeechEngineSummaryMentionsManagedAssets() {
-        let summary = TranscriptionEngine.appleSpeech.summary.lowercased()
-        XCTAssertTrue(summary.contains("managed by macos"))
-        XCTAssertTrue(summary.contains("download"))
-        XCTAssertFalse(summary.contains("built into"))
-    }
 }
 
 // MARK: - TranscriptionRouter Tests

--- a/Tests/VocaMacTests/SherpaServiceTests.swift
+++ b/Tests/VocaMacTests/SherpaServiceTests.swift
@@ -119,4 +119,33 @@ final class SherpaServiceTests: XCTestCase {
         XCTAssertTrue(router.isModelLoaded)
         XCTAssertEqual(router.loadedModelName, model.rawValue)
     }
+
+    func testJoinTranscriptPiecesInsertsSpacesForWesternLanguages() {
+        let joined = SherpaService.joinTranscriptPieces(["hello", "world"], language: "en")
+        XCTAssertEqual(joined, "hello world")
+    }
+
+    func testJoinTranscriptPiecesOmitsSpacesForCJK() {
+        XCTAssertEqual(
+            SherpaService.joinTranscriptPieces(["你好", "世界"], language: "zh"),
+            "你好世界"
+        )
+        XCTAssertEqual(
+            SherpaService.joinTranscriptPieces(["こんにちは", "世界"], language: "ja"),
+            "こんにちは世界"
+        )
+        XCTAssertEqual(
+            SherpaService.joinTranscriptPieces(["你好", "世界"], language: "<|yue|>"),
+            "你好世界"
+        )
+    }
+
+    func testIdeographicSpacingRecognizesCommonLanguageTags() {
+        XCTAssertTrue(SherpaService.usesIdeographicSpacing("zh-CN"))
+        XCTAssertTrue(SherpaService.usesIdeographicSpacing("japanese"))
+        XCTAssertTrue(SherpaService.usesIdeographicSpacing("ko"))
+        XCTAssertFalse(SherpaService.usesIdeographicSpacing("en"))
+        XCTAssertFalse(SherpaService.usesIdeographicSpacing("ru"))
+        XCTAssertFalse(SherpaService.usesIdeographicSpacing(""))
+    }
 }

--- a/Tests/VocaMacTests/SherpaServiceTests.swift
+++ b/Tests/VocaMacTests/SherpaServiceTests.swift
@@ -138,14 +138,9 @@ final class SherpaServiceTests: XCTestCase {
             SherpaService.joinTranscriptPieces(["你好", "世界"], language: "<|yue|>"),
             "你好世界"
         )
-    }
-
-    func testIdeographicSpacingRecognizesCommonLanguageTags() {
-        XCTAssertTrue(SherpaService.usesIdeographicSpacing("zh-CN"))
-        XCTAssertTrue(SherpaService.usesIdeographicSpacing("japanese"))
-        XCTAssertTrue(SherpaService.usesIdeographicSpacing("ko"))
-        XCTAssertFalse(SherpaService.usesIdeographicSpacing("en"))
-        XCTAssertFalse(SherpaService.usesIdeographicSpacing("ru"))
-        XCTAssertFalse(SherpaService.usesIdeographicSpacing(""))
+        XCTAssertEqual(
+            SherpaService.joinTranscriptPieces(["안녕", "하세요"], language: "ko-KR"),
+            "안녕하세요"
+        )
     }
 }

--- a/scripts/select-xcode-26.sh
+++ b/scripts/select-xcode-26.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+# Select Xcode 26 so Apple Speech (SpeechAnalyzer, Swift 6.2+) is compiled in.
+# macos-15 runners default to Xcode 16.4, which leaves only the unsupported stub.
+set -euo pipefail
+
+XCODE=$(ls -d /Applications/Xcode_26*.app 2>/dev/null | sort -V | tail -1 || true)
+if [ -z "${XCODE}" ]; then
+  echo "Xcode 26 is required to build Apple Speech support" >&2
+  ls /Applications/Xcode*.app 2>/dev/null || true
+  exit 1
+fi
+
+sudo xcode-select -s "${XCODE}"
+xcodebuild -version


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Follow-up to #191 addressing the remaining review findings.

- **Apple Speech actually ships:** CI, release, nightly, and pr-build run `scripts/select-xcode-26.sh` before building. Default Xcode 16.4 on `macos-15` was compiling the `#if compiler(>=6.2)` path out, so green CI only proved the stub.
- **Load vs transcribe:** `LoadSerializer` is now generic and shared by both load and transcription, so a hotkey mid-switch cannot decode against an engine that load just unloaded.
- **Stale restore:** `AppState.loadModel` bumps a generation token; failure restores and success UI updates only apply when that generation is still current.
- **SenseVoice CJK join:** multi-segment transcripts join without spaces for zh/ja/yue/ko.
- **ONNX install:** if marker write or post-install validation fails after the new dir lands, the displaced previous install is restored.
- **Download cancel:** cancel-before-begin now cancels the suspended `URLSessionDownloadTask`.
- **Copy:** Settings, README, and the Apple Speech engine summary no longer claim "built into" / "no download".

## Ponytail review

After the first push, ran a `/ponytail-review` pass and cut:

- duplicated Xcode 26 shell blocks → one script
- `performTranscribe` wrapper → inline in the serializer closure
- `usesIdeographicSpacing` + English name cases → one `joinTranscriptPieces` helper
- copy-string unit test for the engine summary

## Out of scope

The ONNX 8 MB → 54 MB binary size tradeoff is still a product call (keep / optionalize / drop). No change in this PR.

## Test plan

- [ ] CI green on this branch (Xcode 26 select must succeed on the runner image)
- [ ] On a Mac with Xcode 26: confirm Apple Speech appears in Settings on macOS 26
- [ ] Switch models while holding the hotkey / mid-recording stop: no crash, no silent wrong engine
- [ ] Fail a model load while quickly selecting another: the newer model stays active
- [ ] Long SenseVoice clip: no Western spaces injected between CJK segments
- [ ] Settings / README wording for Apple Speech looks right

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-404ae165-e3bd-478b-92a3-1e5ed293167a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-404ae165-e3bd-478b-92a3-1e5ed293167a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

