### PR TITLE
docs: document Homebrew dual-tap conflict after VocaHQ migration

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,12 @@ brew trust vocahq/vocamac
 brew install --cask vocamac
 ```
 
+> **Still have the old tap?** If you previously used `jatinkrmalik/vocamac`, untap it first or Homebrew will error with `Cask vocamac exists in multiple taps`:
+> ```bash
+> brew untap jatinkrmalik/vocamac
+> brew tap vocahq/vocamac && brew trust vocahq/vocamac && brew install --cask vocamac
+> ```
+
 Homebrew installs VocaMac to `/Applications/VocaMac.app`. Launch it from Spotlight or your Applications folder. Updates are a single command away:
 
 ```bash

--- a/docs/HOMEBREW.md
+++ b/docs/HOMEBREW.md
@@ -31,6 +31,25 @@ After installation, VocaMac appears in `/Applications/VocaMac.app`. Launch it fr
 
 `brew trust vocahq/vocamac` trusts the whole VocaMac tap. This is intentional: the stable and nightly casks conflict with each other, so Homebrew may load both cask definitions while resolving an install.
 
+## Migrating from `jatinkrmalik/vocamac`
+
+The Homebrew tap moved to `vocahq/vocamac` when the project transferred to the VocaHQ GitHub organization. Existing installs keep working via GitHub redirects, but if you still have the old tap **and** the new one, Homebrew sees the same cask in both places:
+
+```text
+Error: Cask vocamac exists in multiple taps:
+  jatinkrmalik/vocamac/vocamac
+  vocahq/vocamac/vocamac
+```
+
+**Fix:** remove the old tap, then use the new one:
+
+```bash
+brew untap jatinkrmalik/vocamac
+brew tap vocahq/vocamac && brew trust vocahq/vocamac && brew install --cask vocamac
+```
+
+If you already have VocaMac installed from Homebrew and only need to clean up the duplicate tap (no reinstall), `brew untap jatinkrmalik/vocamac` is enough — then upgrade with `brew upgrade --cask vocamac`.
+
 ## Nightly Builds
 
 A nightly cask is also available, built daily from the latest `main` branch:
@@ -231,6 +250,19 @@ Homebrew moves the launched app into the configured app directory, usually `/App
 This prevents conflicts between Homebrew's version management and the app's own update mechanism. Always use `brew upgrade --cask vocamac` or `brew upgrade --cask vocamac-nightly` to update a Homebrew-installed copy of VocaMac.
 
 ## Troubleshooting
+
+### Error: Cask vocamac exists in multiple taps
+
+You have both the pre-migration tap (`jatinkrmalik/vocamac`) and the current tap (`vocahq/vocamac`) installed. Homebrew cannot choose which cask definition to use.
+
+**Fix:**
+
+```bash
+brew untap jatinkrmalik/vocamac
+brew tap vocahq/vocamac && brew trust vocahq/vocamac && brew install --cask vocamac
+```
+
+See [Migrating from `jatinkrmalik/vocamac`](#migrating-from-jatinkrmalikvocamac).
 
 ### Cask install fails with "SHA256 mismatch"
 

--- a/docs/HOMEBREW.md
+++ b/docs/HOMEBREW.md
@@ -37,8 +37,8 @@ The Homebrew tap moved to `vocahq/vocamac` when the project transferred to the V
 
 ```text
 Error: Cask vocamac exists in multiple taps:
-  jatinkrmalik/vocamac/vocamac
-  vocahq/vocamac/vocamac
+       * jatinkrmalik/vocamac/vocamac
+       * vocahq/vocamac/vocamac
 ```
 
 **Fix:** remove the old tap, then use the new one:
@@ -48,7 +48,9 @@ brew untap jatinkrmalik/vocamac
 brew tap vocahq/vocamac && brew trust vocahq/vocamac && brew install --cask vocamac
 ```
 
-If you already have VocaMac installed from Homebrew and only need to clean up the duplicate tap (no reinstall), `brew untap jatinkrmalik/vocamac` is enough — then upgrade with `brew upgrade --cask vocamac`.
+Installed apps are untouched. If you already have VocaMac installed from Homebrew and only need to clean up the duplicate tap (no reinstall), `brew untap jatinkrmalik/vocamac` is enough — then upgrade with `brew upgrade --cask vocamac`.
+
+The same recovery steps are documented in the [homebrew-vocamac tap](https://github.com/VocaHQ/homebrew-vocamac/pull/2).
 
 ## Nightly Builds
 

--- a/homebrew/README.md
+++ b/homebrew/README.md
@@ -11,16 +11,22 @@ brew install --cask vocamac
 
 ### Migrating from the old tap
 
-If you previously tapped `jatinkrmalik/vocamac`, untap it before using `vocahq/vocamac`. Having both causes:
+If you previously tapped via the personal account (`jatinkrmalik/vocamac`), remove it before using the org tap. Keeping both causes Homebrew to fail with:
 
 ```text
-Error: Cask vocamac exists in multiple taps
+Error: Cask vocamac exists in multiple taps:
+       * jatinkrmalik/vocamac/vocamac
+       * vocahq/vocamac/vocamac
 ```
+
+Fix (installed apps are untouched):
 
 ```bash
 brew untap jatinkrmalik/vocamac
 brew tap vocahq/vocamac && brew trust vocahq/vocamac && brew install --cask vocamac
 ```
+
+Matching guidance also lives in the [tap README](https://github.com/VocaHQ/homebrew-vocamac).
 
 ## Nightly Builds
 

--- a/homebrew/README.md
+++ b/homebrew/README.md
@@ -9,6 +9,19 @@ brew tap vocahq/vocamac
 brew install --cask vocamac
 ```
 
+### Migrating from the old tap
+
+If you previously tapped `jatinkrmalik/vocamac`, untap it before using `vocahq/vocamac`. Having both causes:
+
+```text
+Error: Cask vocamac exists in multiple taps
+```
+
+```bash
+brew untap jatinkrmalik/vocamac
+brew tap vocahq/vocamac && brew trust vocahq/vocamac && brew install --cask vocamac
+```
+
 ## Nightly Builds
 
 For early access to the latest features, install the nightly build:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Documents the Homebrew dual-tap conflict that appears after the VocaHQ org migration when both `jatinkrmalik/vocamac` and `vocahq/vocamac` are tapped:

```text
Error: Cask vocamac exists in multiple taps:
       * jatinkrmalik/vocamac/vocamac
       * vocahq/vocamac/vocamac
```

Companion docs on the tap side: [VocaHQ/homebrew-vocamac README](https://github.com/VocaHQ/homebrew-vocamac#migrating-from-the-old-tap).

## Changes

- **`README.md`** — short callout under the Homebrew install snippet with the untap/retap fix
- **`docs/HOMEBREW.md`** — new **Migrating from `jatinkrmalik/vocamac`** section, plus a matching Troubleshooting entry
- **`homebrew/README.md`** — migration subsection under Installation, aligned with the tap README wording

**Fix:**

```bash
brew untap jatinkrmalik/vocamac
brew tap vocahq/vocamac && brew trust vocahq/vocamac && brew install --cask vocamac
```

Installed apps are untouched. For an already-installed cask, `brew untap jatinkrmalik/vocamac` alone is enough, then `brew upgrade --cask vocamac`.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ae2a4325-769b-4abb-9770-3099780f8e04?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ae2a4325-769b-4abb-9770-3099780f8e04&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

