### PR TITLE
fix: tolerate Bluetooth HFP settle for headset input routing

### DIFF
--- a/Sources/VocaMac/Services/AudioEngine.swift
+++ b/Sources/VocaMac/Services/AudioEngine.swift
@@ -503,8 +503,10 @@ final class AudioEngine {
             return true
         }
 
-        let routeIsHealthy = configuredInputDeviceID != nil
-            && currentInputDeviceID == configuredInputDeviceID
+        let routeIsHealthy = isConfiguredRouteHealthy(
+            configuredInputDeviceID: configuredInputDeviceID,
+            currentInputDeviceID: currentInputDeviceID
+        )
 
         // A notification posted during preparation but processed after start must
         // not be ignored blindly: if the headset disconnected mid-settle, recover.
@@ -517,6 +519,24 @@ final class AudioEngine {
             && elapsedSinceRecordingStart >= 0
             && elapsedSinceRecordingStart <= recoveryWindow
             && routeIsHealthy
+    }
+
+    /// True when the live AudioUnit device matches the configured one, or is an
+    /// acceptable Bluetooth HFP sibling of that headset.
+    static func isConfiguredRouteHealthy(
+        configuredInputDeviceID: AudioDeviceID?,
+        currentInputDeviceID: AudioDeviceID?
+    ) -> Bool {
+        guard let configuredInputDeviceID, let currentInputDeviceID else {
+            return false
+        }
+        if configuredInputDeviceID == currentInputDeviceID {
+            return true
+        }
+        return isAcceptableBluetoothRouteSubstitute(
+            targetDeviceID: configuredInputDeviceID,
+            actualDeviceID: currentInputDeviceID
+        )
     }
 
     static func describeCoreAudioError(_ error: Error) -> String {
@@ -739,9 +759,21 @@ final class AudioEngine {
             targetDeviceID: targetDeviceID
         ) else {
             // Warm engines can keep CurrentDevice while Bluetooth has already
-            // fallen back to A2DP. Settle HFP before installing the tap.
+            // fallen back to A2DP. Settle HFP before installing the tap, and if
+            // Core Audio moves to an HFP sibling endpoint, return that ID so
+            // later route-health checks match the live device.
             if isBluetoothTarget {
                 Self.waitForBluetoothHFPIfNeeded(deviceID: targetDeviceID, timeout: routeTimeout)
+                if let settledDeviceID = Self.currentInputDeviceID(for: audioUnit),
+                   settledDeviceID != targetDeviceID,
+                   Self.isAcceptableBluetoothRouteSubstitute(
+                    targetDeviceID: targetDeviceID,
+                    actualDeviceID: settledDeviceID
+                   ) {
+                    let substituteName = Self.audioDeviceName(for: settledDeviceID) ?? "bluetooth input"
+                    VocaLogger.info(.audioEngine, "Warm Bluetooth route resolved to HFP endpoint: \(substituteName)")
+                    return settledDeviceID
+                }
             }
             let deviceName = Self.audioDeviceName(for: targetDeviceID) ?? requestedUID ?? "system default"
             VocaLogger.debug(.audioEngine, "Input device already configured: \(deviceName)")

--- a/Sources/VocaMac/Services/AudioEngine.swift
+++ b/Sources/VocaMac/Services/AudioEngine.swift
@@ -183,8 +183,13 @@ final class AudioEngine {
             let currentInputDeviceID = self.engine?.inputNode.audioUnit.flatMap {
                 Self.currentInputDeviceID(for: $0)
             }
+            // Preparation notifications are queued behind startRecording's sync work,
+            // so by the time we run here preparation has usually finished. Only ignore
+            // those delayed notifications when the configured route is still healthy;
+            // otherwise a disconnect mid-settle would be silently dropped.
             if Self.shouldIgnoreConfigurationChange(
                 occurredDuringRecordingPreparation: occurredDuringRecordingPreparation,
+                isStillPreparingRecording: self.isPreparingRecording,
                 isRecording: wasRecording,
                 engineIsRunning: self.engine?.isRunning == true,
                 elapsedSinceRecordingStart: elapsedSinceRecordingStart,
@@ -485,6 +490,7 @@ final class AudioEngine {
 
     static func shouldIgnoreConfigurationChange(
         occurredDuringRecordingPreparation: Bool = false,
+        isStillPreparingRecording: Bool = false,
         isRecording: Bool,
         engineIsRunning: Bool,
         elapsedSinceRecordingStart: TimeInterval,
@@ -492,16 +498,25 @@ final class AudioEngine {
         currentInputDeviceID: AudioDeviceID?,
         recoveryWindow: TimeInterval = startupConfigurationChangeRecoveryWindow
     ) -> Bool {
-        if occurredDuringRecordingPreparation {
+        // Still inside configureInputRoute / startRecording on lifecycleQueue.
+        if isStillPreparingRecording {
             return true
+        }
+
+        let routeIsHealthy = configuredInputDeviceID != nil
+            && currentInputDeviceID == configuredInputDeviceID
+
+        // A notification posted during preparation but processed after start must
+        // not be ignored blindly: if the headset disconnected mid-settle, recover.
+        if occurredDuringRecordingPreparation {
+            return isRecording && engineIsRunning && routeIsHealthy
         }
 
         return isRecording
             && engineIsRunning
             && elapsedSinceRecordingStart >= 0
             && elapsedSinceRecordingStart <= recoveryWindow
-            && configuredInputDeviceID != nil
-            && currentInputDeviceID == configuredInputDeviceID
+            && routeIsHealthy
     }
 
     static func describeCoreAudioError(_ error: Error) -> String {
@@ -723,6 +738,11 @@ final class AudioEngine {
             currentDeviceID: currentDeviceID,
             targetDeviceID: targetDeviceID
         ) else {
+            // Warm engines can keep CurrentDevice while Bluetooth has already
+            // fallen back to A2DP. Settle HFP before installing the tap.
+            if isBluetoothTarget {
+                Self.waitForBluetoothHFPIfNeeded(deviceID: targetDeviceID, timeout: routeTimeout)
+            }
             let deviceName = Self.audioDeviceName(for: targetDeviceID) ?? requestedUID ?? "system default"
             VocaLogger.debug(.audioEngine, "Input device already configured: \(deviceName)")
             return targetDeviceID
@@ -870,10 +890,32 @@ final class AudioEngine {
             return true
         }
         if let targetName, let actualName,
-           targetName.localizedCaseInsensitiveCompare(actualName) == .orderedSame {
+           bluetoothDeviceNamesMatch(targetName, actualName) {
             return true
         }
         return false
+    }
+
+    /// macOS often lists the same headset as "Name" (A2DP) and "Name Hands-Free" (HFP).
+    static func bluetoothDeviceNamesMatch(_ lhs: String, _ rhs: String) -> Bool {
+        let normalizedLHS = normalizeBluetoothDeviceName(lhs)
+        let normalizedRHS = normalizeBluetoothDeviceName(rhs)
+        guard !normalizedLHS.isEmpty, !normalizedRHS.isEmpty else { return false }
+        return normalizedLHS.localizedCaseInsensitiveCompare(normalizedRHS) == .orderedSame
+    }
+
+    static func normalizeBluetoothDeviceName(_ name: String) -> String {
+        var result = name.trimmingCharacters(in: .whitespacesAndNewlines)
+        let suffixes = [" Hands-Free", " Hands Free", " Headset", " HFP"]
+        let lowercased = result.lowercased()
+        for suffix in suffixes {
+            if lowercased.hasSuffix(suffix.lowercased()) {
+                result = String(result.dropLast(suffix.count))
+                    .trimmingCharacters(in: .whitespacesAndNewlines)
+                break
+            }
+        }
+        return result
     }
 
     private static func isAcceptableBluetoothRouteSubstitute(

--- a/Sources/VocaMac/Services/AudioEngine.swift
+++ b/Sources/VocaMac/Services/AudioEngine.swift
@@ -26,8 +26,15 @@ final class AudioEngine {
     private var configuredInputDeviceID: AudioDeviceID?
     private let bufferQueue = DispatchQueue(label: "com.vocamac.audio-buffer", qos: .userInteractive)
     private let lifecycleQueue = DispatchQueue(label: "com.vocamac.audio-engine.lifecycle", qos: .userInitiated)
+    private let recordingPreparationLock = NSLock()
+    private var _isPreparingRecording = false
 
     static let inputRouteConfigurationTimeout: TimeInterval = 0.25
+    /// Bluetooth headsets need longer for the A2DP → HFP/SCO profile switch.
+    static let bluetoothInputRouteConfigurationTimeout: TimeInterval = 3.0
+    static let inputRoutePollInterval: TimeInterval = 0.05
+    /// HFP/SCO typically runs at 8/16/24 kHz; A2DP stays at 44.1/48 kHz.
+    static let bluetoothHFPSampleRateThreshold: Double = 44100
     static let startupConfigurationChangeRecoveryWindow: TimeInterval = 1.0
     static let idleEngineReleaseDelay: TimeInterval = 3.0
 
@@ -37,6 +44,12 @@ final class AudioEngine {
 
     var isEngineAllocatedForTesting: Bool {
         lifecycleQueue.sync { engine != nil }
+    }
+
+    private var isPreparingRecording: Bool {
+        recordingPreparationLock.lock()
+        defer { recordingPreparationLock.unlock() }
+        return _isPreparingRecording
     }
 
     // Silence detection
@@ -157,6 +170,10 @@ final class AudioEngine {
     /// is invalidated — the installed tap references a stale format and no audio
     /// flows. We must stop, reset, and notify AppState so it can recover.
     @objc private func handleAudioConfigurationChange(_ notification: Notification) {
+        // Capture preparation state on the posting queue. startRecording holds
+        // lifecycleQueue during Bluetooth HFP settle, so reading later would race.
+        let occurredDuringRecordingPreparation = isPreparingRecording
+
         lifecycleQueue.async { [weak self] in
             guard let self = self else { return }
             VocaLogger.info(.audioEngine, "Audio configuration changed (device plug/unplug or route change)")
@@ -167,6 +184,7 @@ final class AudioEngine {
                 Self.currentInputDeviceID(for: $0)
             }
             if Self.shouldIgnoreConfigurationChange(
+                occurredDuringRecordingPreparation: occurredDuringRecordingPreparation,
                 isRecording: wasRecording,
                 engineIsRunning: self.engine?.isRunning == true,
                 elapsedSinceRecordingStart: elapsedSinceRecordingStart,
@@ -243,6 +261,9 @@ final class AudioEngine {
     ) -> Bool {
         lifecycleQueue.sync {
             guard !self._isCurrentlyRecording else { return true }
+
+            self.setIsPreparingRecording(true)
+            defer { self.setIsPreparingRecording(false) }
 
             self.silenceThreshold = silenceThreshold
             self.silenceDuration = silenceDuration
@@ -324,6 +345,10 @@ final class AudioEngine {
                     return false
                 }
 
+                // Anchor max-duration / startup recovery to the moment capture
+                // actually begins, not the start of Bluetooth route settling.
+                recordingStartTime = Date()
+                lastSoundTime = Date()
                 _isCurrentlyRecording = true
                 return true
             }
@@ -387,6 +412,12 @@ final class AudioEngine {
         recordingStartTime = Date()
         silenceCallbackFired = false
         maxDurationCallbackFired = false
+    }
+
+    private func setIsPreparingRecording(_ isPreparing: Bool) {
+        recordingPreparationLock.lock()
+        _isPreparingRecording = isPreparing
+        recordingPreparationLock.unlock()
     }
 
     /// Clears captured audio samples while preserving buffer capacity.
@@ -453,6 +484,7 @@ final class AudioEngine {
     }
 
     static func shouldIgnoreConfigurationChange(
+        occurredDuringRecordingPreparation: Bool = false,
         isRecording: Bool,
         engineIsRunning: Bool,
         elapsedSinceRecordingStart: TimeInterval,
@@ -460,7 +492,11 @@ final class AudioEngine {
         currentInputDeviceID: AudioDeviceID?,
         recoveryWindow: TimeInterval = startupConfigurationChangeRecoveryWindow
     ) -> Bool {
-        isRecording
+        if occurredDuringRecordingPreparation {
+            return true
+        }
+
+        return isRecording
             && engineIsRunning
             && elapsedSinceRecordingStart >= 0
             && elapsedSinceRecordingStart <= recoveryWindow
@@ -651,6 +687,11 @@ final class AudioEngine {
     /// Setting CurrentDevice can asynchronously invalidate AVAudioEngine's formats,
     /// so a real route change is allowed to settle and the graph is reset before
     /// the tap's format is queried.
+    ///
+    /// Bluetooth headsets additionally switch from A2DP to HFP/SCO when the mic is
+    /// activated. That profile change can take multiple seconds and may temporarily
+    /// clear CurrentDevice across `engine.reset()`, so we poll, re-apply, and only
+    /// then verify the active route.
     private func configureInputRoute(
         preferredInputDeviceID: String?,
         engine: AVAudioEngine,
@@ -675,6 +716,8 @@ final class AudioEngine {
             return nil
         }
 
+        let isBluetoothTarget = Self.isBluetoothDevice(targetDeviceID)
+        let routeTimeout = Self.inputRouteTimeout(isBluetooth: isBluetoothTarget)
         let currentDeviceID = Self.currentInputDeviceID(for: audioUnit)
         guard Self.shouldReconfigureInputDevice(
             currentDeviceID: currentDeviceID,
@@ -697,18 +740,8 @@ final class AudioEngine {
         }
         defer { NotificationCenter.default.removeObserver(observer) }
 
-        var mutableDeviceID = targetDeviceID
-        let status = AudioUnitSetProperty(
-            audioUnit,
-            kAudioOutputUnitProperty_CurrentDevice,
-            kAudioUnitScope_Global,
-            0,
-            &mutableDeviceID,
-            UInt32(MemoryLayout<AudioDeviceID>.size)
-        )
-
-        guard status == noErr else {
-            VocaLogger.warning(.audioEngine, "Failed to set input device: OSStatus \(status)")
+        guard Self.applyInputDevice(targetDeviceID, to: audioUnit) else {
+            VocaLogger.warning(.audioEngine, "Failed to set input device \(targetDeviceID)")
             return nil
         }
 
@@ -717,9 +750,16 @@ final class AudioEngine {
             VocaLogger.debug(.audioEngine, "Input route change is still pending after AudioUnitSetProperty")
         }
 
-        let waitResult = routeChangeSignal.wait(timeout: .now() + Self.inputRouteConfigurationTimeout)
-        if waitResult == .timedOut {
-            VocaLogger.debug(.audioEngine, "No configuration notification received after input route change; rebuilding graph after timeout")
+        // Wait for either a configuration notification or the device ID to stick.
+        // Bluetooth HFP negotiation commonly exceeds the short wired timeout.
+        let appliedBeforeReset = Self.waitForInputDevice(
+            targetDeviceID,
+            on: audioUnit,
+            signal: routeChangeSignal,
+            timeout: routeTimeout
+        )
+        if !appliedBeforeReset {
+            VocaLogger.debug(.audioEngine, "Requested input device not confirmed before graph rebuild; continuing with rebuild")
         }
 
         // Apple documents that configuration changes stop and uninitialize the
@@ -728,18 +768,63 @@ final class AudioEngine {
         engine.stop()
         engine.reset()
 
-        let deviceIDAfterReset = Self.currentInputDeviceID(for: audioUnit)
-        guard Self.shouldAcceptConfiguredInputRoute(
+        var deviceIDAfterReset = Self.currentInputDeviceID(for: audioUnit)
+        if !Self.shouldAcceptConfiguredInputRoute(
             targetDeviceID: targetDeviceID,
             deviceIDAfterReset: deviceIDAfterReset
-        ) else {
-            VocaLogger.warning(.audioEngine, "Core Audio did not apply the requested input device after rebuilding the graph")
+        ) {
+            // `reset()` can drop a Bluetooth CurrentDevice mid-profile-switch.
+            // Re-apply and wait again before giving up.
+            VocaLogger.debug(.audioEngine, "Re-applying input device after graph reset")
+            guard Self.applyInputDevice(targetDeviceID, to: audioUnit) else {
+                VocaLogger.warning(.audioEngine, "Failed to re-apply input device after rebuilding the graph")
+                return nil
+            }
+            _ = Self.waitForInputDevice(
+                targetDeviceID,
+                on: audioUnit,
+                signal: routeChangeSignal,
+                timeout: routeTimeout
+            )
+            deviceIDAfterReset = Self.currentInputDeviceID(for: audioUnit)
+        }
+
+        // Bluetooth profile switches can expose a sibling input endpoint with a
+        // different AudioDeviceID. Accept that sibling when it shares the UID or
+        // name of the requested headset.
+        let resolvedDeviceID: AudioDeviceID
+        if Self.shouldAcceptConfiguredInputRoute(
+            targetDeviceID: targetDeviceID,
+            deviceIDAfterReset: deviceIDAfterReset
+        ) {
+            resolvedDeviceID = targetDeviceID
+        } else if isBluetoothTarget,
+                  let deviceIDAfterReset,
+                  Self.isAcceptableBluetoothRouteSubstitute(
+                    targetDeviceID: targetDeviceID,
+                    actualDeviceID: deviceIDAfterReset
+                  ) {
+            let substituteName = Self.audioDeviceName(for: deviceIDAfterReset) ?? "bluetooth input"
+            VocaLogger.info(.audioEngine, "Using Bluetooth HFP input endpoint: \(substituteName)")
+            resolvedDeviceID = deviceIDAfterReset
+        } else {
+            let actualDescription = deviceIDAfterReset.map(String.init) ?? "none"
+            VocaLogger.warning(
+                .audioEngine,
+                "Core Audio did not apply the requested input device after rebuilding the graph (wanted \(targetDeviceID), got \(actualDescription), bluetooth=\(isBluetoothTarget))"
+            )
             return nil
         }
 
-        let deviceName = Self.audioDeviceName(for: targetDeviceID) ?? requestedUID ?? "system default"
+        // Wait for A2DP → HFP/SCO after the route is confirmed so the tap is
+        // installed against the headset mic format, not the stale A2DP rate.
+        if isBluetoothTarget {
+            Self.waitForBluetoothHFPIfNeeded(deviceID: resolvedDeviceID, timeout: routeTimeout)
+        }
+
+        let deviceName = Self.audioDeviceName(for: resolvedDeviceID) ?? requestedUID ?? "system default"
         VocaLogger.info(.audioEngine, "Using input device: \(deviceName)")
-        return targetDeviceID
+        return resolvedDeviceID
     }
 
     static func shouldReconfigureInputDevice(
@@ -754,6 +839,134 @@ final class AudioEngine {
         deviceIDAfterReset: AudioDeviceID?
     ) -> Bool {
         deviceIDAfterReset == targetDeviceID
+    }
+
+    static func inputRouteTimeout(isBluetooth: Bool) -> TimeInterval {
+        isBluetooth ? bluetoothInputRouteConfigurationTimeout : inputRouteConfigurationTimeout
+    }
+
+    static func isBluetoothTransport(_ transportType: UInt32) -> Bool {
+        transportType == kAudioDeviceTransportTypeBluetooth
+            || transportType == kAudioDeviceTransportTypeBluetoothLE
+    }
+
+    static func hasBluetoothHFPSettled(
+        sampleRate: Double?,
+        threshold: Double = bluetoothHFPSampleRateThreshold
+    ) -> Bool {
+        guard let sampleRate, sampleRate > 0 else { return false }
+        return sampleRate < threshold
+    }
+
+    static func isAcceptableBluetoothRouteSubstitute(
+        targetUID: String?,
+        actualUID: String?,
+        targetName: String?,
+        actualName: String?,
+        actualIsBluetooth: Bool
+    ) -> Bool {
+        guard actualIsBluetooth else { return false }
+        if let targetUID, let actualUID, targetUID == actualUID {
+            return true
+        }
+        if let targetName, let actualName,
+           targetName.localizedCaseInsensitiveCompare(actualName) == .orderedSame {
+            return true
+        }
+        return false
+    }
+
+    private static func isAcceptableBluetoothRouteSubstitute(
+        targetDeviceID: AudioDeviceID,
+        actualDeviceID: AudioDeviceID
+    ) -> Bool {
+        isAcceptableBluetoothRouteSubstitute(
+            targetUID: audioDeviceUID(for: targetDeviceID),
+            actualUID: audioDeviceUID(for: actualDeviceID),
+            targetName: audioDeviceName(for: targetDeviceID),
+            actualName: audioDeviceName(for: actualDeviceID),
+            actualIsBluetooth: isBluetoothDevice(actualDeviceID)
+        )
+    }
+
+    private static func applyInputDevice(_ deviceID: AudioDeviceID, to audioUnit: AudioUnit) -> Bool {
+        var mutableDeviceID = deviceID
+        let status = AudioUnitSetProperty(
+            audioUnit,
+            kAudioOutputUnitProperty_CurrentDevice,
+            kAudioUnitScope_Global,
+            0,
+            &mutableDeviceID,
+            UInt32(MemoryLayout<AudioDeviceID>.size)
+        )
+        if status != noErr {
+            VocaLogger.warning(.audioEngine, "AudioUnitSetProperty CurrentDevice failed: OSStatus \(status)")
+            return false
+        }
+        return true
+    }
+
+    /// Waits until the AudioUnit reports `targetDeviceID`, or until timeout.
+    /// Returns `true` when the device was observed; `false` on timeout.
+    @discardableResult
+    private static func waitForInputDevice(
+        _ targetDeviceID: AudioDeviceID,
+        on audioUnit: AudioUnit,
+        signal: DispatchSemaphore,
+        timeout: TimeInterval
+    ) -> Bool {
+        let deadline = Date().addingTimeInterval(timeout)
+        while Date() < deadline {
+            if currentInputDeviceID(for: audioUnit) == targetDeviceID {
+                return true
+            }
+            let remaining = deadline.timeIntervalSinceNow
+            guard remaining > 0 else { break }
+            let slice = min(inputRoutePollInterval, remaining)
+            _ = signal.wait(timeout: .now() + slice)
+        }
+        return currentInputDeviceID(for: audioUnit) == targetDeviceID
+    }
+
+    private static func waitForBluetoothHFPIfNeeded(deviceID: AudioDeviceID, timeout: TimeInterval) {
+        guard isBluetoothDevice(deviceID) else { return }
+
+        let deadline = Date().addingTimeInterval(timeout)
+        var lastRate = audioDeviceSampleRate(for: deviceID)
+        while Date() < deadline {
+            let rate = audioDeviceSampleRate(for: deviceID)
+            lastRate = rate
+            if hasBluetoothHFPSettled(sampleRate: rate) {
+                VocaLogger.debug(.audioEngine, "Bluetooth HFP settled at \(Int(rate))Hz")
+                return
+            }
+            Thread.sleep(forTimeInterval: inputRoutePollInterval)
+        }
+
+        VocaLogger.debug(
+            .audioEngine,
+            "Bluetooth HFP settle timed out at \(Int(lastRate))Hz; continuing with current route"
+        )
+    }
+
+    private static func isBluetoothDevice(_ deviceID: AudioDeviceID) -> Bool {
+        guard let transportType = audioDeviceTransportType(for: deviceID) else {
+            return false
+        }
+        return isBluetoothTransport(transportType)
+    }
+
+    private static func audioDeviceTransportType(for deviceID: AudioDeviceID) -> UInt32? {
+        var address = AudioObjectPropertyAddress(
+            mSelector: kAudioDevicePropertyTransportType,
+            mScope: kAudioObjectPropertyScopeGlobal,
+            mElement: kAudioObjectPropertyElementMain
+        )
+        var transportType = UInt32(0)
+        var dataSize = UInt32(MemoryLayout<UInt32>.size)
+        let status = AudioObjectGetPropertyData(deviceID, &address, 0, nil, &dataSize, &transportType)
+        guard status == noErr else { return nil }
+        return transportType
     }
 
     private static func currentInputDeviceID(for audioUnit: AudioUnit) -> AudioDeviceID? {

--- a/Sources/VocaMac/Services/AudioEngine.swift
+++ b/Sources/VocaMac/Services/AudioEngine.swift
@@ -770,6 +770,9 @@ final class AudioEngine {
                     targetDeviceID: targetDeviceID,
                     actualDeviceID: settledDeviceID
                    ) {
+                    // Match the cold path: settle against the live HFP endpoint
+                    // before the tap format is read.
+                    Self.waitForBluetoothHFPIfNeeded(deviceID: settledDeviceID, timeout: routeTimeout)
                     let substituteName = Self.audioDeviceName(for: settledDeviceID) ?? "bluetooth input"
                     VocaLogger.info(.audioEngine, "Warm Bluetooth route resolved to HFP endpoint: \(substituteName)")
                     return settledDeviceID

--- a/Tests/VocaMacTests/ServiceTests.swift
+++ b/Tests/VocaMacTests/ServiceTests.swift
@@ -825,6 +825,34 @@ final class AudioEngineDeviceChangeTests: XCTestCase {
         )
     }
 
+    func testConfiguredRouteHealthRequiresMatchingDevice() {
+        XCTAssertTrue(
+            AudioEngine.isConfiguredRouteHealthy(
+                configuredInputDeviceID: 42,
+                currentInputDeviceID: 42
+            )
+        )
+        XCTAssertFalse(
+            AudioEngine.isConfiguredRouteHealthy(
+                configuredInputDeviceID: 42,
+                currentInputDeviceID: 41
+            ),
+            "Unrelated device IDs are not healthy without Bluetooth substitute metadata"
+        )
+        XCTAssertFalse(
+            AudioEngine.isConfiguredRouteHealthy(
+                configuredInputDeviceID: nil,
+                currentInputDeviceID: 42
+            )
+        )
+        XCTAssertFalse(
+            AudioEngine.isConfiguredRouteHealthy(
+                configuredInputDeviceID: 42,
+                currentInputDeviceID: nil
+            )
+        )
+    }
+
     func testStartupConfigurationChangeIsIgnoredOnlyForStableConfiguredRoute() {
         XCTAssertTrue(
             AudioEngine.shouldIgnoreConfigurationChange(

--- a/Tests/VocaMacTests/ServiceTests.swift
+++ b/Tests/VocaMacTests/ServiceTests.swift
@@ -787,6 +787,22 @@ final class AudioEngineDeviceChangeTests: XCTestCase {
             ),
             "Matching Bluetooth names identify the same headset when UIDs diverge"
         )
+        XCTAssertTrue(
+            AudioEngine.isAcceptableBluetoothRouteSubstitute(
+                targetUID: "uid-a",
+                actualUID: "uid-b",
+                targetName: "Soundcore Life Q30",
+                actualName: "Soundcore Life Q30 Hands-Free",
+                actualIsBluetooth: true
+            ),
+            "HFP Hands-Free suffix should still match the A2DP device name"
+        )
+        XCTAssertTrue(
+            AudioEngine.bluetoothDeviceNamesMatch(
+                "AirPods Pro",
+                "AirPods Pro Hands-Free"
+            )
+        )
         XCTAssertFalse(
             AudioEngine.isAcceptableBluetoothRouteSubstitute(
                 targetUID: "uid-a",
@@ -812,6 +828,39 @@ final class AudioEngineDeviceChangeTests: XCTestCase {
     func testStartupConfigurationChangeIsIgnoredOnlyForStableConfiguredRoute() {
         XCTAssertTrue(
             AudioEngine.shouldIgnoreConfigurationChange(
+                isStillPreparingRecording: true,
+                isRecording: false,
+                engineIsRunning: false,
+                elapsedSinceRecordingStart: 0,
+                configuredInputDeviceID: nil,
+                currentInputDeviceID: nil
+            ),
+            "Churn while startRecording still owns preparation must not abort start"
+        )
+        XCTAssertTrue(
+            AudioEngine.shouldIgnoreConfigurationChange(
+                occurredDuringRecordingPreparation: true,
+                isRecording: true,
+                engineIsRunning: true,
+                elapsedSinceRecordingStart: 2.5,
+                configuredInputDeviceID: 42,
+                currentInputDeviceID: 42
+            ),
+            "Delayed prep notifications may be ignored only while the configured route stays healthy"
+        )
+        XCTAssertFalse(
+            AudioEngine.shouldIgnoreConfigurationChange(
+                occurredDuringRecordingPreparation: true,
+                isRecording: true,
+                engineIsRunning: true,
+                elapsedSinceRecordingStart: 0.1,
+                configuredInputDeviceID: 42,
+                currentInputDeviceID: 41
+            ),
+            "Route loss during Bluetooth settle must still recover after start"
+        )
+        XCTAssertFalse(
+            AudioEngine.shouldIgnoreConfigurationChange(
                 occurredDuringRecordingPreparation: true,
                 isRecording: false,
                 engineIsRunning: false,
@@ -819,7 +868,7 @@ final class AudioEngineDeviceChangeTests: XCTestCase {
                 configuredInputDeviceID: nil,
                 currentInputDeviceID: nil
             ),
-            "Route preparation churn (including Bluetooth HFP settle) must not abort start"
+            "Prep-originated notifications after a failed start must not be treated as healthy"
         )
         XCTAssertTrue(
             AudioEngine.shouldIgnoreConfigurationChange(

--- a/Tests/VocaMacTests/ServiceTests.swift
+++ b/Tests/VocaMacTests/ServiceTests.swift
@@ -4,6 +4,7 @@
 // Tests for services: KeyCodeReference, TextInjector, SoundManager, AudioEngine.
 
 import XCTest
+import CoreAudio
 @testable import VocaMac
 
 // MARK: - KeyCodeReference Tests
@@ -733,7 +734,93 @@ final class AudioEngineDeviceChangeTests: XCTestCase {
         )
     }
 
+    func testBluetoothInputRouteUsesLongerSettleTimeout() {
+        XCTAssertEqual(
+            AudioEngine.inputRouteTimeout(isBluetooth: false),
+            AudioEngine.inputRouteConfigurationTimeout
+        )
+        XCTAssertEqual(
+            AudioEngine.inputRouteTimeout(isBluetooth: true),
+            AudioEngine.bluetoothInputRouteConfigurationTimeout
+        )
+        XCTAssertGreaterThan(
+            AudioEngine.bluetoothInputRouteConfigurationTimeout,
+            AudioEngine.inputRouteConfigurationTimeout
+        )
+    }
+
+    func testBluetoothTransportDetection() {
+        XCTAssertTrue(AudioEngine.isBluetoothTransport(kAudioDeviceTransportTypeBluetooth))
+        XCTAssertTrue(AudioEngine.isBluetoothTransport(kAudioDeviceTransportTypeBluetoothLE))
+        XCTAssertFalse(AudioEngine.isBluetoothTransport(kAudioDeviceTransportTypeBuiltIn))
+        XCTAssertFalse(AudioEngine.isBluetoothTransport(kAudioDeviceTransportTypeUSB))
+    }
+
+    func testBluetoothHFPSettleUsesHeadsetSampleRates() {
+        XCTAssertTrue(AudioEngine.hasBluetoothHFPSettled(sampleRate: 16000))
+        XCTAssertTrue(AudioEngine.hasBluetoothHFPSettled(sampleRate: 8000))
+        XCTAssertTrue(AudioEngine.hasBluetoothHFPSettled(sampleRate: 24000))
+        XCTAssertFalse(AudioEngine.hasBluetoothHFPSettled(sampleRate: 44100))
+        XCTAssertFalse(AudioEngine.hasBluetoothHFPSettled(sampleRate: 48000))
+        XCTAssertFalse(AudioEngine.hasBluetoothHFPSettled(sampleRate: nil))
+        XCTAssertFalse(AudioEngine.hasBluetoothHFPSettled(sampleRate: 0))
+    }
+
+    func testBluetoothRouteSubstituteAcceptance() {
+        XCTAssertTrue(
+            AudioEngine.isAcceptableBluetoothRouteSubstitute(
+                targetUID: "Soundcore-UID",
+                actualUID: "Soundcore-UID",
+                targetName: "Soundcore Life Q30",
+                actualName: "Soundcore Life Q30 Hands-Free",
+                actualIsBluetooth: true
+            ),
+            "Matching Bluetooth UIDs identify the same headset across HFP endpoints"
+        )
+        XCTAssertTrue(
+            AudioEngine.isAcceptableBluetoothRouteSubstitute(
+                targetUID: "uid-a",
+                actualUID: "uid-b",
+                targetName: "Soundcore Life Q30",
+                actualName: "Soundcore Life Q30",
+                actualIsBluetooth: true
+            ),
+            "Matching Bluetooth names identify the same headset when UIDs diverge"
+        )
+        XCTAssertFalse(
+            AudioEngine.isAcceptableBluetoothRouteSubstitute(
+                targetUID: "uid-a",
+                actualUID: "uid-b",
+                targetName: "Soundcore Life Q30",
+                actualName: "MacBook Pro Microphone",
+                actualIsBluetooth: true
+            ),
+            "Unrelated Bluetooth devices must not be treated as substitutes"
+        )
+        XCTAssertFalse(
+            AudioEngine.isAcceptableBluetoothRouteSubstitute(
+                targetUID: "uid-a",
+                actualUID: "uid-b",
+                targetName: "Soundcore Life Q30",
+                actualName: "MacBook Pro Microphone",
+                actualIsBluetooth: false
+            ),
+            "Wired fallback devices must never be treated as Bluetooth substitutes"
+        )
+    }
+
     func testStartupConfigurationChangeIsIgnoredOnlyForStableConfiguredRoute() {
+        XCTAssertTrue(
+            AudioEngine.shouldIgnoreConfigurationChange(
+                occurredDuringRecordingPreparation: true,
+                isRecording: false,
+                engineIsRunning: false,
+                elapsedSinceRecordingStart: 0,
+                configuredInputDeviceID: nil,
+                currentInputDeviceID: nil
+            ),
+            "Route preparation churn (including Bluetooth HFP settle) must not abort start"
+        )
         XCTAssertTrue(
             AudioEngine.shouldIgnoreConfigurationChange(
                 isRecording: true,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes [#196](https://github.com/VocaHQ/vocamac/issues/196): push-to-talk with a Bluetooth headset (e.g. Soundcore) flashes red and records nothing, with:

`Core Audio did not apply the requested input device after rebuilding the graph`

### Root cause

Selecting/activating a Bluetooth mic triggers an A2DP → HFP/SCO profile switch. That is asynchronous and often takes longer than the previous **250ms** route-wait. After `engine.reset()`, `CurrentDevice` frequently still does not match the target (or lands on an HFP sibling endpoint), and `configureInputRoute` hard-failed — so recording never started.

### Fix

In `AudioEngine.configureInputRoute`:

- Detect Bluetooth transport and wait up to **3s**, polling until `CurrentDevice` sticks
- Re-apply `CurrentDevice` if `engine.reset()` dropped it mid-switch
- Accept Bluetooth HFP sibling endpoints that share UID or normalized name (including `Hands-Free` suffix)
- Wait for HFP sample-rate settle (< 44.1 kHz) before installing the tap, including on warm-engine reuse
- On warm Bluetooth paths, return the live HFP endpoint ID after settle so route-health checks stay consistent
- Ignore preparation-time config churn only when the configured route remains healthy after start (including Bluetooth siblings)
- Anchor `recordingStartTime` to actual capture start (after settle), not route preparation

### Tests

- Unit coverage for Bluetooth timeout selection, transport detection, HFP sample-rate settle, Hands-Free name matching, route health, and preparation-phase config-change ignore
- Full `swift test` runs on macOS CI

### Validation needed on hardware

Please verify with a Bluetooth headset (Soundcore / AirPods):

1. System Default = headset → push-to-talk should record (may take ~1–3s on first activation while HFP connects)
2. Explicitly select the headset in Settings → Audio → same
3. Rapid repeat PTT within the warm-engine window should keep working
4. Built-in mic / wired USB mic should still start immediately with no behavior change
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f7496ac1-218b-42a4-bc9c-0c54d4ece8dc?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f7496ac1-218b-42a4-bc9c-0c54d4ece8dc&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

