### PR TITLE
chore: add Cloud Agent environment for the Hugo website

### DIFF
--- a/.cursor/environment.json
+++ b/.cursor/environment.json
@@ -1,0 +1,14 @@
+{
+  "name": "VocaMac Website (Hugo)",
+  "install": ".cursor/install.sh",
+  "terminals": [
+    {
+      "name": "hugo-server",
+      "command": "cd web && hugo server --bind 0.0.0.0 --port 1313",
+      "description": "Hugo dev server for the VocaMac marketing website (web/). Serves http://localhost:1313 with live reload."
+    }
+  ],
+  "ports": [
+    { "name": "hugo", "port": 1313 }
+  ]
+}

--- a/.cursor/install.sh
+++ b/.cursor/install.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+#
+# Cloud Agent install script for VocaMac.
+#
+# VocaMac is primarily a native macOS menu bar app (Swift + SwiftUI) that depends
+# on AppKit, CoreML and AVFoundation, so `swift build`/`swift test` only work on
+# macOS. This Cloud Agent runs on Linux, so the reproducible end-to-end dev
+# experience here is the marketing website in `web/`, a Hugo site.
+#
+# This script provisions the Hugo (extended) toolchain and verifies the site
+# builds. It is idempotent: re-running it is a no-op once Hugo is installed.
+set -euo pipefail
+
+# Pinned to match the version the site is developed/deployed with. `latest` is
+# used in CI, but pin here for deterministic Cloud Agent builds.
+HUGO_VERSION="0.164.0"
+INSTALL_DIR="/usr/local/bin"
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+log() { echo "[install] $*"; }
+
+install_hugo() {
+  local arch hugo_arch url tmp
+  arch="$(uname -m)"
+  case "$arch" in
+    x86_64) hugo_arch="amd64" ;;
+    aarch64 | arm64) hugo_arch="arm64" ;;
+    *) echo "[install] Unsupported architecture: $arch" >&2; exit 1 ;;
+  esac
+
+  url="https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/hugo_extended_${HUGO_VERSION}_linux-${hugo_arch}.tar.gz"
+  tmp="$(mktemp -d)"
+  trap 'rm -rf "$tmp"' RETURN
+
+  log "Downloading Hugo extended v${HUGO_VERSION} (${hugo_arch})"
+  curl -fsSL "$url" -o "$tmp/hugo.tar.gz"
+  tar -xzf "$tmp/hugo.tar.gz" -C "$tmp" hugo
+  sudo install -m 0755 "$tmp/hugo" "${INSTALL_DIR}/hugo"
+}
+
+# Install Hugo only if the pinned extended version is not already present.
+if command -v hugo >/dev/null 2>&1 \
+  && hugo version | grep -q "v${HUGO_VERSION}" \
+  && hugo version | grep -qi "extended"; then
+  log "Hugo extended v${HUGO_VERSION} already installed — skipping"
+else
+  install_hugo
+fi
+
+hugo version
+
+# Verify the website builds cleanly. Output (web/public, web/resources) is
+# gitignored; this both validates the toolchain and warms Hugo's caches.
+log "Building website (cd web && hugo --minify --gc)"
+( cd "${ROOT}/web" && hugo --minify --gc )
+log "Website build succeeded"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a Cloud Agent development environment for VocaMac.

VocaMac's primary product is a native macOS menu bar app (Swift + SwiftUI) that depends on AppKit, CoreML, and AVFoundation, so `swift build` / `swift test` only work on macOS (CI runs those on `macos-15`). A Cloud Agent runs on Linux, so the reproducible end-to-end development experience it can offer is the **marketing website** in `web/`, which is a **Hugo** site (built on `ubuntu-latest` in CI and deployed to GitHub Pages).

This environment provisions Hugo and serves the site so future Cloud Agents can iterate on `web/` end to end.

## Changes

- `​.cursor/install.sh` — idempotently installs **Hugo extended** (pinned to `0.164.0`) into `/usr/local/bin` and runs `hugo --minify --gc` in `web/` to verify the toolchain and site build. Re-running is a no-op once Hugo is present.
- `​.cursor/environment.json` — sets `install` to the script above and starts a `hugo-server` terminal (`cd web && hugo server --bind 0.0.0.0 --port 1313`), exposing port `1313` with live reload.

## Validation

- `hugo --minify --gc` builds 22 pages cleanly.
- Install script is idempotent (second run skips the Hugo download).
- Dev server returns `HTTP 200` on `/`, `/features/push-to-talk/`, and `/screenshots/` with the expected titles/content.

## Notes

- The macOS Swift app is intentionally out of scope for this Linux environment; it cannot compile without Apple frameworks. Contributors continue to build/test the app on macOS via `make build` / `swift test`.
- Hugo emits a non-fatal deprecation warning for `languageCode` in `web/hugo.toml`; left as-is to keep this change scoped to environment setup.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2d4538c3-4a06-41f9-ae4d-2481f224266a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2d4538c3-4a06-41f9-ae4d-2481f224266a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

