### PR TITLE
chore: bump version to 0.8.0

### DIFF
--- a/Sources/VocaMac/Services/CursorOverlayManager.swift
+++ b/Sources/VocaMac/Services/CursorOverlayManager.swift
@@ -448,10 +448,23 @@ struct HandyOverlayView: View {
     @State private var isPulsing = false
     @State private var hasEntered = false
 
-    private let brandGreen = Color(nsColor: BrandAssets.brandGreen)
-    private let processingColor = Color(nsColor: .systemYellow)
-
     private var isDark: Bool { colorScheme == .dark }
+
+    /// A brighter recording accent keeps the small waveform and status icon
+    /// distinct from the panel in both system appearances.
+    private var recordingColor: Color {
+        isDark
+            ? Color(red: 0.35, green: 0.91, blue: 0.70)
+            : Color(red: 0.0, green: 0.45, blue: 0.33)
+    }
+
+    /// Yellow is clear on a dark panel, while the deeper amber remains visible
+    /// against the light panel when it is used for the processing spinner.
+    private var processingColor: Color {
+        isDark
+            ? Color(nsColor: .systemYellow)
+            : Color(red: 0.55, green: 0.27, blue: 0.0)
+    }
 
     private var panelFill: Color {
         isDark
@@ -476,11 +489,7 @@ struct HandyOverlayView: View {
     }
 
     private var waveformColor: Color {
-        viewModel.phase == .recording ? brandGreen : processingColor
-    }
-
-    private var accentColor: Color {
-        viewModel.phase == .recording ? brandGreen : processingColor
+        viewModel.phase == .recording ? recordingColor : processingColor
     }
 
     private var slideInOffset: CGFloat {
@@ -509,7 +518,7 @@ struct HandyOverlayView: View {
             RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
                 .strokeBorder(
                     viewModel.phase == .recording
-                        ? brandGreen.opacity(isPulsing ? 0.95 : 0.55)
+                        ? recordingColor.opacity(isPulsing ? 0.95 : 0.55)
                         : strokeBase,
                     lineWidth: viewModel.phase == .recording ? 1.6 : 1
                 )
@@ -567,7 +576,7 @@ struct HandyOverlayView: View {
 
     private var liveHeader: some View {
         HStack(spacing: 7) {
-            brandMarkBadge
+            recordingIndicatorIcon
 
             Text(viewModel.phase == .recording ? "Listening" : "Transcribing")
                 .font(.system(size: 13, weight: .semibold))
@@ -626,16 +635,14 @@ struct HandyOverlayView: View {
     private var minimalControlRow: some View {
         HStack(spacing: 8) {
             if viewModel.phase == .recording {
-                brandMarkBadge
+                recordingIndicatorIcon
                 waveform
             } else {
                 ProgressView()
                     .controlSize(.small)
                     .tint(processingColor)
-
-                Text("Transcribing…")
-                    .font(.system(size: 12, weight: .semibold))
-                    .foregroundStyle(primaryText)
+                    .accessibilityLabel("Transcribing")
+                    .frame(maxWidth: .infinity)
             }
         }
         .padding(.horizontal, 10)
@@ -667,30 +674,20 @@ struct HandyOverlayView: View {
         .accessibilityLabel("Microphone level")
     }
 
-    private var brandMarkBadge: some View {
+    private var recordingIndicatorIcon: some View {
         ZStack {
             if viewModel.phase == .recording {
                 Circle()
-                    .fill(brandGreen.opacity(isDark ? 0.28 : 0.18))
+                    .fill(recordingColor.opacity(isDark ? 0.28 : 0.18))
                     .frame(width: 22, height: 22)
                     .scaleEffect(isPulsing ? 1.08 : 0.86)
                     .opacity(isPulsing ? 0.55 : 0.9)
             }
 
-            Group {
-                if let mark = BrandAssets.mark {
-                    Image(nsImage: mark)
-                        .resizable()
-                        .renderingMode(.template)
-                        .scaledToFit()
-                        .frame(width: 12, height: 12)
-                } else {
-                    Image(systemName: "mic.fill")
-                        .font(.system(size: 10, weight: .semibold))
-                }
-            }
-            .foregroundStyle(accentColor)
-            .shadow(color: accentColor.opacity(0.4), radius: 3)
+            Image(systemName: "mic.fill")
+                .font(.system(size: 11, weight: .bold))
+                .foregroundStyle(viewModel.phase == .recording ? recordingColor : processingColor)
+                .shadow(color: waveformColor.opacity(0.45), radius: 3)
         }
         .frame(width: 22, height: 22)
         .accessibilityLabel(viewModel.phase == .recording ? "Recording" : "Transcribing")

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -8,8 +8,8 @@
 # 3. Code signs — Developer ID if CODE_SIGN_IDENTITY is set, ad-hoc otherwise
 #
 # Environment variables:
-#   APP_VERSION         — Version string to embed in Info.plist. Defaults to 0.7.2.
-#                         Set by CI for nightly builds (e.g., 0.7.2-nightly.20260512+abc1234).
+#   APP_VERSION         — Version string to embed in Info.plist. Defaults to 0.8.0.
+#                         Set by CI for nightly builds (e.g., 0.8.0-nightly.20260512+abc1234).
 #   CODE_SIGN_IDENTITY  — Signing identity to use. Defaults to auto-detect
 #                         Developer ID Application in the login keychain.
 #                         Set to "-" to force ad-hoc signing.
@@ -29,7 +29,7 @@ BUNDLE_ID="com.vocamac.app"
 APP_NAME="VocaMac"
 APP_DIR="${APP_NAME}.app"
 ENTITLEMENTS="VocaMac.entitlements"
-APP_VERSION="${APP_VERSION:-0.7.2}"
+APP_VERSION="${APP_VERSION:-0.8.0}"
 
 # Resolve signing identity:
 # 1. Use CODE_SIGN_IDENTITY env var if set

--- a/web/layouts/index.html
+++ b/web/layouts/index.html
@@ -39,7 +39,7 @@
             "Open source (AGPL-3.0 license)"
         ],
         "screenshot": "https://vocamac.com/og-image.png",
-        "softwareVersion": "0.7.2",
+        "softwareVersion": "0.8.0",
         "softwareRequirements": "macOS 14 (Sonoma) or later, Apple Silicon (M1 or later), 8 GB RAM minimum"
     }
     </script>
@@ -52,7 +52,7 @@
             <div class="hero__content">
                 <div class="hero__badges">
                     <span class="badge badge--beta">BETA RELEASE</span>
-                    <span class="badge badge--outline" id="version-badge">v0.7.2</span>
+                    <span class="badge badge--outline" id="version-badge">v0.8.0</span>
                 </div>
                 <h1 class="hero__headline">
                     Your Voice,<br>


### PR DESCRIPTION
## Summary

Prepares the **v0.8.0** minor release.

This release contains 25 commits since v0.7.2. It adds backward-compatible transcription, input, model-management, and command-line capabilities alongside reliability and product-surface improvements; no breaking change is introduced.

### Changes since v0.7.2

| PR | Type | Summary |
|---|---|---|
| #190 | fix | Open update details in a standalone window with clearer controls |
| #191, #192 | feat / fix | Add Parakeet, Apple Speech, and specialized ONNX transcription engines; harden their shared model lifecycle |
| #194, #195 | ci / docs | Move Homebrew release automation and migration guidance to the VocaHQ tap |
| #197 | fix | Let Bluetooth HFP/SCO input routing settle before dictation starts |
| #200 | feat | Add a headless file-transcription CLI |
| #201 | fix | Preserve quoted HTML metadata through site minification |
| #202, #203 | feat / fix | Apply Voca branding and use the template menu-bar mark |
| #204 | feat | Support modifier-plus-key quick-dictation shortcuts |
| #205 | feat | Add the Parakeet TDT-CTC 110M English model |
| #207 | feat | Refresh output polish, power controls, and the settings shell |
| #208 | fix | Prevent a stale clipboard value from replacing a transcription |
| #209 | fix | Serialize model downloads and loads |
| #210 | feat | Add a configurable recording overlay |
| #211 | feat | Let users delete downloaded models |
| #215 | feat | Add a menu-bar microphone switcher |
| #216 | fix | Retire AVAudioEngine cleanly after configuration changes |
| #217 | fix | Remove the rectangular overlay glow |
| #218 | ui | Redesign the website with the Voca warm-paper system |
| #219, #220 | docs | Refresh VocaHQ links, shields, and project-family documentation |
| #221, #222 | docs(web) | Clarify beta/macOS support and list current nightly engines and models |

### Version surfaces

- `scripts/build.sh` now defaults `APP_VERSION` and the generated app Info.plist to **0.8.0**.
- The redesigned site reads its stable version, release page, and DMG URL from `web/data/product.toml`. It intentionally remains at the latest published v0.7.2 until v0.8.0 is tagged and its artifacts exist; updating it in this pre-release PR would point visitors at a non-existent download.

### Validation

- Rebased onto `main` at `7c33336` (`fix: remove rectangular overlay glow (#217)`).
- `swift test` on the rebased head.
- A signed and notarized PR build is requested after the force-with-lease push, so the test DMG is produced from the exact rebased commit.

### Release plan after merge

1. Tag and push `v0.8.0`; `release.yml` builds, signs, notarizes, and creates the draft release.
2. Use `/private/tmp/RELEASE_NOTES_v0.8.0.md` as the draft GitHub Release body, then verify its attached artifacts.
3. Publish the release; the Homebrew tap and website deploy workflows follow publication.
