### PR TITLE
docs: VocaHQ parity plan (bring VocaLinux v0.15 UX to VocaMac)

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -514,36 +514,40 @@ swift build -c release
 
 ## 8. Cross-Platform Strategy
 
-### 8.1 Architecture for Future Portability
+VocaMac is part of [VocaHQ](https://github.com/VocaHQ): offline voice dictation on each OS, with feature parity over time. Sister apps: [VocaLinux](https://github.com/VocaHQ/vocalinux) (stable), VocaWin (coming soon), VocaPhone (in development).
 
-While VocaMac is a native macOS app, the architecture is designed to facilitate a future Windows port (VocaWin):
+The living Mac ↔ Linux gap list and phased port plan live in [`docs/VOCAHQ_PARITY.md`](VOCAHQ_PARITY.md).
+
+### 8.1 Shared jobs, native code
 
 ```
 Shared Concepts:
-  └── Whisper models        ← Same model family across platforms
-  └── UX patterns           ← Same user interaction design
+  └── Speech model families   ← Whisper-class (+ platform specialists)
+  └── UX patterns             ← Hotkey → speak → inject; searchable settings IA
+  └── Power controls          ← Auto-pause apps; idle model unload
+  └── Output polish           ← Trailing space; capitalization rules
 
 Platform-Specific:
-  ┌──────────────────────┬──────────────────────┐
-  │      macOS            │      Windows         │
-  ├──────────────────────┼──────────────────────┤
-  │ Swift + SwiftUI      │ C++/C# + WinUI 3    │
-  │ AVAudioEngine        │ WASAPI / NAudio      │
-  │ CGEventTap           │ SetWindowsHookEx     │
-  │ NSPasteboard + CGEvt │ Clipboard + SendInput│
-  │ Metal acceleration   │ CUDA / DirectML      │
-  │ MenuBarExtra         │ System Tray (NotifyIcon) │
-  └──────────────────────┴──────────────────────┘
+  ┌──────────────────────┬──────────────────────┬──────────────────────┐
+  │      macOS            │      Linux            │      Windows         │
+  ├──────────────────────┼──────────────────────┼──────────────────────┤
+  │ Swift + SwiftUI      │ Python + GTK         │ (VocaWin TBD)        │
+  │ AVAudioEngine        │ PortAudio            │ WASAPI / NAudio      │
+  │ CGEventTap           │ evdev / pynput       │ SetWindowsHookEx     │
+  │ AX + NSPasteboard    │ IBus / ydotool / …   │ Clipboard + SendInput│
+  │ CoreML / Metal / ANE │ Vulkan / CUDA        │ CUDA / DirectML      │
+  │ MenuBarExtra         │ AppIndicator tray    │ NotifyIcon           │
+  └──────────────────────┴──────────────────────┴──────────────────────┘
 ```
 
-### 8.2 What Can Be Shared
+### 8.2 What can be shared
 
-- **Whisper models** - Same OpenAI Whisper model family on all platforms
-- **Model files** - Each platform uses its optimal format (CoreML on macOS, GGML on Linux/Windows)
-- **Model catalog** - Same model variants and metadata
-- **UX patterns** - Same user flows and interaction design
+- User jobs and settings topic names (Dictation, Speech Model, Audio, Performance, …)
+- Model catalog *ideas* (size tiers, language honesty); each OS keeps its optimal format
+- Preference semantics (auto-pause app list, idle timeout, trailing space)
+- Privacy bar: local engines, no account wall
 
-### 8.3 What Must Be Platform-Specific
+### 8.3 What must stay platform-specific
 
 - UI framework and rendering
 - Audio capture API
@@ -551,7 +555,7 @@ Platform-Specific:
 - Text injection method
 - Permission handling
 - App lifecycle and distribution
-
+- GPU / NPU acceleration APIs
 ---
 
 ## 9. Error Handling Strategy

--- a/docs/VOCAHQ_PARITY.md
+++ b/docs/VOCAHQ_PARITY.md
@@ -1,0 +1,230 @@
+# VocaHQ feature parity (VocaMac)
+
+Living plan for bringing VocaMac in line with the Voca family product bar, starting from VocaLinux v0.15.
+
+**Org principle** ([VocaHQ/PRODUCT.md](https://github.com/VocaHQ/vocahq/blob/main/PRODUCT.md)): feature parity over time across platforms. Same jobs, native code. Not a shared UI toolkit, not identical screenshots.
+
+**Sources reviewed for this draft:**
+
+- VocaLinux `main` (v0.15 line): searchable sidebar settings (#601, #618), auto-pause + idle unload (#592), dictation polish (#554, #608), language catalog (#616)
+- VocaMac `main`: tabbed settings, four-engine `TranscriptionRouter`, cursor overlay, stats, AX injection
+- VocaHQ product principles and status labels
+
+---
+
+## 1. What "parity" means here
+
+| Means | Does not mean |
+|-------|---------------|
+| Same user jobs: hotkey → speak → text at cursor | Shared GTK/SwiftUI widgets |
+| Same settings topics and searchability | Pixel-identical layouts |
+| Same power controls (pause for apps, unload when idle) | Porting `psutil` / logind / Vulkan pickers |
+| Honest per-engine language and model labels | One engine stack on every OS |
+| Shared vocabulary for features in docs and marketing | Shipping Linux-only packaging or IBus |
+
+Platform adapters stay native: `NSWorkspace` instead of `psutil`, `NSWorkspace` sleep/wake instead of logind, Metal/CoreML instead of Vulkan.
+
+---
+
+## 2. Snapshot matrix
+
+Status as of this document. Update cells when follow-up PRs land.
+
+| Category | Capability | VocaLinux v0.15 | VocaMac | Target |
+|----------|------------|-----------------|---------|--------|
+| Core loop | Push-to-talk / toggle, silence stop, inject | Yes | Yes | Keep |
+| Settings IA | Topic pages in a **left sidebar** | Yes | Horizontal tabs | Port UX |
+| Settings IA | Live **settings search** | Yes | No | Port UX |
+| Settings IA | Persistent status / mic / test footer | Yes | No | Port UX |
+| Output | Trailing space after utterance | Yes | No | Port |
+| Output | Auto-capitalize after sentence ends | Yes (esp. VOSK path) | No | Port where useful |
+| Output | Voice commands | Yes (engine-gated) | No | Later / optional |
+| Output | Custom vocabulary | No | Yes (Whisper) | Keep; feed Linux later |
+| Output | Translation | No | Yes (Whisper) | Keep |
+| Power | Auto-pause while listed apps run | Yes | No | Port |
+| Power | Idle model unload (keep-alive) | Yes | No | Port |
+| Power | Sleep/wake recovery | Yes (logind) | Partial (audio route) | Strengthen |
+| Models | Multi-engine catalog | 3 + remote | 4 on-device | Keep Mac lead |
+| Models | Language catalog depth | ~33 + auto | ~17 + auto | Expand |
+| Updates | Stable / nightly channel picker | Yes | Nightly via separate cask/DMG | Align UX |
+| Diagnostics | In-app log viewer | Yes | Copy/export only | Improve |
+| Stats | Usage stats / streaks | Thin | Rich Stats tab | Keep; feed Linux later |
+| UX | Cursor mic overlay | No | Yes | Keep |
+| UX | Onboarding wizard | Basic first-run | Full multi-step | Keep |
+
+---
+
+## 3. Unified settings IA (target)
+
+Mirror VocaLinux topic names where they map cleanly. Keep Mac-only content under the right topic.
+
+```
+Dictation       Hotkey, mode, silence/VAD, output formatting, voice commands (later)
+Speech Model    Engine/model picker, downloads, language catalog, translation/vocab
+Audio           Device, mic test, sound effects
+Performance     Auto-pause apps, idle unload, resource readout
+Application     Launch at login, cursor overlay, clipboard preserve, notifications
+Advanced        Engine knobs (gated), debug tools
+About           Version, update channel, links, setup wizard
+[Sidebar footer] Status, level meter, Test Dictation, Close
+```
+
+**macOS shell:** SwiftUI `NavigationSplitView` (or equivalent sidebar list + detail) + `.searchable`. Do not paste GTK layout into SwiftUI.
+
+**Search contract** (match Linux behavior):
+
+1. Index each control by title, subtitle, and optional keywords
+2. Filter rows in place; badge match counts on sidebar pages
+3. Jump to first page with matches; empty state when none
+4. Esc clears search; restore previous page
+
+Current tab → target page mapping:
+
+| Today | Target page |
+|-------|-------------|
+| General (hotkey, language, translation, vocab, behavior) | Split across Dictation / Speech Model / Application |
+| Models | Speech Model (+ resource bits → Performance) |
+| Stats | Application or its own sidebar entry (keep Mac lead) |
+| Audio | Audio |
+| Debug | Advanced |
+| About | About |
+
+---
+
+## 4. Power management (port of #592)
+
+### 4.1 Auto-pause for apps
+
+**Linux:** poll process basenames; unload model while any listed name runs; reload when none remain.
+
+**Mac adapter:**
+
+- Watch `NSWorkspace.shared.runningApplications` (and/or `NSWorkspace` launch/terminate notifications)
+- Match on bundle ID and/or executable basename (user-facing list should prefer app names + bundle IDs)
+- On pause: stop recording if active, call existing unload paths on `TranscriptionRouter` / engine services, set an `isAutoPaused` gate so hotkeys do not start capture
+- On resume: lazy reload on next dictation (same as Linux), or warm-reload if already preferred
+
+**Settings:** Performance page. Toggle + editable list + "Choose Running App…" picker.
+
+**Defaults:** off; empty app list; poll / refresh interval ~5s (reuse the existing ProcessMonitor cadence mindset; do not add a second high-frequency timer).
+
+### 4.2 Idle model unload ("keep-alive")
+
+**Linux:** after N seconds idle (default 300, options 1-30 min), unload model; next dictation reloads.
+
+**Mac adapter:**
+
+- Arm timer when `AppStatus` returns to `.idle` after a transcription
+- Cancel while recording/processing or while auto-paused
+- Call the same unload APIs used on engine switch
+- Surface cold-start latency honestly in UI copy
+
+**Note:** `AudioEngine` already releases the AVAudioEngine after 3s idle for Bluetooth HFP. Idle *model* unload is separate and optional.
+
+### 4.3 Sleep / wake
+
+Subscribe to `NSWorkspace.willSleepNotification` / `didWakeNotification` (and/or screen sleep). On wake: refresh audio devices and hotkey tap health; bump keep-alive. Skip model reload if still auto-paused.
+
+---
+
+## 5. Dictation polish (port of #554 / #608)
+
+Apply in one place before `TextInjector.inject`:
+
+| Preference | Default | Behavior |
+|------------|---------|----------|
+| `appendTrailingSpace` | `true` | Append a trailing space after a completed utterance so the next PTT/toggle session does not glue onto the previous sentence |
+| `autoCapitalize` | `true` | Capitalize start of session and after `.` `!` `?` when the engine did not already |
+
+Whisper / Apple Speech often emit capitalization already; keep the pass idempotent (do not double-upcase). Marketing copy that already claims this behavior should match the implementation once shipped.
+
+Voice commands stay **out of phase 1**. Port later as an optional, engine-aware post-processor, not as a default for WhisperKit.
+
+---
+
+## 6. Phased delivery (separate PRs)
+
+Ship one concern per PR. Do not bundle the settings shell with model lifecycle.
+
+### Phase 1: Output polish
+
+- Trailing space + auto-capitalize preferences and injection hook
+- Tests for edge cases (empty text, already capitalized, CJK, trailing punctuation)
+- Settings toggles under Dictation/Output (can live in General until the sidebar lands)
+
+### Phase 2: Performance / power
+
+- `AutoPauseMonitor` + preferences + Settings UI
+- `ModelKeepAlive` idle unload + preferences
+- Sleep/wake hardening
+- Tests with injected process snapshots / fake clocks
+
+### Phase 3: Settings shell
+
+- Sidebar navigation + searchable index
+- Sidebar footer: status, level, Test Dictation, Close
+- Rehome existing controls into the target IA
+- Preserve Stats and Mac-only controls
+
+### Phase 4: Catalog and updates
+
+- Expand language list toward the VocaLinux catalog; searchable language picker
+- Update channel selector (stable vs nightly) wired to the right GitHub release endpoints
+- Optional: richer log viewer in Advanced
+
+### Phase 5: Bidirectional / org
+
+- Feed Mac wins back to Linux where useful: stats, custom vocabulary, translation UX, multi-engine honesty
+- Keep the matrix in this file (and eventually a short matrix on vocahq.com) updated
+- VocaWin / VocaPhone consume the same taxonomy when they grow past marketing
+
+---
+
+## 7. Suggested Swift touch points
+
+| Work | Where |
+|------|--------|
+| Preferences | `AppState` `@AppStorage` keys (`vocamac.appendTrailingSpace`, `vocamac.autoCapitalize`, `vocamac.autoPause.*`, `vocamac.modelKeepAlive.*`) |
+| Text polish | Small helper used from `AppState` before `TextInjector` |
+| Auto-pause | New `AutoPauseMonitor` service; wire from `AppState` / app lifecycle |
+| Idle unload | New `ModelKeepAlive` helper calling `TranscriptionRouter` unload APIs |
+| Settings shell | Refactor `SettingsView.swift` off `TabView`; keep tab bodies as page views |
+| Search index | Lightweight struct listing title/subtitle/keywords → page id (no new dependency) |
+| Tests | `Tests/VocaMacTests/` mirrors Linux: pure matching + timeout logic without UI |
+
+Reuse unload already present on Whisper / Parakeet / Apple Speech / Sherpa services. Do not invent a second model lifecycle path.
+
+---
+
+## 8. Explicit non-goals (do not port)
+
+- IBus / ydotool / wtype / xdotool injection stacks
+- Vulkan device picker
+- VOSK as a Mac engine
+- Flatpak / AppImage / AUR packaging
+- systemd-logind D-Bus suspend API
+- Remote OpenAI-compatible API engine (revisit only if VocaGateway needs a Mac client)
+
+---
+
+## 9. Acceptance bar for "settings parity"
+
+A reviewer can open Settings and:
+
+1. Navigate by left sidebar topics (not only top tabs)
+2. Search "pause" or "idle" and land on Performance controls
+3. See live recognition status and run Test Dictation without leaving Settings
+4. Enable auto-pause, pick a running app, confirm the model unloads while it runs and reloads after
+5. Enable idle unload, wait past the timeout (or advance a test clock), confirm unload + next-dictation reload
+6. Dictate twice in a row with trailing-space on and get a clean space between utterances
+
+---
+
+## 10. Open questions
+
+1. **Stats placement:** keep a dedicated sidebar item vs fold into Application?
+2. **Auto-pause matching:** bundle ID only, or also process name for CLI tools / games?
+3. **Idle unload default:** stay opt-in (Linux default) or recommend-on for large models?
+4. **Voice commands:** skip until a Whisper-friendly design exists, or ship a small English command set behind a toggle?
+
+Resolve these in the phase PRs; do not block Phase 1 on them.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Draft plan for unifying VocaMac with the VocaLinux v0.15 feature bar under VocaHQ. This PR is docs only. Implementation lands in follow-up PRs, one phase each.

Deep dive compared VocaLinux `main` (sidebar settings, search, auto-pause, idle unload, dictation polish) against current VocaMac (tabbed settings, four-engine router, cursor overlay, stats). Org product truth still says "feature parity over time"; nothing in the repos tracked that as a living matrix until now.

### What this adds

- `docs/VOCAHQ_PARITY.md` — gap matrix, target settings IA, Mac adapters for auto-pause / idle unload / sleep-wake, phased delivery, explicit non-goals, acceptance bar
- `docs/ARCHITECTURE.md` §8 — points at VocaLinux / VocaHQ instead of a Windows-only sketch

### Priority order (follow-up PRs)

1. **Output polish** — trailing space + auto-capitalize before inject (Linux #554 / #608)
2. **Performance** — auto-pause listed apps + idle model unload (Linux #592), sleep/wake hardening via `NSWorkspace`
3. **Settings shell** — left sidebar + search + persistent dictation footer (Linux #601 / #618), SwiftUI `NavigationSplitView`, not a GTK port
4. **Catalog / updates** — deeper language list, searchable picker, stable/nightly channel UX
5. **Bidirectional** — feed Mac wins (stats, vocab, translation, multi-engine honesty) back toward Linux / org matrix

### Keep on Mac (do not regress)

Cursor overlay, AX-first injection, four on-device engines, usage stats, custom vocabulary, translation, richer onboarding.

### Do not port

IBus / ydotool stacks, Vulkan pickers, VOSK, Flatpak/AppImage, logind D-Bus.

### Open questions (called out in the doc)

- Stats as its own sidebar item vs under Application
- Auto-pause match on bundle ID vs process name
- Idle unload stay opt-in or nudge for large models
- Voice commands later vs a small optional English set

## Test plan

- [ ] Read `docs/VOCAHQ_PARITY.md` end to end; check the matrix matches what you know about both apps
- [ ] Skim ARCHITECTURE §8 for accuracy
- [ ] Decide whether Phase 1 (output polish) should be the first implementation PR after merge
- [ ] No code/runtime changes in this PR; CI docs-only is fine

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ff3afbc6-f148-446b-9ab6-d0863841eb4c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ff3afbc6-f148-446b-9ab6-d0863841eb4c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

