### PR TITLE
feat: add headless file transcription CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ make install
 
 This builds VocaMac, installs it to `/Applications`, and launches it. Permissions are granted directly to VocaMac, just like the DMG method.
 
-### Option 4: CLI Commands (For Developers)
+### Option 4: Launch/Build Helper Commands (For Developers)
 
 ```bash
 git clone https://github.com/VocaHQ/vocamac.git
@@ -174,11 +174,79 @@ cd vocamac
 make install-cli
 ```
 
-This installs two commands to `~/.local/bin`:
+This installs two development helpers to `~/.local/bin`:
+
 - `vocamac &`: Launch VocaMac in background
 - `vocamac-build`: Rebuild from source after pulling updates
 
-> **Permissions note:** In CLI mode, macOS assigns permissions to your **terminal app** (Terminal, iTerm2, etc.) rather than VocaMac itself. Grant Microphone, Accessibility, and Input Monitoring to your terminal app instead.
+These are launch/build helpers, not the headless transcription interface described below. Because the launcher runs a development binary from Terminal, macOS may assign its GUI permissions to the terminal app rather than the installed VocaMac app.
+
+### Headless File Transcription CLI
+
+The installed app binary can transcribe an existing audio file without opening the GUI, recording the microphone, injecting text, or disturbing an already-running VocaMac instance:
+
+```bash
+/Applications/VocaMac.app/Contents/MacOS/VocaMac \
+  --transcribe-file /path/to/audio.wav \
+  --json
+```
+
+By default, the command follows the model and language currently selected in the VocaMac app. `auto` language selection is passed to the engine as automatic detection. You can override either choice for one request without changing the saved app preferences:
+
+```bash
+/Applications/VocaMac.app/Contents/MacOS/VocaMac \
+  --transcribe-file /path/to/audio.wav \
+  --model parakeet-tdt-0.6b-v2 \
+  --language en \
+  --json
+```
+
+The model must already be downloaded in VocaMac. Headless mode never downloads a missing model automatically. Input is validated and converted with AVFoundation to mono, 16 kHz, Float32 PCM; files are limited to 500 MB and 30 minutes.
+
+Successful transcription writes exactly one JSON object to stdout:
+
+```json
+{
+  "audio_length_seconds": 4.3,
+  "detected_language": "en",
+  "duration_seconds": 0.72,
+  "engine": "parakeet",
+  "model": "parakeet-tdt-0.6b-v2",
+  "text": "Transcribed text"
+}
+```
+
+`engine` is one of `whisperkit`, `parakeet`, `apple_speech`, or `sherpa_onnx`. Operational messages continue to VocaMac's unified and file logs, keeping stdout safe for JSON consumers such as VocaPhone.
+
+List every known model and its current state with:
+
+```bash
+/Applications/VocaMac.app/Contents/MacOS/VocaMac --list-models --json
+```
+
+The response is a `models` array whose entries have this schema:
+
+```json
+{
+  "id": "parakeet-tdt-0.6b-v2",
+  "name": "Parakeet v2 (English)",
+  "engine": "parakeet",
+  "selected": true,
+  "downloaded": true,
+  "supported": true,
+  "system_managed": false
+}
+```
+
+Failures exit nonzero and write a JSON error to stderr, for example:
+
+```json
+{"error":"model_not_downloaded","message":"Model is not downloaded: small"}
+```
+
+Stable error categories are `invalid_arguments`, `invalid_audio`, `model_not_found`, `model_not_downloaded`, `model_unsupported`, and `transcription_failed`. Use `--help` for command syntax; it exits without launching the GUI.
+
+One-shot CLI mode loads the selected model in a separate process for each request. This preserves isolation from the running menu bar app, but the first request has the normal model-loading cost.
 
 ### First Launch
 
@@ -336,17 +404,19 @@ Open Settings from the menu bar popover or with **⌘,**
 VocaMac is built with a clean, modular architecture using native Swift and SwiftUI:
 
 ```
-VocaMacApp (SwiftUI MenuBarExtra)
-├── AppState          - Central observable state
-├── HotKeyManager     - CGEventTap global hotkey listener
-├── AudioEngine       - AVAudioEngine mic capture (16kHz, mono, Float32)
-├── WhisperService    - WhisperKit async transcription wrapper
-│   └── ModelManager  - Model download, storage, device recommendations
-│       └── SystemInfo - Hardware detection & model recommendation
-├── SoundManager      - Audio feedback (start/stop recording cues)
-├── TextInjector      - Clipboard + Cmd+V text injection
-├── MenuBarView       - Status popover UI
-└── SettingsView      - Configuration tabs (General, Models, Audio, Debug, About)
+VocaMacMain (pre-SwiftUI dispatcher)
+├── CLIEntrypoint
+│   ├── AudioFileLoader       - Existing-file validation and 16 kHz mono conversion
+│   ├── ModelManager          - Saved model resolution and local-asset checks
+│   └── TranscriptionRouter   - Whisper, Parakeet, Apple Speech, and sherpa-onnx
+└── VocaMacApp (SwiftUI MenuBarExtra)
+    ├── AppState              - Central observable state
+    ├── HotKeyManager         - CGEventTap global hotkey listener
+    ├── AudioEngine           - AVAudioEngine mic capture (16 kHz, mono, Float32)
+    ├── SoundManager          - Audio feedback (start/stop recording cues)
+    ├── TextInjector          - Clipboard + Cmd+V text injection
+    ├── MenuBarView           - Status popover UI
+    └── SettingsView          - Configuration tabs (General, Models, Audio, Debug, About)
 ```
 
 For detailed documentation, see:
@@ -370,7 +440,11 @@ VocaMac/
 ├── Sources/
 │   └── VocaMac/
 │       ├── App/
-│       │   └── VocaMacApp.swift    # Entry point, MenuBarExtra
+│       │   └── VocaMacApp.swift    # SwiftUI MenuBarExtra app
+│       ├── CLI/
+│       │   ├── CLIEntrypoint.swift # Process dispatcher and headless execution
+│       │   ├── HeadlessTranscriber.swift # Model resolution and router orchestration
+│       │   └── AudioFileLoader.swift # File validation and PCM conversion
 │       ├── Views/
 │       │   ├── MenuBarView.swift   # Menu bar popover
 │       │   └── SettingsView.swift  # Settings window (5 tabs)
@@ -392,7 +466,7 @@ VocaMac/
 ├── Makefile                        # make build, install, test, clean
 ├── scripts/
 │   ├── build.sh                    # Build .app bundle (dev)
-│   ├── install.sh                  # Install to /Applications or CLI
+│   ├── install.sh                  # Install app or development helpers
 │   └── uninstall.sh                # Full uninstall & cleanup
 ├── web/                            # Marketing website (vocamac.com)
 ├── docs/

--- a/README.md
+++ b/README.md
@@ -203,6 +203,8 @@ By default, the command follows the model and language currently selected in the
 
 The model must already be downloaded in VocaMac. Headless mode never downloads a missing model automatically. Input is validated and converted with AVFoundation to mono, 16 kHz, Float32 PCM; files are limited to 500 MB and 30 minutes.
 
+Only the selected model and language follow your app preferences. Translate-to-English and WhisperKit custom vocabulary are always off in headless mode, even if enabled in the app.
+
 Successful transcription writes exactly one JSON object to stdout:
 
 ```json

--- a/Sources/VocaMac/App/VocaMacApp.swift
+++ b/Sources/VocaMac/App/VocaMacApp.swift
@@ -284,10 +284,13 @@ struct VocaMacApp: App {
             app.terminate()
         }
 
-        // Also kill by process name for direct binary execution (no bundle ID)
+        // Also kill by process name for direct binary execution (no bundle ID).
+        // Match against the full command line (pid + args) so a running
+        // headless CLI job (e.g. `VocaMac --transcribe-file ... --json`) is
+        // never mistaken for another GUI instance and killed mid-job.
         let task = Process()
         task.executableURL = URL(fileURLWithPath: "/usr/bin/pgrep")
-        task.arguments = ["-f", "VocaMac"]
+        task.arguments = ["-fl", "VocaMac"]
 
         let pipe = Pipe()
         task.standardOutput = pipe
@@ -297,8 +300,12 @@ struct VocaMacApp: App {
             task.waitUntilExit()
             let data = pipe.fileHandleForReading.readDataToEndOfFile()
             if let output = String(data: data, encoding: .utf8) {
-                let pids = output.split(separator: "\n").compactMap { Int32($0) }
-                for pid in pids where pid != currentPID {
+                for line in output.split(separator: "\n") {
+                    let components = line.split(separator: " ", maxSplits: 1)
+                    guard let pidField = components.first, let pid = Int32(pidField),
+                          pid != currentPID else { continue }
+                    let commandLine = components.count > 1 ? components[1] : ""
+                    guard !Self.isHeadlessCLICommandLine(commandLine) else { continue }
                     VocaLogger.info(.general, "Killing previous VocaMac process (PID \(pid))")
                     kill(pid, SIGTERM)
                 }
@@ -306,6 +313,12 @@ struct VocaMacApp: App {
         } catch {
             // pgrep not found or failed — not critical
         }
+    }
+
+    /// Recognizes the headless CLI flags from `CLICommand.cliFlags` so the GUI
+    /// leaves an in-flight one-shot transcription running instead of killing it.
+    private static func isHeadlessCLICommandLine(_ commandLine: some StringProtocol) -> Bool {
+        CLICommand.cliFlags.contains { commandLine.contains($0) }
     }
 }
 

--- a/Sources/VocaMac/App/VocaMacApp.swift
+++ b/Sources/VocaMac/App/VocaMacApp.swift
@@ -220,7 +220,6 @@ final class OnboardingWindowManager: ObservableObject {
     }
 }
 
-@main
 struct VocaMacApp: App {
     @StateObject private var appState = AppState.production()
     @StateObject private var settingsManager = SettingsWindowManager()

--- a/Sources/VocaMac/CLI/AudioFileLoader.swift
+++ b/Sources/VocaMac/CLI/AudioFileLoader.swift
@@ -1,0 +1,189 @@
+// AudioFileLoader.swift
+// VocaMac
+//
+// Validates and normalizes an audio file for all transcription engines.
+
+import AVFoundation
+import Foundation
+
+/// Normalized PCM input expected by VocaMac's transcription services.
+struct LoadedAudioFile: Equatable {
+    let samples: [Float]
+    let durationSeconds: Double
+}
+
+/// Audio-loading seam used by headless transcription tests.
+protocol AudioFileLoading {
+    func loadAudio(at url: URL) throws -> LoadedAudioFile
+}
+
+/// Loads regular audio files as mono, 16 kHz, Float32 PCM.
+final class AudioFileLoader: AudioFileLoading {
+    static let sampleRate = 16_000.0
+    static let maximumFileSizeBytes: Int64 = 500 * 1_024 * 1_024
+    static let maximumDurationSeconds = 30 * 60.0
+
+    private let fileManager: FileManager
+
+    init(fileManager: FileManager = .default) {
+        self.fileManager = fileManager
+    }
+
+    func loadAudio(at url: URL) throws -> LoadedAudioFile {
+        let standardizedURL = url.standardizedFileURL
+        guard fileManager.fileExists(atPath: standardizedURL.path) else {
+            throw CLIError(.invalidAudio, "Audio file does not exist: \(standardizedURL.path)")
+        }
+
+        let values: URLResourceValues
+        do {
+            values = try standardizedURL.resourceValues(forKeys: [.isRegularFileKey, .fileSizeKey])
+        } catch {
+            throw CLIError(.invalidAudio, "Could not inspect the audio file.")
+        }
+        guard values.isRegularFile == true else {
+            throw CLIError(.invalidAudio, "Audio path must refer to a regular file.")
+        }
+        if let fileSize = values.fileSize, Int64(fileSize) > Self.maximumFileSizeBytes {
+            throw CLIError(.invalidAudio, "Audio file exceeds the 500 MB limit.")
+        }
+
+        let audioFile: AVAudioFile
+        do {
+            audioFile = try AVAudioFile(
+                forReading: standardizedURL,
+                commonFormat: .pcmFormatFloat32,
+                interleaved: false
+            )
+        } catch {
+            throw CLIError(.invalidAudio, "Audio file is unreadable or has an unsupported format.")
+        }
+
+        let sourceFormat = audioFile.processingFormat
+        guard sourceFormat.sampleRate > 0, sourceFormat.channelCount > 0, audioFile.length > 0 else {
+            throw CLIError(.invalidAudio, "Audio file is empty.")
+        }
+
+        let sourceDuration = Double(audioFile.length) / sourceFormat.sampleRate
+        guard sourceDuration.isFinite, sourceDuration <= Self.maximumDurationSeconds else {
+            throw CLIError(.invalidAudio, "Audio duration exceeds the 30 minute limit.")
+        }
+
+        guard let targetFormat = AVAudioFormat(
+            commonFormat: .pcmFormatFloat32,
+            sampleRate: Self.sampleRate,
+            channels: 1,
+            interleaved: false
+        ), let converter = AVAudioConverter(from: sourceFormat, to: targetFormat) else {
+            throw CLIError(.invalidAudio, "Audio could not be converted to 16 kHz mono PCM.")
+        }
+
+        let samples = try convert(
+            audioFile: audioFile,
+            sourceFormat: sourceFormat,
+            targetFormat: targetFormat,
+            converter: converter
+        )
+        guard !samples.isEmpty else {
+            throw CLIError(.invalidAudio, "Audio file contains no samples.")
+        }
+        guard samples.allSatisfy(\.isFinite) else {
+            throw CLIError(.invalidAudio, "Audio file contains invalid samples.")
+        }
+        guard samples.contains(where: { abs($0) > 0.000_000_1 }) else {
+            throw CLIError(.invalidAudio, "Audio file is silent.")
+        }
+
+        return LoadedAudioFile(
+            samples: samples,
+            durationSeconds: Double(samples.count) / Self.sampleRate
+        )
+    }
+
+    /// Stream through AVAudioConverter so large-but-valid source files are not
+    /// first decoded into a second full-size in-memory source buffer.
+    private func convert(
+        audioFile: AVAudioFile,
+        sourceFormat: AVAudioFormat,
+        targetFormat: AVAudioFormat,
+        converter: AVAudioConverter
+    ) throws -> [Float] {
+        let outputCapacity: AVAudioFrameCount = 16_384
+        var samples: [Float] = []
+        samples.reserveCapacity(Int(min(
+            Double(Int.max),
+            (Double(audioFile.length) / sourceFormat.sampleRate * Self.sampleRate).rounded(.up)
+        )))
+
+        var readFailure: Error?
+        var zeroLengthPasses = 0
+
+        while true {
+            guard let outputBuffer = AVAudioPCMBuffer(
+                pcmFormat: targetFormat,
+                frameCapacity: outputCapacity
+            ) else {
+                throw CLIError(.invalidAudio, "Could not allocate an audio conversion buffer.")
+            }
+
+            var conversionError: NSError?
+            let status = converter.convert(to: outputBuffer, error: &conversionError) {
+                requestedFrames, inputStatus in
+                guard audioFile.framePosition < audioFile.length else {
+                    inputStatus.pointee = .endOfStream
+                    return nil
+                }
+                guard let inputBuffer = AVAudioPCMBuffer(
+                    pcmFormat: sourceFormat,
+                    frameCapacity: requestedFrames
+                ) else {
+                    inputStatus.pointee = .noDataNow
+                    return nil
+                }
+
+                do {
+                    try audioFile.read(into: inputBuffer, frameCount: requestedFrames)
+                } catch {
+                    readFailure = error
+                    inputStatus.pointee = .endOfStream
+                    return nil
+                }
+
+                guard inputBuffer.frameLength > 0 else {
+                    inputStatus.pointee = .endOfStream
+                    return nil
+                }
+                inputStatus.pointee = .haveData
+                return inputBuffer
+            }
+
+            if let readFailure {
+                throw CLIError(.invalidAudio, "Audio file could not be read: \(readFailure.localizedDescription)")
+            }
+            if let conversionError {
+                throw CLIError(.invalidAudio, "Audio conversion failed: \(conversionError.localizedDescription)")
+            }
+
+            if outputBuffer.frameLength > 0,
+               let channel = outputBuffer.floatChannelData?[0] {
+                samples.append(contentsOf: UnsafeBufferPointer(
+                    start: channel,
+                    count: Int(outputBuffer.frameLength)
+                ))
+                zeroLengthPasses = 0
+            } else {
+                zeroLengthPasses += 1
+            }
+
+            if status == .endOfStream { break }
+            if status == .error {
+                throw CLIError(.invalidAudio, "Audio conversion failed.")
+            }
+            guard zeroLengthPasses < 3 else {
+                throw CLIError(.invalidAudio, "Audio conversion produced no samples.")
+            }
+        }
+
+        return samples
+    }
+}

--- a/Sources/VocaMac/CLI/CLICommand.swift
+++ b/Sources/VocaMac/CLI/CLICommand.swift
@@ -1,0 +1,110 @@
+// CLICommand.swift
+// VocaMac
+//
+// Parses the one-shot, headless command-line interface before SwiftUI starts.
+
+import Foundation
+
+/// Determines whether process arguments belong to the GUI or headless CLI.
+enum CLIInvocationMode: Equatable {
+    case gui
+    case cli
+}
+
+/// A validated VocaMac command-line operation.
+enum CLICommand: Equatable {
+    case help
+    case transcribeFile(path: String, model: String?, language: String?)
+    case listModels
+
+    /// Any explicit arguments are handled before SwiftUI constructs the app.
+    /// This makes unknown arguments fail safely instead of opening the GUI.
+    static func invocationMode(arguments: [String]) -> CLIInvocationMode {
+        arguments.isEmpty ? .gui : .cli
+    }
+
+    /// Parse arguments excluding the executable path.
+    static func parse(arguments: [String]) throws -> CLICommand {
+        if arguments.contains("--help") || arguments.contains("-h") {
+            return .help
+        }
+
+        var audioPath: String?
+        var model: String?
+        var language: String?
+        var wantsList = false
+        var wantsJSON = false
+        var index = 0
+
+        while index < arguments.count {
+            let argument = arguments[index]
+            switch argument {
+            case "--transcribe-file":
+                guard audioPath == nil else {
+                    throw CLIError(.invalidArguments, "--transcribe-file may only be provided once.")
+                }
+                audioPath = try value(after: argument, in: arguments, index: &index)
+            case "--list-models":
+                guard !wantsList else {
+                    throw CLIError(.invalidArguments, "--list-models may only be provided once.")
+                }
+                wantsList = true
+            case "--model":
+                guard model == nil else {
+                    throw CLIError(.invalidArguments, "--model may only be provided once.")
+                }
+                model = try value(after: argument, in: arguments, index: &index)
+            case "--language":
+                guard language == nil else {
+                    throw CLIError(.invalidArguments, "--language may only be provided once.")
+                }
+                language = try value(after: argument, in: arguments, index: &index)
+            case "--json":
+                guard !wantsJSON else {
+                    throw CLIError(.invalidArguments, "--json may only be provided once.")
+                }
+                wantsJSON = true
+            default:
+                throw CLIError(.invalidArguments, "Unknown argument: \(argument)")
+            }
+            index += 1
+        }
+
+        guard wantsJSON else {
+            throw CLIError(.invalidArguments, "Headless commands require --json.")
+        }
+        guard wantsList != (audioPath != nil) else {
+            throw CLIError(
+                .invalidArguments,
+                "Specify exactly one of --transcribe-file or --list-models."
+            )
+        }
+
+        if wantsList {
+            guard model == nil, language == nil else {
+                throw CLIError(.invalidArguments, "--model and --language only apply to --transcribe-file.")
+            }
+            return .listModels
+        }
+
+        guard let audioPath else {
+            throw CLIError(.invalidArguments, "Missing value for --transcribe-file.")
+        }
+        return .transcribeFile(path: audioPath, model: model, language: language)
+    }
+
+    private static func value(
+        after argument: String,
+        in arguments: [String],
+        index: inout Int
+    ) throws -> String {
+        let valueIndex = index + 1
+        guard valueIndex < arguments.count,
+              !arguments[valueIndex].hasPrefix("--"),
+              !arguments[valueIndex].isEmpty else {
+            throw CLIError(.invalidArguments, "Missing value for \(argument).")
+        }
+        index = valueIndex
+        return arguments[valueIndex]
+    }
+}

--- a/Sources/VocaMac/CLI/CLICommand.swift
+++ b/Sources/VocaMac/CLI/CLICommand.swift
@@ -17,10 +17,19 @@ enum CLICommand: Equatable {
     case transcribeFile(path: String, model: String?, language: String?)
     case listModels
 
-    /// Any explicit arguments are handled before SwiftUI constructs the app.
-    /// This makes unknown arguments fail safely instead of opening the GUI.
+    /// Flags that unambiguously request the headless CLI. Any other launch
+    /// arguments (e.g. GUI-only `--restarted` from Settings → Debug → Restart)
+    /// fall through to the normal SwiftUI app. Also used by
+    /// `VocaMacApp.ensureSingleInstance()` to avoid killing an in-flight CLI job.
+    static let cliFlags: Set<String> = [
+        "--transcribe-file", "--list-models", "--help", "-h",
+    ]
+
+    /// Only dispatch to the headless CLI when a recognized CLI flag is present.
+    /// This makes unknown/GUI-only arguments fail safely into the GUI instead
+    /// of being rejected by the CLI parser before the app ever launches.
     static func invocationMode(arguments: [String]) -> CLIInvocationMode {
-        arguments.isEmpty ? .gui : .cli
+        arguments.contains(where: cliFlags.contains) ? .cli : .gui
     }
 
     /// Parse arguments excluding the executable path.

--- a/Sources/VocaMac/CLI/CLIEntrypoint.swift
+++ b/Sources/VocaMac/CLI/CLIEntrypoint.swift
@@ -1,0 +1,217 @@
+// CLIEntrypoint.swift
+// VocaMac
+//
+// Process dispatcher and stdout-safe CLI execution.
+
+import Darwin
+import Foundation
+
+/// Runs headless commands and emits stable JSON without constructing AppState.
+final class CLIEntrypoint {
+    typealias DataSink = (Data) -> Void
+
+    private let headlessTranscriber: HeadlessTranscriber
+    private let stdout: DataSink
+    private let stderr: DataSink
+    private let isolateOperationalStreams: Bool
+    private let encoder: JSONEncoder
+
+    init(
+        headlessTranscriber: HeadlessTranscriber,
+        stdout: @escaping DataSink = { FileHandle.standardOutput.write($0) },
+        stderr: @escaping DataSink = { FileHandle.standardError.write($0) },
+        isolateOperationalStreams: Bool = false
+    ) {
+        self.headlessTranscriber = headlessTranscriber
+        self.stdout = stdout
+        self.stderr = stderr
+        self.isolateOperationalStreams = isolateOperationalStreams
+        self.encoder = JSONEncoder()
+        self.encoder.outputFormatting = [.sortedKeys, .withoutEscapingSlashes]
+    }
+
+    /// Production dependencies intentionally include no AppState, audio input,
+    /// hotkey, onboarding, text injection, or SwiftUI service.
+    static func production() -> CLIEntrypoint {
+        let modelManager = ModelManager()
+        let preferences = AppCLIPreferencesReader()
+        let transcriber = HeadlessTranscriber(
+            modelManager: modelManager,
+            preferences: preferences,
+            audioLoader: AudioFileLoader(),
+            transcriberFactory: { language in
+                TranscriptionRouter(languagePreferenceProvider: { language })
+            }
+        )
+        return CLIEntrypoint(
+            headlessTranscriber: transcriber,
+            isolateOperationalStreams: true
+        )
+    }
+
+    /// Execute arguments excluding the executable path and return a process code.
+    func run(arguments: [String]) async -> Int32 {
+        let command: CLICommand
+        do {
+            command = try CLICommand.parse(arguments: arguments)
+        } catch {
+            return emit(error: error)
+        }
+
+        switch command {
+        case .help:
+            stdout(Data(Self.helpText.utf8))
+            return 0
+        case .listModels:
+            return await runJSONOperation {
+                self.headlessTranscriber.listModels()
+            }
+        case .transcribeFile(let path, let model, let language):
+            return await runJSONOperation {
+                try await self.headlessTranscriber.transcribe(
+                    fileURL: URL(fileURLWithPath: path),
+                    modelOverride: model,
+                    languageOverride: language
+                )
+            }
+        }
+    }
+
+    private func runJSONOperation<Response: Encodable>(
+        _ operation: () async throws -> Response
+    ) async -> Int32 {
+        let isolatedStreams = isolateOperationalStreams ? beginStandardStreamIsolation() : nil
+        defer { finishStandardStreamIsolation(isolatedStreams) }
+
+        do {
+            let response = try await operation()
+            let data = try encodedLine(response)
+            if let descriptor = isolatedStreams?.stdout {
+                write(data, to: descriptor)
+            } else {
+                stdout(data)
+            }
+            return 0
+        } catch {
+            return emit(error: error, descriptor: isolatedStreams?.stderr)
+        }
+    }
+
+    private func emit(error: Error, descriptor: Int32? = nil) -> Int32 {
+        let cliError = error as? CLIError
+            ?? CLIError(.transcriptionFailed, error.localizedDescription)
+        VocaLogger.error(.general, "CLI \(cliError.category.rawValue): \(cliError.message)")
+
+        do {
+            let data = try encodedLine(CLIErrorResponse(
+                error: cliError.category,
+                message: cliError.message
+            ))
+            if let descriptor {
+                write(data, to: descriptor)
+            } else {
+                stderr(data)
+            }
+        } catch {
+            let fallback = Data("{\"error\":\"transcription_failed\",\"message\":\"Could not encode error response.\"}\n".utf8)
+            if let descriptor {
+                write(fallback, to: descriptor)
+            } else {
+                stderr(fallback)
+            }
+        }
+        return cliError.exitCode
+    }
+
+    private func encodedLine<Value: Encodable>(_ value: Value) throws -> Data {
+        var data = try encoder.encode(value)
+        data.append(0x0A)
+        return data
+    }
+
+    private struct IsolatedStandardStreams {
+        let stdout: Int32?
+        let stderr: Int32?
+    }
+
+    /// Redirect process streams while engines run. JSON is written through a
+    /// saved stdout descriptor, while categorized failures use saved stderr.
+    /// This protects both contracts from direct third-party runtime logging.
+    private func beginStandardStreamIsolation() -> IsolatedStandardStreams {
+        Darwin.fflush(nil)
+        return IsolatedStandardStreams(
+            stdout: beginIsolation(of: STDOUT_FILENO),
+            stderr: beginIsolation(of: STDERR_FILENO)
+        )
+    }
+
+    private func beginIsolation(of descriptor: Int32) -> Int32? {
+        let savedDescriptor = Darwin.dup(descriptor)
+        guard savedDescriptor >= 0 else { return nil }
+
+        let nullDescriptor = Darwin.open("/dev/null", O_WRONLY)
+        guard nullDescriptor >= 0 else {
+            Darwin.close(savedDescriptor)
+            return nil
+        }
+        let result = Darwin.dup2(nullDescriptor, descriptor)
+        Darwin.close(nullDescriptor)
+        guard result >= 0 else {
+            Darwin.close(savedDescriptor)
+            return nil
+        }
+        return savedDescriptor
+    }
+
+    /// Production CLI mode exits immediately after `run` returns, so leave
+    /// the process streams attached to /dev/null through teardown. CoreML can
+    /// emit late background messages after transcription has returned.
+    private func finishStandardStreamIsolation(_ streams: IsolatedStandardStreams?) {
+        if let descriptor = streams?.stdout {
+            Darwin.close(descriptor)
+        }
+        if let descriptor = streams?.stderr {
+            Darwin.close(descriptor)
+        }
+    }
+
+    private func write(_ data: Data, to descriptor: Int32) {
+        data.withUnsafeBytes { rawBuffer in
+            guard var pointer = rawBuffer.baseAddress else { return }
+            var remaining = rawBuffer.count
+            while remaining > 0 {
+                let written = Darwin.write(descriptor, pointer, remaining)
+                guard written > 0 else { return }
+                pointer = pointer.advanced(by: written)
+                remaining -= written
+            }
+        }
+    }
+
+    static let helpText = """
+    VocaMac headless transcription
+
+    Usage:
+      VocaMac --transcribe-file <audio-path> --json [--model <id>] [--language <code>]
+      VocaMac --list-models --json
+      VocaMac --help
+
+    Omitting --model and --language follows the current VocaMac app preferences.
+    Models must already be downloaded; headless mode never opens the GUI or downloads models.
+    """ + "\n"
+}
+
+/// The actual process entrypoint decides CLI versus GUI before SwiftUI can
+/// construct `VocaMacApp` and its production AppState.
+@main
+enum VocaMacMain {
+    static func main() async {
+        let arguments = Array(CommandLine.arguments.dropFirst())
+        if CLICommand.invocationMode(arguments: arguments) == .cli {
+            let exitCode = await CLIEntrypoint.production().run(arguments: arguments)
+            Darwin.exit(exitCode)
+        }
+
+        VocaMacApp.main()
+    }
+}

--- a/Sources/VocaMac/CLI/CLIResponse.swift
+++ b/Sources/VocaMac/CLI/CLIResponse.swift
@@ -1,0 +1,102 @@
+// CLIResponse.swift
+// VocaMac
+//
+// Stable JSON types and error categories for local integrations.
+
+import Foundation
+
+/// Stable machine-readable failure categories exposed by the CLI.
+enum CLIErrorCategory: String, Codable {
+    case invalidArguments = "invalid_arguments"
+    case invalidAudio = "invalid_audio"
+    case modelNotFound = "model_not_found"
+    case modelNotDownloaded = "model_not_downloaded"
+    case modelUnsupported = "model_unsupported"
+    case transcriptionFailed = "transcription_failed"
+}
+
+/// A categorized error with a stable process exit code.
+struct CLIError: LocalizedError {
+    let category: CLIErrorCategory
+    let message: String
+
+    init(_ category: CLIErrorCategory, _ message: String) {
+        self.category = category
+        self.message = message
+    }
+
+    var errorDescription: String? { message }
+
+    var exitCode: Int32 {
+        switch category {
+        case .invalidArguments: return 2
+        case .invalidAudio: return 3
+        case .modelNotFound, .modelNotDownloaded, .modelUnsupported: return 4
+        case .transcriptionFailed: return 5
+        }
+    }
+}
+
+/// Successful file-transcription output.
+struct CLITranscriptionResponse: Codable, Equatable {
+    let text: String
+    let model: String
+    let engine: String
+    let detectedLanguage: String
+    let durationSeconds: Double
+    let audioLengthSeconds: Double
+
+    enum CodingKeys: String, CodingKey {
+        case text
+        case model
+        case engine
+        case detectedLanguage = "detected_language"
+        case durationSeconds = "duration_seconds"
+        case audioLengthSeconds = "audio_length_seconds"
+    }
+}
+
+/// One catalog entry returned by `--list-models`.
+struct CLIModelResponse: Codable, Equatable {
+    let id: String
+    let name: String
+    let engine: String
+    let selected: Bool
+    let downloaded: Bool
+    let supported: Bool
+    let systemManaged: Bool
+
+    enum CodingKeys: String, CodingKey {
+        case id
+        case name
+        case engine
+        case selected
+        case downloaded
+        case supported
+        case systemManaged = "system_managed"
+    }
+}
+
+/// Model-list envelope, allowing the schema to grow without changing the
+/// meaning of each model entry.
+struct CLIModelListResponse: Codable, Equatable {
+    let models: [CLIModelResponse]
+}
+
+/// Error envelope written to stderr.
+struct CLIErrorResponse: Codable, Equatable {
+    let error: CLIErrorCategory
+    let message: String
+}
+
+extension TranscriptionEngine {
+    /// Stable spelling used by external JSON clients.
+    var cliIdentifier: String {
+        switch self {
+        case .whisperKit: return "whisperkit"
+        case .parakeet: return "parakeet"
+        case .appleSpeech: return "apple_speech"
+        case .sherpaOnnx: return "sherpa_onnx"
+        }
+    }
+}

--- a/Sources/VocaMac/CLI/HeadlessTranscriber.swift
+++ b/Sources/VocaMac/CLI/HeadlessTranscriber.swift
@@ -1,0 +1,156 @@
+// HeadlessTranscriber.swift
+// VocaMac
+//
+// Resolves app preferences and runs one transcription without AppState.
+
+import Foundation
+
+/// Read-only access to the GUI app's persisted model and language choices.
+protocol CLIPreferencesReading {
+    var selectedModelIdentifier: String? { get }
+    var selectedLanguageIdentifier: String? { get }
+}
+
+/// Reads the VocaMac application preference domain without mutating it.
+struct AppCLIPreferencesReader: CLIPreferencesReading {
+    private static let applicationDomain = "com.vocamac.app"
+    private let defaults: UserDefaults
+
+    init(defaults: UserDefaults? = nil) {
+        if let defaults {
+            self.defaults = defaults
+        } else if Bundle.main.bundleIdentifier == Self.applicationDomain {
+            // Inside the app, .standard already is com.vocamac.app. Asking
+            // UserDefaults for its own identifier as a suite emits a warning.
+            self.defaults = .standard
+        } else {
+            self.defaults = UserDefaults(suiteName: Self.applicationDomain) ?? .standard
+        }
+    }
+
+    var selectedModelIdentifier: String? {
+        defaults.string(forKey: PreferenceKey.selectedModelSize)
+    }
+
+    var selectedLanguageIdentifier: String? {
+        defaults.string(forKey: PreferenceKey.selectedLanguage)
+    }
+}
+
+/// Headless orchestration that deliberately bypasses AppState and GUI services.
+final class HeadlessTranscriber {
+    typealias TranscriberFactory = (_ language: String?) -> SpeechTranscribing
+
+    private let modelManager: ModelManaging
+    private let preferences: CLIPreferencesReading
+    private let audioLoader: AudioFileLoading
+    private let transcriberFactory: TranscriberFactory
+
+    init(
+        modelManager: ModelManaging,
+        preferences: CLIPreferencesReading,
+        audioLoader: AudioFileLoading,
+        transcriberFactory: @escaping TranscriberFactory
+    ) {
+        self.modelManager = modelManager
+        self.preferences = preferences
+        self.audioLoader = audioLoader
+        self.transcriberFactory = transcriberFactory
+    }
+
+    convenience init(
+        modelManager: ModelManaging,
+        preferences: CLIPreferencesReading,
+        audioLoader: AudioFileLoading,
+        transcriber: SpeechTranscribing
+    ) {
+        self.init(
+            modelManager: modelManager,
+            preferences: preferences,
+            audioLoader: audioLoader,
+            transcriberFactory: { _ in transcriber }
+        )
+    }
+
+    /// Transcribe one file with an optional one-request model and language override.
+    func transcribe(
+        fileURL: URL,
+        modelOverride: String?,
+        languageOverride: String?
+    ) async throws -> CLITranscriptionResponse {
+        let model = try resolveModel(identifier: modelOverride ?? preferences.selectedModelIdentifier)
+        try validateAvailability(of: model)
+
+        let loadedAudio = try audioLoader.loadAudio(at: fileURL)
+        let language = resolvedLanguage(override: languageOverride)
+        let transcriber = transcriberFactory(language)
+        let modelIdentifier = modelManager.modelIdentifier(for: model)
+        let modelFolder = modelManager.modelFolder(for: model)
+
+        do {
+            try await transcriber.loadModel(name: modelIdentifier, folder: modelFolder)
+            let result = try await transcriber.transcribe(
+                audioData: loadedAudio.samples,
+                language: language,
+                translate: false,
+                vocabulary: ""
+            )
+            return CLITranscriptionResponse(
+                text: result.text,
+                model: model.rawValue,
+                engine: model.engine.cliIdentifier,
+                detectedLanguage: result.detectedLanguage,
+                durationSeconds: result.duration,
+                audioLengthSeconds: loadedAudio.durationSeconds
+            )
+        } catch let error as CLIError {
+            throw error
+        } catch {
+            throw CLIError(.transcriptionFailed, "Transcription failed: \(error.localizedDescription)")
+        }
+    }
+
+    /// Return the complete known model catalog with current runtime state.
+    func listModels() -> CLIModelListResponse {
+        let selectedModel = try? resolveModel(identifier: preferences.selectedModelIdentifier)
+        let entries = ModelSize.allCases.map { model in
+            CLIModelResponse(
+                id: model.rawValue,
+                name: model.displayName,
+                engine: model.engine.cliIdentifier,
+                selected: model == selectedModel,
+                downloaded: model.isSystemManaged || modelManager.isModelDownloaded(model),
+                supported: modelManager.isModelSupported(model),
+                systemManaged: model.isSystemManaged
+            )
+        }
+        return CLIModelListResponse(models: entries)
+    }
+
+    private func resolveModel(identifier: String?) throws -> ModelSize {
+        guard let identifier, !identifier.isEmpty else {
+            throw CLIError(.modelNotFound, "No model is selected in VocaMac.")
+        }
+        guard let model = ModelSize(rawValue: identifier) ?? modelManager.modelSize(from: identifier) else {
+            throw CLIError(.modelNotFound, "Unknown model: \(identifier)")
+        }
+        return model
+    }
+
+    private func validateAvailability(of model: ModelSize) throws {
+        guard modelManager.isModelSupported(model) else {
+            throw CLIError(.modelUnsupported, "Model is not supported on this Mac: \(model.rawValue)")
+        }
+        guard model.isSystemManaged || modelManager.isModelDownloaded(model) else {
+            throw CLIError(.modelNotDownloaded, "Model is not downloaded: \(model.rawValue)")
+        }
+        guard model.isSystemManaged || modelManager.modelFolder(for: model) != nil else {
+            throw CLIError(.modelNotDownloaded, "Model files are missing: \(model.rawValue)")
+        }
+    }
+
+    private func resolvedLanguage(override: String?) -> String? {
+        let identifier = override ?? preferences.selectedLanguageIdentifier ?? "auto"
+        return identifier == "auto" ? nil : identifier
+    }
+}

--- a/Sources/VocaMac/CLI/HeadlessTranscriber.swift
+++ b/Sources/VocaMac/CLI/HeadlessTranscriber.swift
@@ -89,6 +89,8 @@ final class HeadlessTranscriber {
 
         do {
             try await transcriber.loadModel(name: modelIdentifier, folder: modelFolder)
+            // Only model and language follow app prefs (see README); translate
+            // and custom vocabulary are intentionally always off headlessly.
             let result = try await transcriber.transcribe(
                 audioData: loadedAudio.samples,
                 language: language,
@@ -129,7 +131,9 @@ final class HeadlessTranscriber {
 
     private func resolveModel(identifier: String?) throws -> ModelSize {
         guard let identifier, !identifier.isEmpty else {
-            throw CLIError(.modelNotFound, "No model is selected in VocaMac.")
+            // Matches AppState's @AppStorage default, so a fresh install (or
+            // prefs that never persisted the key) behaves the same headlessly.
+            return .tiny
         }
         guard let model = ModelSize(rawValue: identifier) ?? modelManager.modelSize(from: identifier) else {
             throw CLIError(.modelNotFound, "Unknown model: \(identifier)")

--- a/Sources/VocaMac/Models/AppState.swift
+++ b/Sources/VocaMac/Models/AppState.swift
@@ -101,7 +101,7 @@ final class AppState: ObservableObject {
     @AppStorage("vocamac.maxRecordingDuration") var maxRecordingDuration: Int = 60
     @AppStorage("vocamac.selectedAudioDeviceID") var selectedAudioDeviceID: String = ""
     @AppStorage("vocamac.selectedAudioDeviceName") var selectedAudioDeviceName: String = ""
-    @AppStorage("vocamac.selectedModelSize") var selectedModelSize: String = ModelSize.tiny.rawValue
+    @AppStorage(PreferenceKey.selectedModelSize) var selectedModelSize: String = ModelSize.tiny.rawValue
     @AppStorage(PreferenceKey.selectedLanguage) var selectedLanguage: String = "auto"
     @AppStorage("vocamac.launchAtLogin") var launchAtLogin: Bool = false
     @AppStorage("vocamac.preserveClipboard") var preserveClipboard: Bool = true

--- a/Sources/VocaMac/Models/TranscriptionEngine.swift
+++ b/Sources/VocaMac/Models/TranscriptionEngine.swift
@@ -9,6 +9,7 @@ import Foundation
 /// Preference keys shared between `AppState`'s `@AppStorage` properties and
 /// services that must read the same setting outside the view layer.
 enum PreferenceKey {
+    static let selectedModelSize = "vocamac.selectedModelSize"
     static let selectedLanguage = "vocamac.selectedLanguage"
 }
 

--- a/Sources/VocaMac/Services/SherpaService.swift
+++ b/Sources/VocaMac/Services/SherpaService.swift
@@ -124,9 +124,27 @@ final class SherpaService: @unchecked Sendable {
 
     // MARK: - Model Management
 
-    /// Load a sherpa-onnx model from its extracted directory.
+    /// Load a sherpa-onnx model using the GUI's saved language preference.
+    /// Direct service callers retain the pre-headless behavior; the router
+    /// uses the explicit-language overload below.
     func loadModel(
         name modelName: String? = nil,
+        onPhaseChange: ((String) -> Void)? = nil
+    ) async throws {
+        let stored = UserDefaults.standard.string(forKey: PreferenceKey.selectedLanguage) ?? "auto"
+        try await loadModel(
+            name: modelName,
+            language: stored == "auto" ? nil : stored,
+            onPhaseChange: onPhaseChange
+        )
+    }
+
+    /// Load a sherpa-onnx model with a caller-supplied one-request language.
+    /// `nil` explicitly means automatic language selection and never falls
+    /// back to the saved GUI preference.
+    func loadModel(
+        name modelName: String? = nil,
+        language: String?,
         onPhaseChange: ((String) -> Void)? = nil
     ) async throws {
         unloadModel()
@@ -141,15 +159,13 @@ final class SherpaService: @unchecked Sendable {
             throw SherpaError.modelFilesMissing(directory.path)
         }
 
-        VocaLogger.info(.sherpaService, "Loading ONNX model: \(size.rawValue)...")
+        let preferredLanguage = Self.normalizedLoadLanguage(language)
+        VocaLogger.info(
+            .sherpaService,
+            "Loading ONNX model: \(size.rawValue) (language: \(preferredLanguage))..."
+        )
         let startTime = CFAbsoluteTimeGetCurrent()
         onPhaseChange?("Loading ONNX model…")
-
-        // The user's language preference influences config for SenseVoice
-        // (recognition language) and Canary (source language). Both are fixed
-        // at load time by the C API, so AppState reloads the active model when
-        // the preference changes (see reloadModelForLanguageChangeIfNeeded).
-        let preferredLanguage = UserDefaults.standard.string(forKey: PreferenceKey.selectedLanguage) ?? "auto"
 
         let created: OpaquePointer? = await withCheckedContinuation { continuation in
             DispatchQueue.global(qos: .userInitiated).async {
@@ -341,6 +357,13 @@ final class SherpaService: @unchecked Sendable {
     }
 
     // MARK: - Configuration
+
+    /// Convert the router's optional language into the value expected by the
+    /// sherpa config builders. A nil override is intentional `auto`, not a
+    /// request to reread persistent preferences.
+    static func normalizedLoadLanguage(_ language: String?) -> String {
+        language ?? "auto"
+    }
 
     /// Build the C recognizer config for a model spec.
     private static func recognizerConfig(

--- a/Sources/VocaMac/Services/TranscriptionRouter.swift
+++ b/Sources/VocaMac/Services/TranscriptionRouter.swift
@@ -23,9 +23,10 @@ final class TranscriptionRouter: @unchecked Sendable {
     /// against an engine that a concurrent load just unloaded.
     private let operationSerializer = LoadSerializer()
 
-    /// Supplies the language Apple Speech must prepare before transcription.
-    /// The GUI reads the normal app preference; headless callers inject the
-    /// one-request language without changing that preference.
+    /// Supplies the language engines with load-time language configuration
+    /// must prepare before transcription. The GUI reads the normal app
+    /// preference; headless callers inject the one-request language without
+    /// changing that preference.
     private let languagePreferenceProvider: () -> String?
 
     init(languagePreferenceProvider: @escaping () -> String? = {
@@ -122,7 +123,11 @@ extension TranscriptionRouter: SpeechTranscribing {
         case .appleSpeech:
             try await appleSpeech.loadModel(language: languagePreference, onPhaseChange: onPhaseChange)
         case .sherpaOnnx:
-            try await sherpa.loadModel(name: name, onPhaseChange: onPhaseChange)
+            try await sherpa.loadModel(
+                name: name,
+                language: languagePreference,
+                onPhaseChange: onPhaseChange
+            )
         }
 
         activeEngine = engine

--- a/Sources/VocaMac/Services/TranscriptionRouter.swift
+++ b/Sources/VocaMac/Services/TranscriptionRouter.swift
@@ -23,6 +23,18 @@ final class TranscriptionRouter: @unchecked Sendable {
     /// against an engine that a concurrent load just unloaded.
     private let operationSerializer = LoadSerializer()
 
+    /// Supplies the language Apple Speech must prepare before transcription.
+    /// The GUI reads the normal app preference; headless callers inject the
+    /// one-request language without changing that preference.
+    private let languagePreferenceProvider: () -> String?
+
+    init(languagePreferenceProvider: @escaping () -> String? = {
+        let stored = UserDefaults.standard.string(forKey: PreferenceKey.selectedLanguage) ?? "auto"
+        return stored == "auto" ? nil : stored
+    }) {
+        self.languagePreferenceProvider = languagePreferenceProvider
+    }
+
     // MARK: - Engine Resolution
 
     /// Resolve which engine owns a model identifier.
@@ -118,8 +130,7 @@ extension TranscriptionRouter: SpeechTranscribing {
 
     /// The transcription language the user selected, or nil for auto-detect.
     private var languagePreference: String? {
-        let stored = UserDefaults.standard.string(forKey: PreferenceKey.selectedLanguage) ?? "auto"
-        return stored == "auto" ? nil : stored
+        languagePreferenceProvider()
     }
 
     func transcribe(

--- a/Tests/VocaMacTests/CLITests.swift
+++ b/Tests/VocaMacTests/CLITests.swift
@@ -1,0 +1,403 @@
+// CLITests.swift
+// VocaMacTests
+
+import AVFoundation
+import XCTest
+@testable import VocaMac
+
+final class CLITests: XCTestCase {
+
+    // MARK: - Dispatch and parsing
+
+    func testNoCLIArgumentsRouteToGUI() {
+        XCTAssertEqual(CLICommand.invocationMode(arguments: []), .gui)
+    }
+
+    func testHelpRoutesToCLIAndDoesNotRunHeadlessServices() async {
+        let dependencies = makeDependencies(selectedModel: .tiny)
+        var standardOutput = Data()
+        let entrypoint = CLIEntrypoint(
+            headlessTranscriber: dependencies.headless,
+            stdout: { standardOutput.append($0) },
+            stderr: { _ in XCTFail("Help should not write an error.") }
+        )
+
+        XCTAssertEqual(CLICommand.invocationMode(arguments: ["--help"]), .cli)
+        let exitCode = await entrypoint.run(arguments: ["--help"])
+        XCTAssertEqual(exitCode, 0)
+        XCTAssertTrue(String(decoding: standardOutput, as: UTF8.self).contains("--transcribe-file"))
+        XCTAssertEqual(dependencies.audioLoader.loadCount, 0)
+        XCTAssertTrue(dependencies.transcriber.loadRequests.isEmpty)
+    }
+
+    func testMissingTranscribeFileValueFails() {
+        XCTAssertThrowsError(try CLICommand.parse(arguments: ["--transcribe-file", "--json"])) { error in
+            XCTAssertCLIError(error, category: .invalidArguments)
+        }
+    }
+
+    func testUnknownArgumentFails() {
+        XCTAssertThrowsError(try CLICommand.parse(arguments: ["--unknown", "--json"])) { error in
+            XCTAssertCLIError(error, category: .invalidArguments)
+        }
+    }
+
+    // MARK: - Preference and model resolution
+
+    func testOmittedModelReadsInjectedAppSelection() async throws {
+        let dependencies = makeDependencies(selectedModel: .parakeetV2)
+
+        let response = try await dependencies.headless.transcribe(
+            fileURL: URL(fileURLWithPath: "/mock/audio.wav"),
+            modelOverride: nil,
+            languageOverride: nil
+        )
+
+        XCTAssertEqual(response.model, ModelSize.parakeetV2.rawValue)
+        XCTAssertEqual(response.engine, "parakeet")
+        XCTAssertEqual(dependencies.transcriber.loadRequests.first?.name, ModelSize.parakeetV2.rawValue)
+    }
+
+    func testAppPreferencesReaderUsesInjectedDefaultsDomain() throws {
+        let suiteName = "VocaMac.CLITests.\(UUID().uuidString)"
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))
+        addTeardownBlock { defaults.removePersistentDomain(forName: suiteName) }
+        defaults.set(ModelSize.small.rawValue, forKey: PreferenceKey.selectedModelSize)
+        defaults.set("de", forKey: PreferenceKey.selectedLanguage)
+
+        let reader = AppCLIPreferencesReader(defaults: defaults)
+
+        XCTAssertEqual(reader.selectedModelIdentifier, ModelSize.small.rawValue)
+        XCTAssertEqual(reader.selectedLanguageIdentifier, "de")
+    }
+
+    func testExplicitModelOverridesWithoutChangingPreferences() async throws {
+        let dependencies = makeDependencies(selectedModel: .tiny)
+
+        let response = try await dependencies.headless.transcribe(
+            fileURL: URL(fileURLWithPath: "/mock/audio.wav"),
+            modelOverride: ModelSize.parakeetV2.rawValue,
+            languageOverride: nil
+        )
+
+        XCTAssertEqual(response.model, ModelSize.parakeetV2.rawValue)
+        XCTAssertEqual(dependencies.preferences.selectedModelIdentifier, ModelSize.tiny.rawValue)
+    }
+
+    func testSelectedIdentifiersRouteToEveryEngine() async throws {
+        let cases: [(ModelSize, String)] = [
+            (.small, "whisperkit"),
+            (.parakeetV2, "parakeet"),
+            (.appleSpeech, "apple_speech"),
+            (.moonshineTiny, "sherpa_onnx"),
+        ]
+
+        for (model, expectedEngine) in cases {
+            let dependencies = makeDependencies(selectedModel: model)
+            let response = try await dependencies.headless.transcribe(
+                fileURL: URL(fileURLWithPath: "/mock/audio.wav"),
+                modelOverride: nil,
+                languageOverride: nil
+            )
+
+            XCTAssertEqual(response.engine, expectedEngine, "Wrong engine for \(model.rawValue)")
+            XCTAssertEqual(
+                dependencies.transcriber.loadRequests.first?.name,
+                dependencies.modelManager.modelIdentifier(for: model)
+            )
+            XCTAssertEqual(
+                TranscriptionRouter.engine(
+                    forModelIdentifier: dependencies.modelManager.modelIdentifier(for: model)
+                ),
+                model.engine
+            )
+        }
+    }
+
+    func testOmittedLanguageReadsPreferenceAndAutoBecomesNil() async throws {
+        let selectedLanguage = makeDependencies(selectedModel: .small)
+        selectedLanguage.preferences.selectedLanguageIdentifier = "fr"
+        _ = try await selectedLanguage.headless.transcribe(
+            fileURL: URL(fileURLWithPath: "/mock/audio.wav"),
+            modelOverride: nil,
+            languageOverride: nil
+        )
+        XCTAssertEqual(selectedLanguage.transcriber.lastLanguage, "fr")
+
+        let automaticLanguage = makeDependencies(selectedModel: .small)
+        automaticLanguage.preferences.selectedLanguageIdentifier = "auto"
+        _ = try await automaticLanguage.headless.transcribe(
+            fileURL: URL(fileURLWithPath: "/mock/audio.wav"),
+            modelOverride: nil,
+            languageOverride: nil
+        )
+        XCTAssertNil(automaticLanguage.transcriber.lastLanguage)
+    }
+
+    func testMissingUnsupportedAndUndownloadedModelsAreDistinct() async {
+        let unknown = makeDependencies(selectedModelIdentifier: "does-not-exist")
+        await assertTranscriptionFailure(unknown.headless, category: .modelNotFound)
+
+        let unsupported = makeDependencies(selectedModel: .parakeetV2)
+        unsupported.modelManager.supportedModels.removeAll { $0 == .parakeetV2 }
+        await assertTranscriptionFailure(unsupported.headless, category: .modelUnsupported)
+
+        let undownloaded = makeDependencies(selectedModel: .small)
+        undownloaded.modelManager.downloadedModels.remove(.small)
+        await assertTranscriptionFailure(undownloaded.headless, category: .modelNotDownloaded)
+    }
+
+    func testListModelsJSONMarksSelectedModel() async throws {
+        let dependencies = makeDependencies(selectedModel: .parakeetV2)
+        var standardOutput = Data()
+        let entrypoint = CLIEntrypoint(
+            headlessTranscriber: dependencies.headless,
+            stdout: { standardOutput.append($0) },
+            stderr: { _ in XCTFail("Model listing should not fail.") }
+        )
+
+        let exitCode = await entrypoint.run(arguments: ["--list-models", "--json"])
+        XCTAssertEqual(exitCode, 0)
+        let response = try JSONDecoder().decode(CLIModelListResponse.self, from: standardOutput)
+        let selected = try XCTUnwrap(response.models.first(where: \.selected))
+        XCTAssertEqual(selected.id, ModelSize.parakeetV2.rawValue)
+        XCTAssertEqual(selected.engine, "parakeet")
+        XCTAssertTrue(selected.downloaded)
+        XCTAssertTrue(selected.supported)
+        XCTAssertFalse(selected.systemManaged)
+    }
+
+    // MARK: - Transcription JSON
+
+    func testSuccessJSONIncludesContractFieldsAndLanguage() async throws {
+        let dependencies = makeDependencies(selectedModel: .parakeetV2)
+        dependencies.transcriber.mockTranscriptionResult = VocaTranscription(
+            text: "Transcribed text",
+            duration: 0.72,
+            detectedLanguage: "en",
+            audioLengthSeconds: 4.3,
+            modelUsed: .parakeetV2
+        )
+        dependencies.audioLoader.loadedAudio = LoadedAudioFile(
+            samples: [0.2, -0.2],
+            durationSeconds: 4.3
+        )
+        var standardOutput = Data()
+        let entrypoint = CLIEntrypoint(
+            headlessTranscriber: dependencies.headless,
+            stdout: { standardOutput.append($0) },
+            stderr: { _ in XCTFail("Transcription should not fail.") }
+        )
+
+        let exitCode = await entrypoint.run(arguments: [
+            "--transcribe-file", "/mock/audio.wav", "--language", "en", "--json",
+        ])
+        XCTAssertEqual(exitCode, 0)
+        let response = try JSONDecoder().decode(CLITranscriptionResponse.self, from: standardOutput)
+        XCTAssertEqual(response.text, "Transcribed text")
+        XCTAssertEqual(response.model, ModelSize.parakeetV2.rawValue)
+        XCTAssertEqual(response.engine, "parakeet")
+        XCTAssertEqual(response.detectedLanguage, "en")
+        XCTAssertEqual(response.durationSeconds, 0.72)
+        XCTAssertEqual(response.audioLengthSeconds, 4.3)
+        XCTAssertEqual(dependencies.transcriber.lastLanguage, "en")
+    }
+
+    func testUnicodeTranscriptJSONIsValid() async throws {
+        let dependencies = makeDependencies(selectedModel: .small)
+        let transcript = "नमस्ते — こんにちは 👋\nnext line"
+        dependencies.transcriber.mockTranscriptionResult = VocaTranscription(
+            text: transcript,
+            duration: 0.1,
+            detectedLanguage: "hi",
+            audioLengthSeconds: 1,
+            modelUsed: .small
+        )
+        var standardOutput = Data()
+        let entrypoint = CLIEntrypoint(
+            headlessTranscriber: dependencies.headless,
+            stdout: { standardOutput.append($0) },
+            stderr: { _ in XCTFail("Transcription should not fail.") }
+        )
+
+        let exitCode = await entrypoint.run(arguments: [
+            "--transcribe-file", "/mock/audio.wav", "--json",
+        ])
+        XCTAssertEqual(exitCode, 0)
+        let object = try XCTUnwrap(
+            JSONSerialization.jsonObject(with: standardOutput) as? [String: Any]
+        )
+        XCTAssertEqual(object["text"] as? String, transcript)
+    }
+
+    // MARK: - Audio conversion
+
+    func testStereoNon16kHzWAVConvertsToMono16kHzSamples() throws {
+        let url = temporaryURL(extension: "wav")
+        let sourceRate = 44_100.0
+        let frameCount: AVAudioFrameCount = 4_410
+        let format = try XCTUnwrap(AVAudioFormat(
+            commonFormat: .pcmFormatFloat32,
+            sampleRate: sourceRate,
+            channels: 2,
+            interleaved: false
+        ))
+        let buffer = try XCTUnwrap(AVAudioPCMBuffer(pcmFormat: format, frameCapacity: frameCount))
+        buffer.frameLength = frameCount
+        let channels = try XCTUnwrap(buffer.floatChannelData)
+        for frame in 0..<Int(frameCount) {
+            let sample = Float(sin(2 * Double.pi * 440 * Double(frame) / sourceRate)) * 0.25
+            channels[0][frame] = sample
+            channels[1][frame] = sample * 0.5
+        }
+        do {
+            let file = try AVAudioFile(forWriting: url, settings: format.settings)
+            try file.write(from: buffer)
+        }
+
+        let loaded = try AudioFileLoader().loadAudio(at: url)
+
+        XCTAssertEqual(loaded.samples.count, 1_600, accuracy: 2)
+        XCTAssertEqual(loaded.durationSeconds, 0.1, accuracy: 0.001)
+        XCTAssertTrue(loaded.samples.contains(where: { abs($0) > 0.01 }))
+    }
+
+    func testEmptyAndInvalidAudioAreRejected() throws {
+        let emptyURL = temporaryURL(extension: "wav")
+        let format = try XCTUnwrap(AVAudioFormat(
+            commonFormat: .pcmFormatInt16,
+            sampleRate: 16_000,
+            channels: 1,
+            interleaved: false
+        ))
+        _ = try AVAudioFile(forWriting: emptyURL, settings: format.settings)
+
+        XCTAssertThrowsError(try AudioFileLoader().loadAudio(at: emptyURL)) { error in
+            XCTAssertCLIError(error, category: .invalidAudio)
+        }
+
+        let invalidURL = temporaryURL(extension: "wav")
+        try Data("not audio".utf8).write(to: invalidURL)
+        XCTAssertThrowsError(try AudioFileLoader().loadAudio(at: invalidURL)) { error in
+            XCTAssertCLIError(error, category: .invalidAudio)
+        }
+    }
+
+    func testSilentAudioIsRejected() throws {
+        let url = temporaryURL(extension: "wav")
+        let format = try XCTUnwrap(AVAudioFormat(
+            commonFormat: .pcmFormatFloat32,
+            sampleRate: 16_000,
+            channels: 1,
+            interleaved: false
+        ))
+        let buffer = try XCTUnwrap(AVAudioPCMBuffer(pcmFormat: format, frameCapacity: 800))
+        buffer.frameLength = 800
+        let channel = try XCTUnwrap(buffer.floatChannelData?[0])
+        for frame in 0..<800 {
+            channel[frame] = 0
+        }
+        do {
+            let file = try AVAudioFile(forWriting: url, settings: format.settings)
+            try file.write(from: buffer)
+        }
+
+        XCTAssertThrowsError(try AudioFileLoader().loadAudio(at: url)) { error in
+            XCTAssertCLIError(error, category: .invalidAudio)
+        }
+    }
+
+    // MARK: - Helpers
+
+    private func makeDependencies(selectedModel: ModelSize) -> TestDependencies {
+        makeDependencies(selectedModelIdentifier: selectedModel.rawValue)
+    }
+
+    private func makeDependencies(selectedModelIdentifier: String) -> TestDependencies {
+        let modelManager = MockModelManager()
+        modelManager.downloadedModels = Set(ModelSize.allCases.filter { !$0.isSystemManaged })
+        let preferences = MockCLIPreferences(
+            selectedModelIdentifier: selectedModelIdentifier,
+            selectedLanguageIdentifier: "auto"
+        )
+        let audioLoader = MockAudioFileLoader()
+        let transcriber = MockWhisperService()
+        let headless = HeadlessTranscriber(
+            modelManager: modelManager,
+            preferences: preferences,
+            audioLoader: audioLoader,
+            transcriber: transcriber
+        )
+        return TestDependencies(
+            modelManager: modelManager,
+            preferences: preferences,
+            audioLoader: audioLoader,
+            transcriber: transcriber,
+            headless: headless
+        )
+    }
+
+    private func assertTranscriptionFailure(
+        _ headless: HeadlessTranscriber,
+        category: CLIErrorCategory
+    ) async {
+        do {
+            _ = try await headless.transcribe(
+                fileURL: URL(fileURLWithPath: "/mock/audio.wav"),
+                modelOverride: nil,
+                languageOverride: nil
+            )
+            XCTFail("Expected \(category.rawValue).")
+        } catch {
+            XCTAssertCLIError(error, category: category)
+        }
+    }
+
+    private func XCTAssertCLIError(
+        _ error: Error,
+        category: CLIErrorCategory,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) {
+        guard let cliError = error as? CLIError else {
+            return XCTFail("Expected CLIError, got \(error)", file: file, line: line)
+        }
+        XCTAssertEqual(cliError.category, category, file: file, line: line)
+    }
+
+    private func temporaryURL(extension pathExtension: String) -> URL {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("VocaMac-CLITests-\(UUID().uuidString)")
+            .appendingPathExtension(pathExtension)
+        addTeardownBlock { try? FileManager.default.removeItem(at: url) }
+        return url
+    }
+}
+
+private struct TestDependencies {
+    let modelManager: MockModelManager
+    let preferences: MockCLIPreferences
+    let audioLoader: MockAudioFileLoader
+    let transcriber: MockWhisperService
+    let headless: HeadlessTranscriber
+}
+
+private final class MockCLIPreferences: CLIPreferencesReading {
+    var selectedModelIdentifier: String?
+    var selectedLanguageIdentifier: String?
+
+    init(selectedModelIdentifier: String?, selectedLanguageIdentifier: String?) {
+        self.selectedModelIdentifier = selectedModelIdentifier
+        self.selectedLanguageIdentifier = selectedLanguageIdentifier
+    }
+}
+
+private final class MockAudioFileLoader: AudioFileLoading {
+    var loadedAudio = LoadedAudioFile(samples: [0.1, -0.1], durationSeconds: 1)
+    var loadCount = 0
+
+    func loadAudio(at url: URL) throws -> LoadedAudioFile {
+        loadCount += 1
+        return loadedAudio
+    }
+}

--- a/Tests/VocaMacTests/CLITests.swift
+++ b/Tests/VocaMacTests/CLITests.swift
@@ -114,6 +114,24 @@ final class CLITests: XCTestCase {
         }
     }
 
+    func testSherpaRouterRequestsInjectedOneRequestLanguage() async {
+        var languageProviderCallCount = 0
+        let router = TranscriptionRouter(languagePreferenceProvider: {
+            languageProviderCallCount += 1
+            return "de"
+        })
+
+        do {
+            // This model is intentionally not installed in CI. The provider
+            // must still be consulted before SherpaService rejects its files.
+            try await router.loadModel(name: ModelSize.moonshineTiny.rawValue)
+        } catch {
+            // Missing local model files are expected and unrelated to routing.
+        }
+
+        XCTAssertEqual(languageProviderCallCount, 1)
+    }
+
     func testOmittedLanguageReadsPreferenceAndAutoBecomesNil() async throws {
         let selectedLanguage = makeDependencies(selectedModel: .small)
         selectedLanguage.preferences.selectedLanguageIdentifier = "fr"

--- a/Tests/VocaMacTests/CLITests.swift
+++ b/Tests/VocaMacTests/CLITests.swift
@@ -13,6 +13,12 @@ final class CLITests: XCTestCase {
         XCTAssertEqual(CLICommand.invocationMode(arguments: []), .gui)
     }
 
+    func testRestartedArgumentRoutesToGUI() {
+        // Settings -> Debug -> Restart relaunches with `open ... --args --restarted`.
+        // That argv must reach VocaMacApp, not be rejected by the CLI parser.
+        XCTAssertEqual(CLICommand.invocationMode(arguments: ["--restarted"]), .gui)
+    }
+
     func testHelpRoutesToCLIAndDoesNotRunHeadlessServices() async {
         let dependencies = makeDependencies(selectedModel: .tiny)
         var standardOutput = Data()
@@ -56,6 +62,20 @@ final class CLITests: XCTestCase {
         XCTAssertEqual(response.model, ModelSize.parakeetV2.rawValue)
         XCTAssertEqual(response.engine, "parakeet")
         XCTAssertEqual(dependencies.transcriber.loadRequests.first?.name, ModelSize.parakeetV2.rawValue)
+    }
+
+    func testMissingModelPreferenceFallsBackToTiny() async throws {
+        // AppState's @AppStorage default is ModelSize.tiny, so a fresh install
+        // (or prefs that never persisted the key) must behave the same headlessly.
+        let dependencies = makeDependencies(selectedModelIdentifier: nil)
+
+        let response = try await dependencies.headless.transcribe(
+            fileURL: URL(fileURLWithPath: "/mock/audio.wav"),
+            modelOverride: nil,
+            languageOverride: nil
+        )
+
+        XCTAssertEqual(response.model, ModelSize.tiny.rawValue)
     }
 
     func testAppPreferencesReaderUsesInjectedDefaultsDomain() throws {
@@ -331,7 +351,7 @@ final class CLITests: XCTestCase {
         makeDependencies(selectedModelIdentifier: selectedModel.rawValue)
     }
 
-    private func makeDependencies(selectedModelIdentifier: String) -> TestDependencies {
+    private func makeDependencies(selectedModelIdentifier: String?) -> TestDependencies {
         let modelManager = MockModelManager()
         modelManager.downloadedModels = Set(ModelSize.allCases.filter { !$0.isSystemManaged })
         let preferences = MockCLIPreferences(

--- a/Tests/VocaMacTests/SherpaServiceTests.swift
+++ b/Tests/VocaMacTests/SherpaServiceTests.swift
@@ -79,6 +79,11 @@ final class SherpaServiceTests: XCTestCase {
         XCTAssertTrue(SherpaService.completionMarkerName.hasPrefix("."))
     }
 
+    func testExplicitLoadLanguageDoesNotFallBackToSavedPreference() {
+        XCTAssertEqual(SherpaService.normalizedLoadLanguage("de"), "de")
+        XCTAssertEqual(SherpaService.normalizedLoadLanguage(nil), "auto")
+    }
+
     func testLoadAndTranscribeAcrossThreads() async throws {
         guard let model = installedModel else {
             throw XCTSkip("No sherpa-onnx model downloaded on this machine")


### PR DESCRIPTION
## Summary

- dispatch headless commands before SwiftUI constructs `VocaMacApp`, so CLI invocations never create `AppState`, run single-instance termination, or initialize GUI/microphone/hotkey services
- resolve the saved or one-request model through `ModelManager`, enforce supported/downloaded checks, and transcribe every engine through `TranscriptionRouter`
- normalize regular audio files to mono 16 kHz Float32 PCM and expose stable JSON for transcription results, model listings, and categorized failures
- isolate stdout/stderr from late engine/runtime logging so successful JSON remains exactly one clean object and failures remain concise
- document the headless contract separately from the existing launch/build helpers

## Validation

- `swift build`
- `swift test` — 293 passed, 1 existing hardware-dependent skip
- `make build` — passed with ad-hoc signing; existing ONNX framework-symlink warning remains
- `git diff --check`
- real 4.06-second speech WAV with Parakeet v2: valid JSON, `engine: parakeet`, GUI PID unchanged
- real speech WAV with explicit Whisper Small override: valid JSON, `engine: whisperkit`, saved Parakeet selection unchanged
- bundled `--list-models --json`: one valid JSON line, selected model correct, zero stderr bytes
- missing audio and undownloaded model: nonzero categorized JSON errors, GUI PID unchanged, no orphan process

## Notes

One-shot CLI mode intentionally loads the selected model in a separate process for each request. Persistent serving, daemon, HTTP, and IPC modes remain out of scope for this PR.
