### PR TITLE
Keep quoted meta tags after Hugo minify

### DIFF
--- a/web/hugo.toml
+++ b/web/hugo.toml
@@ -14,6 +14,14 @@ title = "VocaMac - 100% Local Voice-to-Text for macOS"
   [build.buildStats]
     enable = false
 
+# Keep attribute quotes on minify so crawlers that match name="description"
+# / name="twitter:*" / rel="canonical" still see parser-visible tags.
+# Without this, tdewolff emits name=twitter:card (unquoted), which some
+# SEO scanners miss even though the tags are present.
+[minify]
+  [minify.tdewolff.html]
+    keepQuotes = true
+
 [sitemap]
   changeFreq = "weekly"
   priority = 0.5


### PR DESCRIPTION
## Summary
Production already had `meta name=description`, `link rel=canonical`, and full Twitter card tags. Hugo `--minify` was stripping the quotes around attribute names, so the HTML looked like:

```html
<meta name=twitter:card content="summary_large_image">
<link rel=canonical href=https://vocamac.com/>
```

Some SEO scanners (including the sister-site audit in [VocaHQ/vocahq#4](https://github.com/VocaHQ/vocahq/pull/4)) only match quoted forms like `name="twitter:card"` and reported the tags as missing.

## Change
Set `minify.tdewolff.html.keepQuotes = true` so minified output keeps:

```html
<meta name="description" content="...">
<link rel="canonical" href="https://vocamac.com/">
<meta name="twitter:card" content="summary_large_image">
<meta name="twitter:image" content="https://vocamac.com/og-image.png">
```

No content/copy change. Tags were already correct; this makes them parser-visible.

## Test plan
- [x] `cd web && hugo --minify` and grep `public/index.html` for `name="description"`, `rel="canonical"`, `name="twitter:card"`, `name="twitter:image"`
- [ ] Confirm those strings appear with quotes (not `name=twitter:card`)
- [x] Spot-check a feature page for the same tags

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single build-time minifier setting with no runtime, auth, or content changes.
> 
> **Overview**
> Hugo’s `--minify` step was dropping quotes around HTML attributes (e.g. `name=twitter:card` instead of `name="twitter:card"`), so some SEO tools treated description, canonical, and Twitter meta tags as missing even though they were in the page.
> 
> **`web/hugo.toml`** now sets `minify.tdewolff.html.keepQuotes = true` so minified output keeps quoted `name` / `rel` / `content` / `href` on those tags. Meta content is unchanged; only how the minifier serializes attributes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3201e25066b42235f84ef01762498ebaed4f80dd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->