### PR TITLE
Support modifier+key combo hotkeys for quick dictation

### DIFF
--- a/Sources/VocaMac/Models/AppState.swift
+++ b/Sources/VocaMac/Models/AppState.swift
@@ -557,7 +557,8 @@ final class AppState: ObservableObject {
                         keyCode: self.hotKeyCode,
                         mode: self.activationMode,
                         doubleTapThreshold: self.doubleTapThreshold,
-                        safetyTimeout: self.hotKeySafetyTimeout
+                        safetyTimeout: self.hotKeySafetyTimeout,
+                        modifiers: self.hotKeyModifiers
                     )
                 }
             }

--- a/Sources/VocaMac/Models/AppState.swift
+++ b/Sources/VocaMac/Models/AppState.swift
@@ -98,6 +98,7 @@ final class AppState: ObservableObject {
     @AppStorage("vocamac.hasCompletedOnboarding") var hasCompletedOnboarding: Bool = false
     @AppStorage("vocamac.activationMode") var activationMode: ActivationMode = .pushToTalk
     @AppStorage("vocamac.hotKeyCode") var hotKeyCode: Int = 61  // Right Option
+    @AppStorage("vocamac.hotKeyModifiers") var hotKeyModifiers: HotKeyModifiers = []
     @AppStorage("vocamac.doubleTapThreshold") var doubleTapThreshold: Double = 0.4
     @AppStorage("vocamac.silenceThreshold") var silenceThreshold: Double = 0.01
     @AppStorage("vocamac.silenceDuration") var silenceDuration: Double = 2.0
@@ -478,7 +479,8 @@ final class AppState: ObservableObject {
                 keyCode: self.hotKeyCode,
                 mode: self.activationMode,
                 doubleTapThreshold: self.doubleTapThreshold,
-                safetyTimeout: self.hotKeySafetyTimeout
+                safetyTimeout: self.hotKeySafetyTimeout,
+                modifiers: self.hotKeyModifiers
             )
             VocaLogger.info(.appState, "Hotkey listener started after permission grant")
         }
@@ -772,9 +774,10 @@ final class AppState: ObservableObject {
             keyCode: hotKeyCode,
             mode: activationMode,
             doubleTapThreshold: doubleTapThreshold,
-            safetyTimeout: hotKeySafetyTimeout
+            safetyTimeout: hotKeySafetyTimeout,
+            modifiers: hotKeyModifiers
         )
-        VocaLogger.debug(.appState, "Hotkey configuration synced (keyCode=\(hotKeyCode), mode=\(activationMode.rawValue))")
+        VocaLogger.debug(.appState, "Hotkey configuration synced (keyCode=\(hotKeyCode), modifiers=\(hotKeyModifiers.rawValue), mode=\(activationMode.rawValue))")
     }
 
     // MARK: - Force Recovery
@@ -1422,7 +1425,8 @@ final class AppState: ObservableObject {
             keyCode: hotKeyCode,
             mode: activationMode,
             doubleTapThreshold: doubleTapThreshold,
-            safetyTimeout: hotKeySafetyTimeout
+            safetyTimeout: hotKeySafetyTimeout,
+            modifiers: hotKeyModifiers
         )
         if hotKeyManager.isListening {
             VocaLogger.info(.appState, "Hotkey listener active (keyCode=\(hotKeyCode), mode=\(activationMode.rawValue))")

--- a/Sources/VocaMac/Models/HotKeyModifiers.swift
+++ b/Sources/VocaMac/Models/HotKeyModifiers.swift
@@ -1,0 +1,26 @@
+// HotKeyModifiers.swift
+// VocaMac
+//
+// Canonical modifier representation for hotkey combos (e.g. ⌘Space, ⌃Space).
+// Uses its own bit assignments rather than CGEventFlags/NSEvent.ModifierFlags
+// raw values directly, so it isn't coupled to either framework's bit layout.
+
+import Foundation
+
+struct HotKeyModifiers: OptionSet, Hashable, Codable {
+    let rawValue: Int
+
+    static let control  = HotKeyModifiers(rawValue: 1 << 0)
+    static let option   = HotKeyModifiers(rawValue: 1 << 1)
+    static let shift    = HotKeyModifiers(rawValue: 1 << 2)
+    static let command  = HotKeyModifiers(rawValue: 1 << 3)
+    static let function = HotKeyModifiers(rawValue: 1 << 4)
+}
+
+/// A hotkey trigger: an optional set of required modifiers plus a base key.
+/// When `modifiers` is empty, `keyCode` behaves exactly as the legacy
+/// single-key hotkey (a lone modifier key or a lone regular key).
+struct HotKeyCombo: Hashable {
+    var keyCode: Int
+    var modifiers: HotKeyModifiers
+}

--- a/Sources/VocaMac/Services/HotKeyManager.swift
+++ b/Sources/VocaMac/Services/HotKeyManager.swift
@@ -24,6 +24,17 @@ final class HotKeyManager {
     /// The key code to listen for
     private var targetKeyCode: Int = 61  // Right Option
 
+    /// Modifiers required alongside `targetKeyCode` for a combo hotkey
+    /// (e.g. ⌘Space). Empty means legacy single-key behavior — `targetKeyCode`
+    /// alone triggers the hotkey, regardless of what other modifiers are held.
+    private var requiredModifiers: HotKeyModifiers = []
+
+    /// Whether the current key-down for `targetKeyCode` passed the modifier
+    /// check and is considered "held" for combo purposes. Tracked separately
+    /// from `isKeyHeld` because a key-down can now be rejected for having the
+    /// wrong modifiers without ever starting a recording.
+    private var isBaseKeyHeld = false
+
     /// Current activation mode
     private var mode: ActivationMode = .pushToTalk
 
@@ -90,7 +101,8 @@ final class HotKeyManager {
         keyCode: Int = 61,
         mode: ActivationMode = .pushToTalk,
         doubleTapThreshold: Double = 0.4,
-        safetyTimeout: Double = 65.0
+        safetyTimeout: Double = 65.0,
+        modifiers: HotKeyModifiers = []
     ) {
         guard !isListening else {
             VocaLogger.debug(.hotKeyManager, "Already listening")
@@ -98,6 +110,7 @@ final class HotKeyManager {
         }
 
         self.targetKeyCode = keyCode
+        self.requiredModifiers = modifiers
         self.mode = mode
         self.doubleTapThreshold = doubleTapThreshold
         self.safetyTimeoutSeconds = safetyTimeout
@@ -105,6 +118,7 @@ final class HotKeyManager {
         self.isKeyHeld = false
         self.isToggled = false
         self.isModifierKeyHeld = false
+        self.isBaseKeyHeld = false
 
         // Create event tap for key events and flags changed (modifier keys)
         let eventMask: CGEventMask = (
@@ -158,6 +172,7 @@ final class HotKeyManager {
         isKeyHeld = false
         isToggled = false
         isModifierKeyHeld = false
+        isBaseKeyHeld = false
         cancelSafetyTimer()
 
         VocaLogger.info(.hotKeyManager, "Stopped listening")
@@ -171,6 +186,7 @@ final class HotKeyManager {
         isKeyHeld = false
         isToggled = false
         isModifierKeyHeld = false
+        isBaseKeyHeld = false
         cancelSafetyTimer()
         VocaLogger.debug(.hotKeyManager, "Key state reset")
     }
@@ -187,12 +203,14 @@ final class HotKeyManager {
         keyCode: Int? = nil,
         mode: ActivationMode? = nil,
         doubleTapThreshold: Double? = nil,
-        safetyTimeout: Double? = nil
+        safetyTimeout: Double? = nil,
+        modifiers: HotKeyModifiers? = nil
     ) {
         if let keyCode = keyCode { self.targetKeyCode = keyCode }
         if let mode = mode { self.mode = mode }
         if let threshold = doubleTapThreshold { self.doubleTapThreshold = threshold }
         if let timeout = safetyTimeout { self.safetyTimeoutSeconds = timeout }
+        if let modifiers = modifiers { self.requiredModifiers = modifiers }
     }
 
     // MARK: - Event Tap Callback
@@ -235,11 +253,34 @@ final class HotKeyManager {
             if keyCode == targetKeyCode {
                 VocaLogger.debug(.hotKeyManager, "flagsChanged event for target keyCode \(keyCode)")
             }
-            return handleModifierKeyEvent(keyCode: keyCode, event: event)
+            if handleModifierKeyEvent(keyCode: keyCode, event: event) {
+                return true
+            }
+            return handleModifierReleaseDuringCombo(flags: event.flags)
         } else if type == .keyDown || type == .keyUp {
             return handleRegularKeyEvent(keyCode: keyCode, isKeyDown: type == .keyDown, event: event)
         }
 
+        return false
+    }
+
+    /// Detect a required modifier being released while a combo hotkey's base
+    /// key is still held (push-to-talk only), and force a stop. This is the
+    /// combo analogue of the safety timer: without it, releasing ⌘ before
+    /// Space in a ⌘Space hotkey would leave recording stuck until the base
+    /// key's own key-up (which may never come if the user releases Space
+    /// separately in a different app-focus context) or the safety timer fires.
+    ///
+    /// Does not consume the event — the modifier that changed isn't the
+    /// configured target key, so the frontmost app should still see it.
+    private func handleModifierReleaseDuringCombo(flags: CGEventFlags) -> Bool {
+        guard isBaseKeyHeld, mode == .pushToTalk, !requiredModifiers.isEmpty else { return false }
+        guard !requiredModifiers.isSubset(of: HotKeyModifiers(cgEventFlags: flags)) else { return false }
+        VocaLogger.warning(.hotKeyManager, "Combo modifier released while base key held — forcing STOP")
+        // Leave isBaseKeyHeld set so the base key's eventual real key-up is
+        // still consumed (reserving it from the frontmost app), even though
+        // handleKeyUp() here already performed the actual stop.
+        handleKeyUp()
         return false
     }
 
@@ -315,17 +356,33 @@ final class HotKeyManager {
     private func handleRegularKeyEvent(keyCode: Int, isKeyDown: Bool, event: CGEvent) -> Bool {
         guard keyCode == targetKeyCode else { return false }
 
-        if isKeyDown && event.getIntegerValueField(.keyboardEventAutorepeat) != 0 {
-            return true
-        }
-
         if isKeyDown {
+            if event.getIntegerValueField(.keyboardEventAutorepeat) != 0 {
+                // Only consume autorepeat if this key is actively our hotkey.
+                // Otherwise (e.g. a Space-based combo whose modifier wasn't
+                // held on the initial press) repeated keystrokes must keep
+                // reaching the frontmost app rather than being swallowed.
+                return isBaseKeyHeld
+            }
+            guard modifiersMatch(event.flags) else { return false }
+            isBaseKeyHeld = true
             handleKeyDown()
         } else {
+            guard isBaseKeyHeld else { return false }
+            isBaseKeyHeld = false
             handleKeyUp()
         }
 
         return true
+    }
+
+    /// Whether the live modifier flags satisfy this hotkey's configuration.
+    /// Legacy (no required modifiers) always matches, regardless of what
+    /// other modifiers happen to be held — preserving today's behavior for
+    /// single-key hotkeys like F5. A combo requires an exact match so that,
+    /// e.g., a ⌘Space hotkey does not also fire on ⌘⇧Space.
+    private func modifiersMatch(_ flags: CGEventFlags) -> Bool {
+        requiredModifiers.isEmpty || HotKeyModifiers(cgEventFlags: flags) == requiredModifiers
     }
 
     /// Process a key-down event for the target hotkey
@@ -446,8 +503,25 @@ extension HotKeyManager: HotKeyMonitoring {
         Self.checkAccessibilityPermission(prompt: prompt)
     }
 
-    func _updateConfiguration(keyCode: Int?, mode: ActivationMode?, doubleTapThreshold: Double?, safetyTimeout: Double?) {
-        updateConfiguration(keyCode: keyCode, mode: mode, doubleTapThreshold: doubleTapThreshold, safetyTimeout: safetyTimeout)
+    func _updateConfiguration(keyCode: Int?, mode: ActivationMode?, doubleTapThreshold: Double?, safetyTimeout: Double?, modifiers: HotKeyModifiers?) {
+        updateConfiguration(keyCode: keyCode, mode: mode, doubleTapThreshold: doubleTapThreshold, safetyTimeout: safetyTimeout, modifiers: modifiers)
+    }
+}
+
+// MARK: - HotKeyModifiers Conversion
+
+extension HotKeyModifiers {
+    /// Maps the 5 relevant CGEventFlags bits (Control/Option/Shift/Command/Fn)
+    /// into our own canonical representation. Other bits (e.g. caps lock,
+    /// numeric pad) are ignored.
+    init(cgEventFlags flags: CGEventFlags) {
+        var result: HotKeyModifiers = []
+        if flags.contains(.maskControl) { result.insert(.control) }
+        if flags.contains(.maskAlternate) { result.insert(.option) }
+        if flags.contains(.maskShift) { result.insert(.shift) }
+        if flags.contains(.maskCommand) { result.insert(.command) }
+        if flags.contains(.maskSecondaryFn) { result.insert(.function) }
+        self = result
     }
 }
 
@@ -467,21 +541,25 @@ extension HotKeyManager {
 enum KeyCodeReference {
     static let escapeKeyCode = 53
 
-    static let commonHotKeys: [(name: String, keyCode: Int)] = [
-        ("Right Option (⌥)", 61),
-        ("Left Option (⌥)", 58),
-        ("Right Command (⌘)", 54),
-        ("Right Shift (⇧)", 60),
-        ("Right Control (⌃)", 62),
-        ("Fn", 63),
-        ("F5", 96),
-        ("F6", 97),
-        ("F7", 98),
-        ("F8", 100),
-        ("F9", 101),
-        ("F10", 109),
-        ("F11", 103),
-        ("F12", 111),
+    static let commonHotKeys: [(name: String, keyCode: Int, modifiers: HotKeyModifiers)] = [
+        ("Right Option (⌥)", 61, []),
+        ("Left Option (⌥)", 58, []),
+        ("Right Command (⌘)", 54, []),
+        ("Right Shift (⇧)", 60, []),
+        ("Right Control (⌃)", 62, []),
+        ("Fn", 63, []),
+        ("F5", 96, []),
+        ("F6", 97, []),
+        ("F7", 98, []),
+        ("F8", 100, []),
+        ("F9", 101, []),
+        ("F10", 109, []),
+        ("F11", 103, []),
+        ("F12", 111, []),
+        ("⌘ Space", 49, .command),
+        ("⌃ Space", 49, .control),
+        ("⌥ Space", 49, .option),
+        ("⌃⌥ Space", 49, [.control, .option]),
     ]
 
     private static let namedKeyCodes: [Int: String] = [
@@ -550,17 +628,38 @@ enum KeyCodeReference {
         126: "Up Arrow",
     ]
 
-    /// Get the display name for a key code
-    static func displayName(for keyCode: Int) -> String {
-        commonHotKeys.first(where: { $0.keyCode == keyCode })?.name
-            ?? namedKeyCodes[keyCode]
-            ?? displayCharacter(for: keyCode)
-            ?? "Key \(keyCode)"
+    /// Get the display name for a hotkey combo (required modifiers + base key).
+    static func displayName(for combo: HotKeyCombo) -> String {
+        if let preset = commonHotKeys.first(where: { $0.keyCode == combo.keyCode && $0.modifiers == combo.modifiers }) {
+            return preset.name
+        }
+        let base = bareKeyName(for: combo.keyCode)
+        return combo.modifiers.isEmpty ? base : "\(symbol(for: combo.modifiers))\(base)"
     }
 
-    /// Whether this key code is included in the curated preset list.
-    static func isCommonHotKey(_ keyCode: Int) -> Bool {
-        commonHotKeys.contains(where: { $0.keyCode == keyCode })
+    /// Whether this combo is included in the curated preset list.
+    static func isCommonHotKey(_ combo: HotKeyCombo) -> Bool {
+        commonHotKeys.contains(where: { $0.keyCode == combo.keyCode && $0.modifiers == combo.modifiers })
+    }
+
+    /// Modifier symbols in standard macOS menu order (⌃⌥⇧⌘), plus "fn".
+    private static func symbol(for modifiers: HotKeyModifiers) -> String {
+        var symbols = ""
+        if modifiers.contains(.control) { symbols += "⌃" }
+        if modifiers.contains(.option) { symbols += "⌥" }
+        if modifiers.contains(.shift) { symbols += "⇧" }
+        if modifiers.contains(.command) { symbols += "⌘" }
+        if modifiers.contains(.function) { symbols += "fn" }
+        return symbols + " "
+    }
+
+    /// The base key's own name, ignoring any combo presets that share its
+    /// key code — e.g. keyCode 49 must resolve to "Space", not "⌘ Space",
+    /// regardless of which combo preset happens to appear first in the list.
+    private static func bareKeyName(for keyCode: Int) -> String {
+        namedKeyCodes[keyCode]
+            ?? displayCharacter(for: keyCode)
+            ?? "Key \(keyCode)"
     }
 
     /// Whether this key code represents a modifier key that emits flagsChanged events.

--- a/Sources/VocaMac/Services/ServiceProtocols.swift
+++ b/Sources/VocaMac/Services/ServiceProtocols.swift
@@ -48,15 +48,15 @@ protocol HotKeyMonitoring: AnyObject {
     var onRecordingStop: (() -> Void)? { get set }
 
     func checkAccessibilityPermission(prompt: Bool) -> Bool
-    func startListening(keyCode: Int, mode: ActivationMode, doubleTapThreshold: Double, safetyTimeout: Double)
+    func startListening(keyCode: Int, mode: ActivationMode, doubleTapThreshold: Double, safetyTimeout: Double, modifiers: HotKeyModifiers)
     func stopListening()
     func resetKeyState()
-    func _updateConfiguration(keyCode: Int?, mode: ActivationMode?, doubleTapThreshold: Double?, safetyTimeout: Double?)
+    func _updateConfiguration(keyCode: Int?, mode: ActivationMode?, doubleTapThreshold: Double?, safetyTimeout: Double?, modifiers: HotKeyModifiers?)
 }
 
 extension HotKeyMonitoring {
-    func updateConfiguration(keyCode: Int? = nil, mode: ActivationMode? = nil, doubleTapThreshold: Double? = nil, safetyTimeout: Double? = nil) {
-        _updateConfiguration(keyCode: keyCode, mode: mode, doubleTapThreshold: doubleTapThreshold, safetyTimeout: safetyTimeout)
+    func updateConfiguration(keyCode: Int? = nil, mode: ActivationMode? = nil, doubleTapThreshold: Double? = nil, safetyTimeout: Double? = nil, modifiers: HotKeyModifiers? = nil) {
+        _updateConfiguration(keyCode: keyCode, mode: mode, doubleTapThreshold: doubleTapThreshold, safetyTimeout: safetyTimeout, modifiers: modifiers)
     }
 }
 

--- a/Sources/VocaMac/Views/HotKeySelectionControl.swift
+++ b/Sources/VocaMac/Views/HotKeySelectionControl.swift
@@ -4,6 +4,7 @@
 // Reusable hotkey picker with direct key recording for settings and onboarding.
 
 import AppKit
+import CoreGraphics
 import SwiftUI
 
 struct HotKeySelectionControl: View {
@@ -19,25 +20,34 @@ struct HotKeySelectionControl: View {
         self.footerText = footerText
     }
 
+    private var comboBinding: Binding<HotKeyCombo> {
+        Binding(
+            get: { HotKeyCombo(keyCode: appState.hotKeyCode, modifiers: appState.hotKeyModifiers) },
+            set: { newCombo in
+                appState.hotKeyCode = newCombo.keyCode
+                appState.hotKeyModifiers = newCombo.modifiers
+                guard !isRecording else { return }
+                appState.syncHotKeyConfiguration()
+            }
+        )
+    }
+
     var body: some View {
         VStack(alignment: .leading, spacing: 8) {
             HStack(spacing: 8) {
-                Picker(pickerLabel, selection: $appState.hotKeyCode) {
-                    ForEach(KeyCodeReference.commonHotKeys, id: \.keyCode) { hotKey in
-                        Text(hotKey.name).tag(hotKey.keyCode)
+                Picker(pickerLabel, selection: comboBinding) {
+                    ForEach(KeyCodeReference.commonHotKeys, id: \.name) { hotKey in
+                        Text(hotKey.name).tag(HotKeyCombo(keyCode: hotKey.keyCode, modifiers: hotKey.modifiers))
                     }
 
-                    if !KeyCodeReference.isCommonHotKey(appState.hotKeyCode) {
+                    let currentCombo = HotKeyCombo(keyCode: appState.hotKeyCode, modifiers: appState.hotKeyModifiers)
+                    if !KeyCodeReference.isCommonHotKey(currentCombo) {
                         Divider()
-                        Text("Custom: \(KeyCodeReference.displayName(for: appState.hotKeyCode))")
-                            .tag(appState.hotKeyCode)
+                        Text("Custom: \(KeyCodeReference.displayName(for: currentCombo))")
+                            .tag(currentCombo)
                     }
                 }
                 .disabled(isRecording)
-                .onChange(of: appState.hotKeyCode) {
-                    guard !isRecording else { return }
-                    appState.syncHotKeyConfiguration()
-                }
 
                 HotKeyRecorderButton(
                     isRecording: $isRecording,
@@ -78,8 +88,9 @@ struct HotKeySelectionControl: View {
         wasListeningBeforeRecording = false
     }
 
-    private func recordKey(_ keyCode: Int) {
-        appState.hotKeyCode = keyCode
+    private func recordKey(_ combo: HotKeyCombo) {
+        appState.hotKeyCode = combo.keyCode
+        appState.hotKeyModifiers = combo.modifiers
         appState.syncHotKeyConfiguration()
         finishRecording()
     }
@@ -89,7 +100,8 @@ struct HotKeySelectionControl: View {
             keyCode: appState.hotKeyCode,
             mode: appState.activationMode,
             doubleTapThreshold: appState.doubleTapThreshold,
-            safetyTimeout: Double(appState.maxRecordingDuration) + 5.0
+            safetyTimeout: Double(appState.maxRecordingDuration) + 5.0,
+            modifiers: appState.hotKeyModifiers
         )
     }
 }
@@ -99,7 +111,7 @@ private struct HotKeyRecorderButton: View {
 
     let onStart: () -> Void
     let onCancel: () -> Void
-    let onKeyRecorded: (Int) -> Void
+    let onKeyRecorded: (HotKeyCombo) -> Void
 
     var body: some View {
         ZStack {
@@ -118,9 +130,9 @@ private struct HotKeyRecorderButton: View {
 
             if isRecording {
                 HotKeyCaptureView(
-                    onCapture: { keyCode in
+                    onCapture: { combo in
                         isRecording = false
-                        onKeyRecorded(keyCode)
+                        onKeyRecorded(combo)
                     },
                     onCancel: {
                         isRecording = false
@@ -136,7 +148,7 @@ private struct HotKeyRecorderButton: View {
 }
 
 private struct HotKeyCaptureView: NSViewRepresentable {
-    let onCapture: (Int) -> Void
+    let onCapture: (HotKeyCombo) -> Void
     let onCancel: () -> Void
 
     func makeNSView(context: Context) -> HotKeyCaptureNSView {
@@ -158,20 +170,46 @@ private struct HotKeyCaptureView: NSViewRepresentable {
 }
 
 private final class HotKeyCaptureNSView: NSView {
-    var onCapture: ((Int) -> Void)?
+    var onCapture: ((HotKeyCombo) -> Void)?
     var onCancel: (() -> Void)?
 
     private var localMonitor: Any?
     private var windowResignObserver: NSObjectProtocol?
     private var didCapture = false
 
+    /// Key code of a modifier that was pressed while it was the *only*
+    /// modifier held — a candidate for a legacy lone-modifier hotkey. Cleared
+    /// as soon as a second modifier joins it, so a chord (e.g. holding
+    /// Control then Shift) is never mistaken for a completed tap.
+    private var singleModifierCandidateKeyCode: Int?
+
+    /// Physical modifier key codes currently believed held, tracked per key
+    /// (not per shared flag) so pressing both Left and Right Shift is
+    /// correctly seen as two distinct keys even though they share one
+    /// NSEvent.ModifierFlags bit.
+    private var heldModifierKeyCodes: Set<Int> = []
+
+    private static let modifierKeyCodes = [54, 55, 56, 58, 59, 60, 61, 62, 63]
+
     override var acceptsFirstResponder: Bool { true }
 
     override func viewDidMoveToWindow() {
         super.viewDidMoveToWindow()
+        seedHeldModifiers()
         installMonitor()
         installWindowObserver()
         focus()
+    }
+
+    /// Reads the *actual* current physical key state so a modifier already
+    /// held down before the user clicks "Record" (e.g. holding Command with
+    /// the other hand) is known from the start, rather than assumed absent.
+    private func seedHeldModifiers() {
+        let held = Self.modifierKeyCodes.filter {
+            CGEventSource.keyState(.combinedSessionState, key: CGKeyCode($0))
+        }
+        heldModifierKeyCodes = Set(held)
+        singleModifierCandidateKeyCode = held.count == 1 ? held[0] : nil
     }
 
     override func keyDown(with event: NSEvent) {
@@ -228,16 +266,61 @@ private final class HotKeyCaptureNSView: NSView {
             return true
         }
 
-        guard shouldCapture(event) else { return false }
+        switch event.type {
+        case .keyDown:
+            guard !event.isARepeat else { return false }
+            // A non-modifier key press always finalizes immediately, using
+            // whatever modifiers are currently held (possibly none).
+            let combo = HotKeyCombo(keyCode: Int(event.keyCode), modifiers: HotKeyModifiers(nsFlags: event.modifierFlags))
+            finalizeCapture(with: combo)
+            return true
 
+        case .flagsChanged:
+            return handleFlagsChanged(event)
+
+        default:
+            return false
+        }
+    }
+
+    /// Tracks modifier presses/releases per physical key so a chord (e.g.
+    /// holding Control then Shift, then pressing Space) can be composed
+    /// before finalizing, while a lone modifier tap (press-then-release with
+    /// nothing else) still finalizes as the legacy single-modifier hotkey.
+    /// A flagsChanged event's `keyCode` always identifies the specific
+    /// physical key that changed, even when its shared modifier flag (e.g.
+    /// `.shift`) was already set by the other key in its left/right pair —
+    /// tracking by key code (rather than by flag) keeps Left+Right presses
+    /// of the same modifier from being conflated into a single toggle.
+    private func handleFlagsChanged(_ event: NSEvent) -> Bool {
+        let keyCode = Int(event.keyCode)
+        guard KeyCodeReference.isModifierKeyCode(keyCode) else { return false }
+
+        if heldModifierKeyCodes.remove(keyCode) != nil {
+            // This physical key was released.
+            guard heldModifierKeyCodes.isEmpty else { return false }
+            if singleModifierCandidateKeyCode == keyCode {
+                finalizeCapture(with: HotKeyCombo(keyCode: keyCode, modifiers: []))
+                return true
+            }
+            singleModifierCandidateKeyCode = nil
+            return false
+        }
+
+        // This physical key was pressed. Only a press from zero-held is a
+        // lone-modifier candidate; anything joining an existing hold is
+        // building a chord and cancels any prior candidacy.
+        singleModifierCandidateKeyCode = heldModifierKeyCodes.isEmpty ? keyCode : nil
+        heldModifierKeyCodes.insert(keyCode)
+        return false
+    }
+
+    private func finalizeCapture(with combo: HotKeyCombo) {
         didCapture = true
         stopMonitoring()
-
-        let keyCode = Int(event.keyCode)
         DispatchQueue.main.async { [weak self] in
-            self?.onCapture?(keyCode)
+            self?.onCapture?(combo)
         }
-        return true
     }
 
     private func cancelCapture() {
@@ -249,45 +332,27 @@ private final class HotKeyCaptureNSView: NSView {
         }
     }
 
-    private func shouldCapture(_ event: NSEvent) -> Bool {
-        switch event.type {
-        case .keyDown:
-            return !event.isARepeat
-        case .flagsChanged:
-            let keyCode = Int(event.keyCode)
-            guard KeyCodeReference.isModifierKeyCode(keyCode),
-                  let modifierFlag = modifierFlag(for: keyCode)
-            else {
-                return false
-            }
-            return event.modifierFlags.contains(modifierFlag)
-        default:
-            return false
-        }
-    }
-
     private func shouldCancel(_ event: NSEvent) -> Bool {
         event.type == .keyDown && Int(event.keyCode) == KeyCodeReference.escapeKeyCode
     }
 
-    private func modifierFlag(for keyCode: Int) -> NSEvent.ModifierFlags? {
-        switch keyCode {
-        case 54, 55:
-            return .command
-        case 56, 60:
-            return .shift
-        case 58, 61:
-            return .option
-        case 59, 62:
-            return .control
-        case 63:
-            return .function
-        default:
-            return nil
-        }
-    }
-
     deinit {
         stopMonitoring()
+    }
+}
+
+// MARK: - HotKeyModifiers Conversion
+
+extension HotKeyModifiers {
+    /// Maps the 5 relevant NSEvent.ModifierFlags bits (Control/Option/Shift/
+    /// Command/Fn) into our own canonical representation.
+    init(nsFlags flags: NSEvent.ModifierFlags) {
+        var result: HotKeyModifiers = []
+        if flags.contains(.control) { result.insert(.control) }
+        if flags.contains(.option) { result.insert(.option) }
+        if flags.contains(.shift) { result.insert(.shift) }
+        if flags.contains(.command) { result.insert(.command) }
+        if flags.contains(.function) { result.insert(.function) }
+        self = result
     }
 }

--- a/Sources/VocaMac/Views/HotKeySelectionControl.swift
+++ b/Sources/VocaMac/Views/HotKeySelectionControl.swift
@@ -161,7 +161,6 @@ private struct HotKeyCaptureView: NSViewRepresentable {
     func updateNSView(_ nsView: HotKeyCaptureNSView, context: Context) {
         nsView.onCapture = onCapture
         nsView.onCancel = onCancel
-        nsView.focus()
     }
 
     static func dismantleNSView(_ nsView: HotKeyCaptureNSView, coordinator: ()) {
@@ -169,81 +168,38 @@ private struct HotKeyCaptureView: NSViewRepresentable {
     }
 }
 
+/// Thin lifecycle shell: starts the recorder while the (hidden) view is on
+/// screen and cancels it if the settings window loses focus mid-recording.
 private final class HotKeyCaptureNSView: NSView {
-    var onCapture: ((HotKeyCombo) -> Void)?
-    var onCancel: (() -> Void)?
+    var onCapture: ((HotKeyCombo) -> Void)? {
+        get { recorder.onCapture }
+        set { recorder.onCapture = newValue }
+    }
 
-    private var localMonitor: Any?
+    var onCancel: (() -> Void)? {
+        get { recorder.onCancel }
+        set { recorder.onCancel = newValue }
+    }
+
+    private let recorder = HotKeyComboRecorder()
     private var windowResignObserver: NSObjectProtocol?
-    private var didCapture = false
-
-    /// Key code of a modifier that was pressed while it was the *only*
-    /// modifier held — a candidate for a legacy lone-modifier hotkey. Cleared
-    /// as soon as a second modifier joins it, so a chord (e.g. holding
-    /// Control then Shift) is never mistaken for a completed tap.
-    private var singleModifierCandidateKeyCode: Int?
-
-    /// Physical modifier key codes currently believed held, tracked per key
-    /// (not per shared flag) so pressing both Left and Right Shift is
-    /// correctly seen as two distinct keys even though they share one
-    /// NSEvent.ModifierFlags bit.
-    private var heldModifierKeyCodes: Set<Int> = []
-
-    private static let modifierKeyCodes = [54, 55, 56, 58, 59, 60, 61, 62, 63]
-
-    override var acceptsFirstResponder: Bool { true }
 
     override func viewDidMoveToWindow() {
         super.viewDidMoveToWindow()
-        seedHeldModifiers()
-        installMonitor()
+        guard window != nil else { return }
+        recorder.start()
         installWindowObserver()
-        focus()
     }
 
-    /// Reads the *actual* current physical key state so a modifier already
-    /// held down before the user clicks "Record" (e.g. holding Command with
-    /// the other hand) is known from the start, rather than assumed absent.
-    private func seedHeldModifiers() {
-        let held = Self.modifierKeyCodes.filter {
-            CGEventSource.keyState(.combinedSessionState, key: CGKeyCode($0))
-        }
-        heldModifierKeyCodes = Set(held)
-        singleModifierCandidateKeyCode = held.count == 1 ? held[0] : nil
-    }
-
-    override func keyDown(with event: NSEvent) {
-        _ = capture(event)
-    }
-
-    override func flagsChanged(with event: NSEvent) {
-        _ = capture(event)
-    }
-
-    func focus() {
-        DispatchQueue.main.async { [weak self] in
-            guard let self else { return }
-            self.window?.makeFirstResponder(self)
-        }
-    }
-
+    /// Silent teardown — used when SwiftUI removes the view (the parent's
+    /// `onDisappear` already restores listener state), so it must not fire
+    /// `onCancel` and double-report a completed capture.
     func stopMonitoring() {
-        if let localMonitor {
-            NSEvent.removeMonitor(localMonitor)
-            self.localMonitor = nil
-        }
+        recorder.stop()
 
         if let windowResignObserver {
             NotificationCenter.default.removeObserver(windowResignObserver)
             self.windowResignObserver = nil
-        }
-    }
-
-    private func installMonitor() {
-        guard localMonitor == nil else { return }
-        localMonitor = NSEvent.addLocalMonitorForEvents(matching: [.keyDown, .flagsChanged]) { [weak self] event in
-            guard let self, self.window?.isKeyWindow == true else { return event }
-            return self.capture(event) ? nil : event
         }
     }
 
@@ -254,90 +210,228 @@ private final class HotKeyCaptureNSView: NSView {
             object: window,
             queue: .main
         ) { [weak self] _ in
-            self?.cancelCapture()
+            self?.recorder.cancel()
         }
     }
 
-    private func capture(_ event: NSEvent) -> Bool {
-        guard !didCapture else { return false }
-
-        if shouldCancel(event) {
-            cancelCapture()
-            return true
-        }
-
-        switch event.type {
-        case .keyDown:
-            guard !event.isARepeat else { return false }
-            // A non-modifier key press always finalizes immediately, using
-            // whatever modifiers are currently held (possibly none).
-            let combo = HotKeyCombo(keyCode: Int(event.keyCode), modifiers: HotKeyModifiers(nsFlags: event.modifierFlags))
-            finalizeCapture(with: combo)
-            return true
-
-        case .flagsChanged:
-            return handleFlagsChanged(event)
-
-        default:
-            return false
-        }
+    deinit {
+        stopMonitoring()
     }
+}
 
-    /// Tracks modifier presses/releases per physical key so a chord (e.g.
-    /// holding Control then Shift, then pressing Space) can be composed
-    /// before finalizing, while a lone modifier tap (press-then-release with
-    /// nothing else) still finalizes as the legacy single-modifier hotkey.
-    /// A flagsChanged event's `keyCode` always identifies the specific
-    /// physical key that changed, even when its shared modifier flag (e.g.
-    /// `.shift`) was already set by the other key in its left/right pair —
-    /// tracking by key code (rather than by flag) keeps Left+Right presses
-    /// of the same modifier from being conflated into a single toggle.
-    private func handleFlagsChanged(_ event: NSEvent) -> Bool {
-        let keyCode = Int(event.keyCode)
-        guard KeyCodeReference.isModifierKeyCode(keyCode) else { return false }
+/// Captures a hotkey combo (required modifiers + base key) from real input.
+///
+/// Uses a `CGEventTap` rather than an `NSEvent` local monitor. A local
+/// monitor only sees keystrokes macOS has already declined to handle itself,
+/// so combos the system reserves never arrive — ⌃Space and ⌃⌥Space are bound
+/// to input-source switching, ⌘Space to Spotlight — and ⌘-based combos are
+/// routed to menu key equivalents first. That made whole categories of
+/// shortcut unrecordable. A session tap inserted at the head of the queue —
+/// the same mechanism `HotKeyManager` already uses at runtime — sees every
+/// keystroke before the system does, so any combination can be recorded.
+/// Key-down events are consumed while recording so the shortcut being
+/// recorded doesn't also fire its normal action.
+private final class HotKeyComboRecorder {
+    var onCapture: ((HotKeyCombo) -> Void)?
+    var onCancel: (() -> Void)?
 
-        if heldModifierKeyCodes.remove(keyCode) != nil {
-            // This physical key was released.
-            guard heldModifierKeyCodes.isEmpty else { return false }
-            if singleModifierCandidateKeyCode == keyCode {
-                finalizeCapture(with: HotKeyCombo(keyCode: keyCode, modifiers: []))
-                return true
+    private var eventTap: CFMachPort?
+    private var runLoopSource: CFRunLoopSource?
+    private var fallbackMonitor: Any?
+    private var didFinish = false
+
+    /// Key code of a modifier pressed while it was the *only* modifier held —
+    /// a candidate for a legacy lone-modifier hotkey. Cleared as soon as a
+    /// second modifier joins it, so a chord is never mistaken for a tap.
+    private var singleModifierCandidateKeyCode: Int?
+
+    /// Modifier key codes currently held, tracked per *physical key* rather
+    /// than per shared flag, so Left+Right Shift register as two distinct
+    /// keys even though they set the same modifier bit.
+    private var heldModifierKeyCodes: Set<Int> = []
+
+    private static let modifierKeyCodes = [54, 55, 56, 58, 59, 60, 61, 62, 63]
+
+    func start() {
+        guard eventTap == nil, fallbackMonitor == nil else { return }
+        didFinish = false
+        seedHeldModifiers()
+
+        if installEventTap() { return }
+
+        // No Accessibility permission — fall back to a local monitor. Ordinary
+        // combos still record; macOS-reserved ones can't reach us this way.
+        VocaLogger.warning(.hotKeyManager, "Recorder event tap unavailable — falling back to local monitor")
+        fallbackMonitor = NSEvent.addLocalMonitorForEvents(matching: [.keyDown, .flagsChanged]) { [weak self] event in
+            guard let self else { return event }
+            let consumed: Bool
+            switch event.type {
+            case .keyDown:
+                consumed = self.processKeyDown(
+                    keyCode: Int(event.keyCode),
+                    modifiers: HotKeyModifiers(nsFlags: event.modifierFlags),
+                    isRepeat: event.isARepeat
+                )
+            case .flagsChanged:
+                consumed = self.processFlagsChanged(keyCode: Int(event.keyCode))
+            default:
+                consumed = false
             }
-            singleModifierCandidateKeyCode = nil
-            return false
-        }
-
-        // This physical key was pressed. Only a press from zero-held is a
-        // lone-modifier candidate; anything joining an existing hold is
-        // building a chord and cancels any prior candidacy.
-        singleModifierCandidateKeyCode = heldModifierKeyCodes.isEmpty ? keyCode : nil
-        heldModifierKeyCodes.insert(keyCode)
-        return false
-    }
-
-    private func finalizeCapture(with combo: HotKeyCombo) {
-        didCapture = true
-        stopMonitoring()
-        DispatchQueue.main.async { [weak self] in
-            self?.onCapture?(combo)
+            return consumed ? nil : event
         }
     }
 
-    private func cancelCapture() {
-        guard !didCapture else { return }
-        didCapture = true
-        stopMonitoring()
+    /// Tear down without reporting anything.
+    func stop() {
+        didFinish = true
+        teardown()
+    }
+
+    /// Tear down and report the recording as cancelled (once).
+    func cancel() {
+        guard !didFinish else { return }
+        didFinish = true
+        teardown()
         DispatchQueue.main.async { [weak self] in
             self?.onCancel?()
         }
     }
 
-    private func shouldCancel(_ event: NSEvent) -> Bool {
-        event.type == .keyDown && Int(event.keyCode) == KeyCodeReference.escapeKeyCode
+    /// Reads actual physical key state so a modifier already held before the
+    /// user clicks "Record" is known from the start rather than assumed absent.
+    private func seedHeldModifiers() {
+        let held = Self.modifierKeyCodes.filter {
+            CGEventSource.keyState(.combinedSessionState, key: CGKeyCode($0))
+        }
+        heldModifierKeyCodes = Set(held)
+        singleModifierCandidateKeyCode = held.count == 1 ? held[0] : nil
+    }
+
+    private func installEventTap() -> Bool {
+        let mask: CGEventMask = (1 << CGEventType.keyDown.rawValue) | (1 << CGEventType.flagsChanged.rawValue)
+
+        guard let tap = CGEvent.tapCreate(
+            tap: .cgSessionEventTap,
+            place: .headInsertEventTap,
+            options: .defaultTap,
+            eventsOfInterest: mask,
+            callback: { _, type, event, userInfo in
+                guard let userInfo else { return Unmanaged.passUnretained(event) }
+                let recorder = Unmanaged<HotKeyComboRecorder>.fromOpaque(userInfo).takeUnretainedValue()
+                return recorder.handleTapEvent(type: type, event: event)
+                    ? nil
+                    : Unmanaged.passUnretained(event)
+            },
+            userInfo: Unmanaged.passUnretained(self).toOpaque()
+        ) else {
+            return false
+        }
+
+        let source = CFMachPortCreateRunLoopSource(kCFAllocatorDefault, tap, 0)
+        CFRunLoopAddSource(CFRunLoopGetMain(), source, .commonModes)
+        CGEvent.tapEnable(tap: tap, enable: true)
+
+        eventTap = tap
+        runLoopSource = source
+        return true
+    }
+
+    private func handleTapEvent(type: CGEventType, event: CGEvent) -> Bool {
+        if type == .tapDisabledByTimeout || type == .tapDisabledByUserInput {
+            if let eventTap {
+                CGEvent.tapEnable(tap: eventTap, enable: true)
+            }
+            return false
+        }
+
+        let keyCode = Int(event.getIntegerValueField(.keyboardEventKeycode))
+
+        switch type {
+        case .keyDown:
+            return processKeyDown(
+                keyCode: keyCode,
+                modifiers: HotKeyModifiers(cgEventFlags: event.flags),
+                isRepeat: event.getIntegerValueField(.keyboardEventAutorepeat) != 0
+            )
+        case .flagsChanged:
+            return processFlagsChanged(keyCode: keyCode)
+        default:
+            return false
+        }
+    }
+
+    /// A non-modifier key press finalizes immediately, using whatever
+    /// modifiers are held at that moment (possibly none).
+    private func processKeyDown(keyCode: Int, modifiers: HotKeyModifiers, isRepeat: Bool) -> Bool {
+        guard !didFinish else { return false }
+        guard !isRepeat else { return true }
+
+        if keyCode == KeyCodeReference.escapeKeyCode {
+            cancel()
+            return true
+        }
+
+        finish(with: HotKeyCombo(keyCode: keyCode, modifiers: modifiers))
+        return true
+    }
+
+    /// Modifier presses accumulate into a chord; a lone modifier pressed and
+    /// released with nothing else joining it records as a single-key hotkey.
+    /// Never consumes the event — modifiers must keep flowing to the system.
+    private func processFlagsChanged(keyCode: Int) -> Bool {
+        guard !didFinish, KeyCodeReference.isModifierKeyCode(keyCode) else { return false }
+
+        if heldModifierKeyCodes.remove(keyCode) != nil {
+            // This physical key was released.
+            guard heldModifierKeyCodes.isEmpty else { return false }
+            if singleModifierCandidateKeyCode == keyCode {
+                finish(with: HotKeyCombo(keyCode: keyCode, modifiers: []))
+            } else {
+                singleModifierCandidateKeyCode = nil
+            }
+            return false
+        }
+
+        // Pressed. Only a press from zero-held is a lone-modifier candidate;
+        // anything joining an existing hold is building a chord.
+        singleModifierCandidateKeyCode = heldModifierKeyCodes.isEmpty ? keyCode : nil
+        heldModifierKeyCodes.insert(keyCode)
+        return false
+    }
+
+    private func finish(with combo: HotKeyCombo) {
+        didFinish = true
+        teardown()
+        DispatchQueue.main.async { [weak self] in
+            self?.onCapture?(combo)
+        }
+    }
+
+    private func teardown() {
+        if let fallbackMonitor {
+            NSEvent.removeMonitor(fallbackMonitor)
+            self.fallbackMonitor = nil
+        }
+
+        guard let tap = eventTap else { return }
+
+        // Disable synchronously so no further callbacks can reach this object,
+        // but defer removing the run loop source so the run loop is never
+        // mutated from inside its own source callback.
+        CGEvent.tapEnable(tap: tap, enable: false)
+        let source = runLoopSource
+        eventTap = nil
+        runLoopSource = nil
+
+        DispatchQueue.main.async {
+            if let source {
+                CFRunLoopRemoveSource(CFRunLoopGetMain(), source, .commonModes)
+            }
+        }
     }
 
     deinit {
-        stopMonitoring()
+        stop()
     }
 }
 

--- a/Sources/VocaMac/Views/MenuBarView.swift
+++ b/Sources/VocaMac/Views/MenuBarView.swift
@@ -473,7 +473,7 @@ struct MenuBarView: View {
     }
 
     private var activationModeHint: String {
-        let keyName = KeyCodeReference.displayName(for: appState.hotKeyCode)
+        let keyName = KeyCodeReference.displayName(for: HotKeyCombo(keyCode: appState.hotKeyCode, modifiers: appState.hotKeyModifiers))
         switch appState.activationMode {
         case .pushToTalk:
             return "Hold \(keyName)"

--- a/Sources/VocaMac/Views/OnboardingView.swift
+++ b/Sources/VocaMac/Views/OnboardingView.swift
@@ -686,6 +686,9 @@ struct HotkeyConfigStep: View {
         .onChange(of: appState.hotKeyCode) {
             appState.syncHotKeyConfiguration()
         }
+        .onChange(of: appState.hotKeyModifiers) {
+            appState.syncHotKeyConfiguration()
+        }
     }
 }
 
@@ -835,7 +838,7 @@ struct CompleteStep: View {
                 if appState.inputMonitoringPermission == .granted {
                     SummaryItem(icon: "keyboard.fill", text: "Input monitoring enabled")
                 }
-                SummaryItem(icon: "keyboard", text: "Hotkey: \(KeyCodeReference.displayName(for: appState.hotKeyCode))")
+                SummaryItem(icon: "keyboard", text: "Hotkey: \(KeyCodeReference.displayName(for: HotKeyCombo(keyCode: appState.hotKeyCode, modifiers: appState.hotKeyModifiers)))")
             }
             .frame(maxWidth: .infinity, alignment: .leading)
             .padding()

--- a/Tests/VocaMacTests/AppStateTests.swift
+++ b/Tests/VocaMacTests/AppStateTests.swift
@@ -152,6 +152,7 @@ final class AppStateOnboardingTests: XCTestCase {
             "vocamac.hasCompletedOnboarding",
             "vocamac.activationMode",
             "vocamac.hotKeyCode",
+            "vocamac.hotKeyModifiers",
             "vocamac.doubleTapThreshold",
             "vocamac.maxRecordingDuration",
         ].forEach { UserDefaults.standard.removeObject(forKey: $0) }

--- a/Tests/VocaMacTests/HotKeyManagerTests.swift
+++ b/Tests/VocaMacTests/HotKeyManagerTests.swift
@@ -266,6 +266,174 @@ final class HotKeyManagerConfigurationTests: XCTestCase {
     }
 }
 
+// MARK: - HotKeyManager Combo Tests
+
+final class HotKeyManagerComboTests: XCTestCase {
+
+    private func markAsExternal(_ event: CGEvent) {
+        event.setIntegerValueField(.eventSourceUnixProcessID, value: 0)
+    }
+
+    /// Space (keyCode 49) is a good combo base key: not itself a modifier.
+    private func spaceEvent(keyDown: Bool, flags: CGEventFlags) throws -> CGEvent {
+        guard let event = CGEvent(keyboardEventSource: nil, virtualKey: 49, keyDown: keyDown) else {
+            throw XCTSkip("Could not create keyboard event")
+        }
+        markAsExternal(event)
+        event.flags = flags
+        return event
+    }
+
+    func testComboKeyDownWithExactModifiersStartsRecording() throws {
+        let manager = HotKeyManager()
+        manager.updateConfiguration(keyCode: 49, mode: .pushToTalk, safetyTimeout: 5.0, modifiers: .command)
+
+        let startExpectation = expectation(description: "Recording starts")
+        manager.onRecordingStart = { startExpectation.fulfill() }
+
+        let keyDown = try spaceEvent(keyDown: true, flags: .maskCommand)
+        XCTAssertTrue(manager._handleTestEvent(type: .keyDown, event: keyDown))
+        wait(for: [startExpectation], timeout: 1.0)
+        manager.resetKeyState()
+    }
+
+    func testComboKeyDownWithExtraModifierIsRejected() throws {
+        let manager = HotKeyManager()
+        manager.updateConfiguration(keyCode: 49, mode: .pushToTalk, safetyTimeout: 5.0, modifiers: .command)
+
+        let startExpectation = expectation(description: "Recording should not start")
+        startExpectation.isInverted = true
+        manager.onRecordingStart = { startExpectation.fulfill() }
+
+        let keyDown = try spaceEvent(keyDown: true, flags: [.maskCommand, .maskShift])
+        XCTAssertFalse(manager._handleTestEvent(type: .keyDown, event: keyDown))
+        wait(for: [startExpectation], timeout: 0.2)
+        manager.resetKeyState()
+    }
+
+    func testComboKeyDownWithMissingModifierIsRejected() throws {
+        let manager = HotKeyManager()
+        manager.updateConfiguration(keyCode: 49, mode: .pushToTalk, safetyTimeout: 5.0, modifiers: .command)
+
+        let startExpectation = expectation(description: "Recording should not start")
+        startExpectation.isInverted = true
+        manager.onRecordingStart = { startExpectation.fulfill() }
+
+        let keyDown = try spaceEvent(keyDown: true, flags: [])
+        XCTAssertFalse(manager._handleTestEvent(type: .keyDown, event: keyDown))
+        wait(for: [startExpectation], timeout: 0.2)
+        manager.resetKeyState()
+    }
+
+    /// Regression guard: plain spacebar-holding in another app must keep
+    /// working when a Space-based combo (e.g. ⌘Space) is configured. The
+    /// rejected initial press must not leave autorepeat events falsely
+    /// consumed on every subsequent repeat.
+    func testComboRejectedKeyDownAutorepeatIsNotConsumed() throws {
+        let manager = HotKeyManager()
+        manager.updateConfiguration(keyCode: 49, mode: .pushToTalk, safetyTimeout: 5.0, modifiers: .command)
+
+        let startExpectation = expectation(description: "Recording should not start")
+        startExpectation.isInverted = true
+        manager.onRecordingStart = { startExpectation.fulfill() }
+
+        let keyDown = try spaceEvent(keyDown: true, flags: [])
+        XCTAssertFalse(manager._handleTestEvent(type: .keyDown, event: keyDown))
+
+        let repeatedKeyDown = try spaceEvent(keyDown: true, flags: [])
+        repeatedKeyDown.setIntegerValueField(.keyboardEventAutorepeat, value: 1)
+        XCTAssertFalse(manager._handleTestEvent(type: .keyDown, event: repeatedKeyDown), "Autorepeat of an unrelated Space press must pass through to the frontmost app")
+
+        wait(for: [startExpectation], timeout: 0.2)
+        manager.resetKeyState()
+    }
+
+    func testComboKeyUpStopsPushToTalk() throws {
+        let manager = HotKeyManager()
+        manager.updateConfiguration(keyCode: 49, mode: .pushToTalk, safetyTimeout: 5.0, modifiers: .command)
+
+        let startExpectation = expectation(description: "Recording starts")
+        let stopExpectation = expectation(description: "Recording stops")
+        manager.onRecordingStart = { startExpectation.fulfill() }
+        manager.onRecordingStop = { stopExpectation.fulfill() }
+
+        let keyDown = try spaceEvent(keyDown: true, flags: .maskCommand)
+        XCTAssertTrue(manager._handleTestEvent(type: .keyDown, event: keyDown))
+        wait(for: [startExpectation], timeout: 1.0)
+
+        let keyUp = try spaceEvent(keyDown: false, flags: .maskCommand)
+        XCTAssertTrue(manager._handleTestEvent(type: .keyUp, event: keyUp))
+        wait(for: [stopExpectation], timeout: 1.0)
+        manager.resetKeyState()
+    }
+
+    func testComboModifierReleasedWhileBaseKeyHeldForcesStop() throws {
+        let manager = HotKeyManager()
+        manager.updateConfiguration(keyCode: 49, mode: .pushToTalk, safetyTimeout: 5.0, modifiers: .command)
+
+        let startExpectation = expectation(description: "Recording starts")
+        let stopExpectation = expectation(description: "Recording stops")
+        manager.onRecordingStart = { startExpectation.fulfill() }
+        manager.onRecordingStop = { stopExpectation.fulfill() }
+
+        let keyDown = try spaceEvent(keyDown: true, flags: .maskCommand)
+        XCTAssertTrue(manager._handleTestEvent(type: .keyDown, event: keyDown))
+        wait(for: [startExpectation], timeout: 1.0)
+
+        // Command is released (flagsChanged for Right Command, keyCode 54)
+        // while Space is still conceptually held.
+        guard let modifierUp = CGEvent(keyboardEventSource: nil, virtualKey: 54, keyDown: false) else {
+            throw XCTSkip("Could not create modifier event")
+        }
+        markAsExternal(modifierUp)
+        modifierUp.flags = []
+
+        _ = manager._handleTestEvent(type: .flagsChanged, event: modifierUp)
+        wait(for: [stopExpectation], timeout: 1.0)
+        manager.resetKeyState()
+    }
+
+    func testComboDoubleTapTiming() throws {
+        let manager = HotKeyManager()
+        manager.updateConfiguration(keyCode: 49, mode: .doubleTapToggle, doubleTapThreshold: 1.0, safetyTimeout: 5.0, modifiers: .control)
+
+        let startExpectation = expectation(description: "Double-tap starts recording")
+        manager.onRecordingStart = { startExpectation.fulfill() }
+
+        let firstTap = try spaceEvent(keyDown: true, flags: .maskControl)
+        XCTAssertTrue(manager._handleTestEvent(type: .keyDown, event: firstTap))
+
+        let releaseDelay = expectation(description: "Delay between taps")
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.06) {
+            releaseDelay.fulfill()
+        }
+        wait(for: [releaseDelay], timeout: 1.0)
+
+        let secondTap = try spaceEvent(keyDown: true, flags: .maskControl)
+        XCTAssertTrue(manager._handleTestEvent(type: .keyDown, event: secondTap))
+        wait(for: [startExpectation], timeout: 1.0)
+        manager.resetKeyState()
+    }
+
+    func testLegacyRegularKeyStillIgnoresModifiers() throws {
+        let manager = HotKeyManager()
+        manager.updateConfiguration(keyCode: 96, mode: .pushToTalk, safetyTimeout: 5.0) // F5, no modifiers configured
+
+        let startExpectation = expectation(description: "Recording starts regardless of held modifiers")
+        manager.onRecordingStart = { startExpectation.fulfill() }
+
+        guard let keyDown = CGEvent(keyboardEventSource: nil, virtualKey: 96, keyDown: true) else {
+            throw XCTSkip("Could not create keyboard event")
+        }
+        markAsExternal(keyDown)
+        keyDown.flags = .maskCommand
+
+        XCTAssertTrue(manager._handleTestEvent(type: .keyDown, event: keyDown))
+        wait(for: [startExpectation], timeout: 1.0)
+        manager.resetKeyState()
+    }
+}
+
 // MARK: - HotKeyManager Reset State Tests
 
 final class HotKeyManagerResetStateTests: XCTestCase {

--- a/Tests/VocaMacTests/Mocks/MockServices.swift
+++ b/Tests/VocaMacTests/Mocks/MockServices.swift
@@ -109,6 +109,7 @@ final class MockHotKeyManager: HotKeyMonitoring {
     var lastMode: ActivationMode?
     var lastDoubleTapThreshold: Double?
     var lastSafetyTimeout: Double?
+    var lastModifiers: HotKeyModifiers?
     var resetKeyStateCallCount = 0
     var updateConfigurationCallCount = 0
 
@@ -122,12 +123,13 @@ final class MockHotKeyManager: HotKeyMonitoring {
         accessibilityPermission = granted
     }
 
-    func startListening(keyCode: Int, mode: ActivationMode, doubleTapThreshold: Double, safetyTimeout: Double) {
+    func startListening(keyCode: Int, mode: ActivationMode, doubleTapThreshold: Double, safetyTimeout: Double, modifiers: HotKeyModifiers) {
         startListeningCallCount += 1
         lastKeyCode = keyCode
         lastMode = mode
         lastDoubleTapThreshold = doubleTapThreshold
         lastSafetyTimeout = safetyTimeout
+        lastModifiers = modifiers
         isListening = true
     }
 
@@ -139,7 +141,7 @@ final class MockHotKeyManager: HotKeyMonitoring {
         resetKeyStateCallCount += 1
     }
 
-    func _updateConfiguration(keyCode: Int?, mode: ActivationMode?, doubleTapThreshold: Double?, safetyTimeout: Double?) {
+    func _updateConfiguration(keyCode: Int?, mode: ActivationMode?, doubleTapThreshold: Double?, safetyTimeout: Double?, modifiers: HotKeyModifiers?) {
         updateConfigurationCallCount += 1
         if let keyCode = keyCode {
             lastKeyCode = keyCode
@@ -152,6 +154,9 @@ final class MockHotKeyManager: HotKeyMonitoring {
         }
         if let safetyTimeout = safetyTimeout {
             lastSafetyTimeout = safetyTimeout
+        }
+        if let modifiers = modifiers {
+            lastModifiers = modifiers
         }
     }
 }

--- a/Tests/VocaMacTests/ServiceTests.swift
+++ b/Tests/VocaMacTests/ServiceTests.swift
@@ -16,7 +16,7 @@ final class KeyCodeReferenceTests: XCTestCase {
     }
 
     func testDisplayNameForKnownKeyCode() {
-        XCTAssertEqual(KeyCodeReference.displayName(for: 61), "Right Option (⌥)")
+        XCTAssertEqual(KeyCodeReference.displayName(for: HotKeyCombo(keyCode: 61, modifiers: [])), "Right Option (⌥)")
     }
 
     func testDisplayNameForRecordedCharacterKeyCodeUsesActiveLayout() throws {
@@ -24,19 +24,19 @@ final class KeyCodeReferenceTests: XCTestCase {
             throw XCTSkip("Could not inspect active keyboard layout")
         }
 
-        XCTAssertEqual(KeyCodeReference.displayName(for: Int(keyCode)), "A")
+        XCTAssertEqual(KeyCodeReference.displayName(for: HotKeyCombo(keyCode: Int(keyCode), modifiers: [])), "A")
     }
 
     func testDisplayNameForRecordedFunctionKeyCode() {
-        XCTAssertEqual(KeyCodeReference.displayName(for: 105), "F13")
+        XCTAssertEqual(KeyCodeReference.displayName(for: HotKeyCombo(keyCode: 105, modifiers: [])), "F13")
     }
 
     func testDisplayNameForUnknownKeyCode() {
-        XCTAssertEqual(KeyCodeReference.displayName(for: 999), "Key 999")
+        XCTAssertEqual(KeyCodeReference.displayName(for: HotKeyCombo(keyCode: 999, modifiers: [])), "Key 999")
     }
 
     func testCustomKeyCodeIsNotCommonPreset() {
-        XCTAssertFalse(KeyCodeReference.isCommonHotKey(105))
+        XCTAssertFalse(KeyCodeReference.isCommonHotKey(HotKeyCombo(keyCode: 105, modifiers: [])))
     }
 
     func testModifierKeyCodeDetection() {
@@ -47,11 +47,19 @@ final class KeyCodeReferenceTests: XCTestCase {
 
     func testEscapeKeyCodeConstant() {
         XCTAssertEqual(KeyCodeReference.escapeKeyCode, 53)
-        XCTAssertEqual(KeyCodeReference.displayName(for: KeyCodeReference.escapeKeyCode), "Escape")
+        XCTAssertEqual(KeyCodeReference.displayName(for: HotKeyCombo(keyCode: KeyCodeReference.escapeKeyCode, modifiers: [])), "Escape")
     }
 
     func testDisplayNameForSpaceUsesReadableName() {
-        XCTAssertEqual(KeyCodeReference.displayName(for: 49), "Space")
+        XCTAssertEqual(KeyCodeReference.displayName(for: HotKeyCombo(keyCode: 49, modifiers: [])), "Space")
+    }
+
+    func testDisplayNameForComboUsesModifierSymbols() {
+        XCTAssertEqual(KeyCodeReference.displayName(for: HotKeyCombo(keyCode: 49, modifiers: .command)), "⌘ Space")
+    }
+
+    func testComboPresetIsRecognizedAsCommonHotKey() {
+        XCTAssertTrue(KeyCodeReference.isCommonHotKey(HotKeyCombo(keyCode: 49, modifiers: .command)))
     }
 
     func testCommonHotKeysValid() {


### PR DESCRIPTION
closes: #132

<img width="560" height="604" alt="Screenshot 2026-08-11 at 3 05 16 AM" src="https://github.com/user-attachments/assets/f5e44fa7-3786-41ec-953a-3249ba1fb7ca" />
<img width="559" height="600" alt="Screenshot 2026-08-11 at 3 05 27 AM" src="https://github.com/user-attachments/assets/28dc5f3d-be54-4fc4-8a6f-0cc8301cde6f" />


## Summary
- Quick dictation was previously limited to a single key (a lone modifier like Right Option, or a regular key like F5). Adds support for modifier+key combos (e.g. ⌘Space, ⌃Space, ⌥Space, ⌃⌥Space) while every existing single-key hotkey keeps working exactly as before.
- New `HotKeyCombo`/`HotKeyModifiers` model (`Sources/VocaMac/Models/HotKeyModifiers.swift`) represents "required modifiers + base key," stored via a new `@AppStorage("vocamac.hotKeyModifiers")` field alongside the existing `hotKeyCode`.
- `HotKeyManager`'s global event tap now gates a combo's base key on an exact modifier match, and force-stops push-to-talk if a required modifier is released before the base key.
- The Settings/Onboarding hotkey recorder now captures full combos: it tracks held modifiers by physical key code (not shared NSEvent flag) so Left+Right presses of the same modifier aren't conflated, and seeds its initial state from live key state (`CGEventSource.keyState`) so a modifier already held down when "Record" is clicked is handled correctly.
- Fixed a regression where an unmatched Space-based combo press could swallow autorepeat keystrokes for plain spacebar use in other apps.

## Test plan
- [x] `swift build` — clean, no warnings introduced
- [x] `swift test` — all pre-existing and new tests pass (full suite run 3x for stability; excluded a pre-existing flaky/segfaulting `AudioEngine` hardware-access suite that reproduces identically on unmodified `main`)
- [x] New unit tests: combo start/stop, exact-match rejection of extra/missing modifiers, early modifier-release force-stop, double-tap combo timing, autorepeat-pass-through regression guard, legacy single-key regression guard
- [ ] Manual verification in the running app (Settings → General → Record a combo, confirm it triggers dictation and a plain key-press elsewhere still works normally)