### PR TITLE
feat: add Parakeet 110M English model

### DIFF
--- a/README.md
+++ b/README.md
@@ -271,6 +271,7 @@ NVIDIA Parakeet TDT models running as CoreML on the Apple Neural Engine (via [Fl
 |-------|------|-------|-----------|
 | **Parakeet v3** | ~0.7 GB | ⚡⚡⚡⚡⚡ | 25 European languages + Japanese, auto-detected |
 | **Parakeet v2** | ~1.2 GB | ⚡⚡⚡⚡⚡ | English only, highest recall |
+| **Parakeet 110M** | ~0.2 GB | ⚡⚡⚡⚡⚡ | English only, smaller download and faster first load |
 
 ### Whisper — widest language coverage
 

--- a/Sources/VocaMac/Models/WhisperModel.swift
+++ b/Sources/VocaMac/Models/WhisperModel.swift
@@ -28,6 +28,7 @@ enum ModelSize: String, CaseIterable, Codable, Identifiable {
     // Parakeet (FluidAudio)
     case parakeetV3                   = "parakeet-tdt-0.6b-v3"
     case parakeetV2                   = "parakeet-tdt-0.6b-v2"
+    case parakeetTdtCtc110m           = "parakeet-tdt-ctc-110m"
 
     // Apple Speech (macOS 26+ system engine)
     case appleSpeech                  = "apple-speech"
@@ -44,7 +45,7 @@ enum ModelSize: String, CaseIterable, Codable, Identifiable {
     /// Which engine runs this model.
     var engine: TranscriptionEngine {
         switch self {
-        case .parakeetV3, .parakeetV2:
+        case .parakeetV3, .parakeetV2, .parakeetTdtCtc110m:
             return .parakeet
         case .appleSpeech:
             return .appleSpeech
@@ -103,6 +104,7 @@ enum ModelSize: String, CaseIterable, Codable, Identifiable {
     static let standardCatalog: [ModelSize] = [
         .parakeetV3,
         .parakeetV2,
+        .parakeetTdtCtc110m,
         .tiny,
         .base,
         .small,
@@ -141,6 +143,7 @@ enum ModelSize: String, CaseIterable, Codable, Identifiable {
         case .medium:                    return "Medium (Legacy)"
         case .parakeetV3:                return "Parakeet v3 (Multilingual)"
         case .parakeetV2:                return "Parakeet v2 (English)"
+        case .parakeetTdtCtc110m:        return "Parakeet 110M (English)"
         case .appleSpeech:               return "Apple Speech (System)"
         case .moonshineTiny:             return "Moonshine v2 Tiny (English)"
         case .moonshineBase:             return "Moonshine v2 Base (English)"
@@ -167,6 +170,7 @@ enum ModelSize: String, CaseIterable, Codable, Identifiable {
         case .medium:                    return 1_500_000_000
         case .parakeetV3:                return 700_000_000
         case .parakeetV2:                return 1_200_000_000
+        case .parakeetTdtCtc110m:        return 220_000_000
         case .appleSpeech:               return 0
         case .moonshineTiny:             return 60_000_000
         case .moonshineBase:             return 190_000_000
@@ -201,6 +205,7 @@ enum ModelSize: String, CaseIterable, Codable, Identifiable {
         case .medium:                    return 5.0
         case .parakeetV3:                return 2.0
         case .parakeetV2:                return 2.5
+        case .parakeetTdtCtc110m:        return 1.0
         case .appleSpeech:               return 1.0
         case .moonshineTiny:             return 0.5
         case .moonshineBase:             return 1.0
@@ -227,6 +232,7 @@ enum ModelSize: String, CaseIterable, Codable, Identifiable {
         case .medium:                    return 8
         case .parakeetV3:                return 1
         case .parakeetV2:                return 1
+        case .parakeetTdtCtc110m:        return 1
         case .appleSpeech:               return 2
         case .moonshineTiny:             return 2
         case .moonshineBase:             return 3
@@ -253,6 +259,7 @@ enum ModelSize: String, CaseIterable, Codable, Identifiable {
         case .medium:                    return "Legacy"
         case .parakeetV3:                return "Excellent"
         case .parakeetV2:                return "Excellent"
+        case .parakeetTdtCtc110m:        return "Great"
         case .appleSpeech:               return "Excellent"
         case .moonshineTiny:             return "Good"
         case .moonshineBase:             return "Better"

--- a/Sources/VocaMac/Services/ModelManager.swift
+++ b/Sources/VocaMac/Services/ModelManager.swift
@@ -296,7 +296,7 @@ final class ModelManager {
             return "openai_whisper-large-v3_turbo"
         case .medium:
             return "openai_whisper-medium"
-        case .parakeetV3, .parakeetV2, .appleSpeech,
+        case .parakeetV3, .parakeetV2, .parakeetTdtCtc110m, .appleSpeech,
              .moonshineTiny, .moonshineBase, .senseVoiceSmall, .gigaamV3, .canary180mFlash:
             // Not WhisperKit models — identified by their raw value.
             return size.rawValue
@@ -770,6 +770,7 @@ final class ModelManager {
             modelStorageBase,
             parakeetDirectory(for: .v3),
             parakeetDirectory(for: .v2),
+            parakeetDirectory(for: .tdtCtc110m),
             SherpaService.storageRoot,
         ]
     }

--- a/Sources/VocaMac/Services/ParakeetService.swift
+++ b/Sources/VocaMac/Services/ParakeetService.swift
@@ -53,9 +53,10 @@ final class ParakeetService: @unchecked Sendable {
     /// Map a catalog entry to FluidAudio's model version.
     static func modelVersion(for size: ModelSize) -> AsrModelVersion? {
         switch size {
-        case .parakeetV3: return .v3
-        case .parakeetV2: return .v2
-        default:          return nil
+        case .parakeetV3:         return .v3
+        case .parakeetV2:         return .v2
+        case .parakeetTdtCtc110m: return .tdtCtc110m
+        default:                  return nil
         }
     }
 

--- a/Tests/VocaMacTests/Mocks/MockServices.swift
+++ b/Tests/VocaMacTests/Mocks/MockServices.swift
@@ -334,7 +334,7 @@ final class MockModelManager: ModelManaging {
             return "openai_whisper-large-v3_turbo"
         case .medium:
             return "openai_whisper-medium"
-        case .parakeetV3, .parakeetV2, .appleSpeech,
+        case .parakeetV3, .parakeetV2, .parakeetTdtCtc110m, .appleSpeech,
              .moonshineTiny, .moonshineBase, .senseVoiceSmall, .gigaamV3, .canary180mFlash:
             return size.rawValue
         }

--- a/Tests/VocaMacTests/ModelTests.swift
+++ b/Tests/VocaMacTests/ModelTests.swift
@@ -103,7 +103,7 @@ final class ModelSizeTests: XCTestCase {
     }
 
     func testAllCasesCount() {
-        XCTAssertEqual(ModelSize.allCases.count, 20)
+        XCTAssertEqual(ModelSize.allCases.count, 21)
     }
 
     func testRawValues() {
@@ -121,6 +121,7 @@ final class ModelSizeTests: XCTestCase {
         XCTAssertEqual(ModelSize.medium.rawValue, "medium")
         XCTAssertEqual(ModelSize.parakeetV3.rawValue, "parakeet-tdt-0.6b-v3")
         XCTAssertEqual(ModelSize.parakeetV2.rawValue, "parakeet-tdt-0.6b-v2")
+        XCTAssertEqual(ModelSize.parakeetTdtCtc110m.rawValue, "parakeet-tdt-ctc-110m")
         XCTAssertEqual(ModelSize.appleSpeech.rawValue, "apple-speech")
         XCTAssertEqual(ModelSize.moonshineTiny.rawValue, "moonshine-v2-tiny-en")
         XCTAssertEqual(ModelSize.moonshineBase.rawValue, "moonshine-v2-base-en")
@@ -137,6 +138,7 @@ final class ModelSizeTests: XCTestCase {
     func testStandardCatalogIncludesNewEngines() {
         XCTAssertTrue(ModelSize.standardCatalog.contains(.parakeetV3))
         XCTAssertTrue(ModelSize.standardCatalog.contains(.parakeetV2))
+        XCTAssertTrue(ModelSize.standardCatalog.contains(.parakeetTdtCtc110m))
         XCTAssertTrue(ModelSize.standardCatalog.contains(.appleSpeech))
         XCTAssertTrue(ModelSize.standardCatalog.contains(.moonshineTiny))
         XCTAssertTrue(ModelSize.standardCatalog.contains(.senseVoiceSmall))
@@ -147,6 +149,7 @@ final class ModelSizeTests: XCTestCase {
     func testEngineAssignment() {
         XCTAssertEqual(ModelSize.parakeetV3.engine, .parakeet)
         XCTAssertEqual(ModelSize.parakeetV2.engine, .parakeet)
+        XCTAssertEqual(ModelSize.parakeetTdtCtc110m.engine, .parakeet)
         XCTAssertEqual(ModelSize.appleSpeech.engine, .appleSpeech)
         XCTAssertEqual(ModelSize.moonshineTiny.engine, .sherpaOnnx)
         XCTAssertEqual(ModelSize.moonshineBase.engine, .sherpaOnnx)
@@ -157,6 +160,13 @@ final class ModelSizeTests: XCTestCase {
         // Everything else is a WhisperKit model.
         let whisperCases = ModelSize.allCases.filter { $0.engine == .whisperKit }
         XCTAssertEqual(whisperCases.count, 12)
+    }
+
+    func testParakeetModelVersionMapping() {
+        XCTAssertEqual(ParakeetService.modelVersion(for: .parakeetV3), .v3)
+        XCTAssertEqual(ParakeetService.modelVersion(for: .parakeetV2), .v2)
+        XCTAssertEqual(ParakeetService.modelVersion(for: .parakeetTdtCtc110m), .tdtCtc110m)
+        XCTAssertNil(ParakeetService.modelVersion(for: .tiny))
     }
 
     func testEngineCapabilities() {
@@ -177,6 +187,7 @@ final class TranscriptionRouterTests: XCTestCase {
         XCTAssertEqual(TranscriptionRouter.engine(forModelIdentifier: "tiny"), .whisperKit)
         XCTAssertEqual(TranscriptionRouter.engine(forModelIdentifier: "parakeet-tdt-0.6b-v3"), .parakeet)
         XCTAssertEqual(TranscriptionRouter.engine(forModelIdentifier: "parakeet-tdt-0.6b-v2"), .parakeet)
+        XCTAssertEqual(TranscriptionRouter.engine(forModelIdentifier: "parakeet-tdt-ctc-110m"), .parakeet)
         XCTAssertEqual(TranscriptionRouter.engine(forModelIdentifier: "apple-speech"), .appleSpeech)
         XCTAssertEqual(TranscriptionRouter.engine(forModelIdentifier: "unknown-model"), .whisperKit)
     }
@@ -258,11 +269,13 @@ final class ModelManagerTests: XCTestCase {
         let manager = ModelManager()
         XCTAssertEqual(manager.modelIdentifier(for: .parakeetV3), "parakeet-tdt-0.6b-v3")
         XCTAssertEqual(manager.modelIdentifier(for: .parakeetV2), "parakeet-tdt-0.6b-v2")
+        XCTAssertEqual(manager.modelIdentifier(for: .parakeetTdtCtc110m), "parakeet-tdt-ctc-110m")
         XCTAssertEqual(manager.modelIdentifier(for: .appleSpeech), "apple-speech")
         XCTAssertEqual(manager.modelIdentifier(for: .tiny), "openai_whisper-tiny")
 
         XCTAssertEqual(manager.modelSize(from: "parakeet-tdt-0.6b-v3"), .parakeetV3)
         XCTAssertEqual(manager.modelSize(from: "parakeet-tdt-0.6b-v2"), .parakeetV2)
+        XCTAssertEqual(manager.modelSize(from: "parakeet-tdt-ctc-110m"), .parakeetTdtCtc110m)
         XCTAssertEqual(manager.modelSize(from: "apple-speech"), .appleSpeech)
     }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds FluidAudio’s Parakeet TDT-CTC 110M as a third Parakeet option in Settings → Models.

### Why
v2/v3 are ~440–460 MB of required CoreML files. The 110M hybrid is ~220 MB, English-only, and FluidAudio’s benches put it around 3% LibriSpeech WER with a quicker cold start. Same `AsrModels.download` path we already use for v2/v3 — no FluidAudio bump (`.tdtCtc110m` is in 0.15.5).

### Changes
- New catalog entry `parakeet-tdt-ctc-110m` → `AsrModelVersion.tdtCtc110m`
- Disk-usage scan includes the 110M cache directory
- Tests for raw value, engine routing, and version mapping
- README Parakeet table row

### Notes
Picker label: **Parakeet 110M (English)**. Kept JA / streaming Parakeet variants out of this PR.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4a8fe777-2422-44ee-93df-8950bb37c1bf?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4a8fe777-2422-44ee-93df-8950bb37c1bf&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

