### PR TITLE
feat: VocaHQ parity (output polish, power controls, settings shell)

### DIFF
--- a/Sources/VocaMac/App/BrandAssets.swift
+++ b/Sources/VocaMac/App/BrandAssets.swift
@@ -33,7 +33,7 @@ enum BrandAssets {
 enum MenuBarIconStyle: Equatable {
     /// Black mark drawn as a template so macOS follows the menu bar appearance.
     case brandMarkTemplate
-    /// Mark tinted with the status color (recording).
+    /// Mark tinted with brand teal while recording (mic hot).
     case brandMarkTinted
     /// SF Symbol for processing / error.
     case systemSymbol(name: String)

--- a/Sources/VocaMac/App/VocaMacApp.swift
+++ b/Sources/VocaMac/App/VocaMacApp.swift
@@ -315,16 +315,16 @@ struct VocaMacApp: App {
 /// Renders the Voca mark in the menu bar with color changes based on app status.
 ///
 /// Idle uses a template silhouette so macOS follows the menu bar appearance.
-/// Recording tints that same mark red. Processing and error keep SF Symbols.
+/// Recording tints that same mark brand teal. Processing and error keep SF Symbols.
 ///
 /// MenuBarExtra strips SwiftUI `.foregroundStyle()` colors, so status colors
 /// are applied via `NSImage` + `sourceAtop` with `isTemplate = false`.
 ///
 /// States:
 ///   • idle       → Voca mark (template, adapts to menu bar)
-///   • recording  → Voca mark in red
-///   • processing → purple ellipsis (non-template, colored)
-///   • error      → yellow warning (non-template, colored)
+///   • recording  → Voca mark in brand teal (mic hot)
+///   • processing → yellow ellipsis (non-template, colored)
+///   • error      → orange warning (non-template, colored)
 struct MenuBarIcon: View {
     let appStatus: AppStatus
 
@@ -343,9 +343,9 @@ struct MenuBarIcon: View {
 
         case .brandMarkTinted:
             if let mark = sizedMark() {
-                return tintedImage(base: mark, color: .systemRed)
+                return tintedImage(base: mark, color: BrandAssets.brandGreen)
             }
-            return fallbackSymbol(named: "mic.fill", tint: .systemRed)
+            return fallbackSymbol(named: "mic.fill", tint: BrandAssets.brandGreen)
 
         case .systemSymbol(let name):
             return fallbackSymbol(named: name, tint: statusColor)
@@ -413,9 +413,9 @@ struct MenuBarIcon: View {
     private var statusColor: NSColor {
         switch appStatus {
         case .idle:       return BrandAssets.brandGreen
-        case .recording:  return .systemRed
-        case .processing: return NSColor(red: 0.749, green: 0.353, blue: 0.949, alpha: 1.0) // #BF5AF2
-        case .error:      return .systemYellow
+        case .recording:  return BrandAssets.brandGreen
+        case .processing: return .systemYellow
+        case .error:      return .systemOrange
         }
     }
 }

--- a/Sources/VocaMac/App/VocaMacApp.swift
+++ b/Sources/VocaMac/App/VocaMacApp.swift
@@ -26,7 +26,7 @@ final class SettingsWindowManager: ObservableObject {
 
         // Create a new window
         let window = NSWindow(
-            contentRect: NSRect(x: 0, y: 0, width: 560, height: 520),
+            contentRect: NSRect(x: 0, y: 0, width: 760, height: 560),
             styleMask: [.titled, .closable, .miniaturizable, .resizable],
             backing: .buffered,
             defer: false

--- a/Sources/VocaMac/Models/AppState.swift
+++ b/Sources/VocaMac/Models/AppState.swift
@@ -114,6 +114,41 @@ final class AppState: ObservableObject {
     @AppStorage("vocamac.translationEnabled") var translationEnabled: Bool = false
     @AppStorage("vocamac.customVocabulary") var customVocabulary: String = ""
     @AppStorage("vocamac.logLevel") var logLevel: String = "info"
+    @AppStorage(PreferenceKey.appendTrailingSpace) var appendTrailingSpace: Bool = true
+    @AppStorage(PreferenceKey.autoCapitalize) var autoCapitalize: Bool = true
+    @AppStorage(PreferenceKey.autoPauseEnabled) var autoPauseEnabled: Bool = false
+    @AppStorage(PreferenceKey.autoPausePollInterval) var autoPausePollIntervalSeconds: Double = 5
+    @AppStorage(PreferenceKey.modelKeepAliveEnabled) var modelKeepAliveEnabled: Bool = false
+    @AppStorage(PreferenceKey.modelKeepAliveIdleTimeout) var modelKeepAliveIdleTimeoutSeconds: Double = 300
+
+    /// JSON-encoded `[AutoPauseAppEntry]` list (complex value not stored via `@AppStorage`).
+    var autoPauseAppsJSON: String {
+        get { UserDefaults.standard.string(forKey: PreferenceKey.autoPauseApps) ?? "[]" }
+        set { UserDefaults.standard.set(newValue, forKey: PreferenceKey.autoPauseApps) }
+    }
+
+    /// Decoded auto-pause app list. Empty when unset or invalid JSON.
+    var autoPauseApps: [AutoPauseAppEntry] {
+        get {
+            guard let data = autoPauseAppsJSON.data(using: .utf8),
+                  let decoded = try? JSONDecoder().decode([AutoPauseAppEntry].self, from: data) else {
+                return []
+            }
+            return decoded
+        }
+        set {
+            if let data = try? JSONEncoder().encode(newValue),
+               let json = String(data: data, encoding: .utf8) {
+                autoPauseAppsJSON = json
+            } else {
+                autoPauseAppsJSON = "[]"
+            }
+            objectWillChange.send()
+        }
+    }
+
+    /// True while a configured auto-pause app is running and dictation is blocked.
+    @Published var isAutoPaused: Bool = false
 
     private var hotKeySafetyTimeout: Double {
         Double(maxRecordingDuration) + 5.0
@@ -132,10 +167,24 @@ final class AppState: ObservableObject {
     let updateChecker = UpdateChecker()
     let permissionManager: any PermissionManaging
 
+    /// Polls configured apps and pauses dictation while they run.
+    let autoPauseMonitor = AutoPauseMonitor()
+    /// Unloads the model after an idle timeout when enabled.
+    let modelKeepAlive = ModelKeepAlive()
+    /// Sleep/wake recovery hooks.
+    let sleepWakeMonitor = SleepWakeMonitor()
+
     // MARK: - Private
 
     private var cancellables = Set<AnyCancellable>()
     private var hasStarted = false
+
+    /// Why the model was last unloaded (for logs / UI).
+    enum ModelUnloadReason: String {
+        case autoPause = "auto_pause"
+        case idleKeepAlive = "idle_keepalive"
+        case manual = "manual"
+    }
 
     /// Bumped when each load operation starts. Failure restores and success UI
     /// updates only apply when the generation is still current, so a stale
@@ -432,6 +481,145 @@ final class AppState: ObservableObject {
 
         // Check permissions
         checkPermissions()
+
+        if !skipSystemIntegration {
+            setupPowerManagement()
+        }
+    }
+
+    // MARK: - Power Management
+
+    /// Wire auto-pause, idle unload, and sleep/wake monitors.
+    private func setupPowerManagement() {
+        autoPauseMonitor.getConfig = { [weak self] in
+            guard let self else {
+                return (false, [], AutoPauseMonitor.defaultPollIntervalSeconds)
+            }
+            return (
+                self.autoPauseEnabled,
+                self.autoPauseApps,
+                self.autoPausePollIntervalSeconds
+            )
+        }
+        autoPauseMonitor.onPause = { [weak self] in
+            Task { @MainActor in
+                await self?.handleAutoPauseEntered()
+            }
+        }
+        autoPauseMonitor.onResume = { [weak self] in
+            Task { @MainActor in
+                await self?.handleAutoPauseCleared()
+            }
+        }
+
+        modelKeepAlive.getConfig = { [weak self] in
+            guard let self else {
+                return (false, ModelKeepAlive.defaultIdleTimeoutSeconds)
+            }
+            return (self.modelKeepAliveEnabled, self.modelKeepAliveIdleTimeoutSeconds)
+        }
+        modelKeepAlive.isSafeToUnload = { [weak self] in
+            guard let self else { return false }
+            return self.appStatus == .idle
+                && !self.isAutoPaused
+                && self.whisperService.isModelLoaded
+        }
+        modelKeepAlive.onIdleUnload = { [weak self] in
+            Task { @MainActor in
+                await self?.unloadActiveModel(reason: .idleKeepAlive)
+            }
+        }
+
+        sleepWakeMonitor.onWillSleep = { [weak self] in
+            self?.modelKeepAlive.cancel()
+            if self?.isRecording == true || self?.appStatus == .recording {
+                self?.forceRecovery()
+            }
+        }
+        sleepWakeMonitor.onDidWake = { [weak self] in
+            guard let self else { return }
+            VocaLogger.info(.appState, "Wake recovery — refreshing hotkey health")
+            if self.permissionManager.allPermissionsGranted {
+                self.syncHotKeyConfiguration()
+                if !self.hotKeyManager.isListening {
+                    self.hotKeyManager.startListening(
+                        keyCode: self.hotKeyCode,
+                        mode: self.activationMode,
+                        doubleTapThreshold: self.doubleTapThreshold,
+                        safetyTimeout: self.hotKeySafetyTimeout
+                    )
+                }
+            }
+            if !self.isAutoPaused {
+                self.modelKeepAlive.bump()
+            }
+        }
+
+        $appStatus
+            .sink { [weak self] status in
+                guard let self else { return }
+                switch status {
+                case .idle:
+                    if !self.isAutoPaused {
+                        self.modelKeepAlive.bump()
+                    }
+                case .recording, .processing, .error:
+                    self.modelKeepAlive.cancel()
+                }
+            }
+            .store(in: &cancellables)
+
+        autoPauseMonitor.start()
+        modelKeepAlive.start()
+        sleepWakeMonitor.start()
+    }
+
+    /// Unload the resident model and clear active UI flags.
+    func unloadActiveModel(reason: ModelUnloadReason) async {
+        VocaLogger.info(.appState, "Unloading model (reason=\(reason.rawValue))")
+        modelKeepAlive.cancel()
+        await whisperService.unloadModel()
+        for i in availableModels.indices {
+            availableModels[i].isActive = false
+            availableModels[i].isLoading = false
+        }
+        currentModel = nil
+    }
+
+    /// Ensure a model is loaded before dictation (lazy reload after idle unload).
+    func ensureModelLoaded() async {
+        guard !whisperService.isModelLoaded else { return }
+        let size = ModelSize(rawValue: selectedModelSize)
+            ?? currentModel?.size
+            ?? .tiny
+        VocaLogger.info(.appState, "Ensuring model loaded: \(size.displayName)")
+        await loadModel(size)
+    }
+
+    private func handleAutoPauseEntered() async {
+        isAutoPaused = true
+        modelKeepAlive.cancel()
+
+        if isRecording || appStatus == .recording {
+            VocaLogger.warning(.appState, "Auto-pause entered while recording — stopping without inject")
+            _ = await stopAudioEngine()
+            isRecording = false
+            audioLevel = 0
+            cursorOverlay.hide()
+            hotKeyManager.resetKeyState()
+            appStatus = .idle
+        }
+
+        if whisperService.isModelLoaded {
+            await unloadActiveModel(reason: .autoPause)
+        }
+    }
+
+    private func handleAutoPauseCleared() async {
+        isAutoPaused = false
+        // Warm-reload so the next hotkey is ready (Linux behavior).
+        await ensureModelLoaded()
+        modelKeepAlive.bump()
     }
 
     /// Build the model list shown in Settings and onboarding.
@@ -569,6 +757,13 @@ final class AppState: ObservableObject {
             return
         }
 
+        if isAutoPaused {
+            let message = "Dictation is paused while a configured app is running."
+            VocaLogger.info(.appState, message)
+            showTemporaryError(message)
+            return
+        }
+
         guard appStatus == .idle else {
             // If stuck in .processing or .error for too long, force recovery
             // so the user can start a fresh recording.
@@ -585,6 +780,17 @@ final class AppState: ObservableObject {
             errorMessage = "Microphone permission is required. Please grant access in System Settings."
             appStatus = .error
             return
+        }
+
+        // Lazy-reload after idle unload (or any other cold start).
+        if !whisperService.isModelLoaded {
+            appStatus = .processing
+            await ensureModelLoaded()
+            guard whisperService.isModelLoaded else {
+                showTemporaryError("Failed to load the speech model. Try again from Settings → Speech Model.")
+                return
+            }
+            appStatus = .idle
         }
 
         appStatus = .recording
@@ -677,8 +883,13 @@ final class AppState: ObservableObject {
             // by WhisperService to remove hallucination tokens like [BLANK_AUDIO])
             let trimmedText = result.text.trimmingCharacters(in: .whitespacesAndNewlines)
             if !trimmedText.isEmpty {
+                let polished = DictationOutputFormatter.apply(
+                    trimmedText,
+                    autoCapitalize: autoCapitalize,
+                    appendTrailingSpace: appendTrailingSpace
+                )
                 textInjector.inject(
-                    text: trimmedText,
+                    text: polished,
                     preserveClipboard: preserveClipboard
                 )
             } else {

--- a/Sources/VocaMac/Models/AppState.swift
+++ b/Sources/VocaMac/Models/AppState.swift
@@ -258,12 +258,6 @@ final class AppState: ObservableObject {
         self.permissionManager = permissionManager ?? PermissionManager(audioEngine: audioEngine, hotKeyManager: hotKeyManager)
         self.skipSystemIntegration = skipSystemIntegration
 
-        cursorOverlay.setCancelHandler { [weak self] in
-            Task { @MainActor [weak self] in
-                await self?.cancelRecording()
-            }
-        }
-
         VocaLogger.info(.appState, "Initializing... id=\(ObjectIdentifier(self))")
         if !skipSystemIntegration {
             syncLaunchAtLogin()

--- a/Sources/VocaMac/Models/AppState.swift
+++ b/Sources/VocaMac/Models/AppState.swift
@@ -547,7 +547,7 @@ final class AppState: ObservableObject {
         }
         sleepWakeMonitor.onDidWake = { [weak self] in
             guard let self else { return }
-            VocaLogger.info(.appState, "Wake recovery — refreshing hotkey health")
+            VocaLogger.info(.appState, "Wake recovery: refreshing hotkey health")
             if self.permissionManager.allPermissionsGranted {
                 self.syncHotKeyConfiguration()
                 if !self.hotKeyManager.isListening {
@@ -621,9 +621,9 @@ final class AppState: ObservableObject {
         guard !whisperService.isModelLoaded else { return nil }
         if isAutoPaused {
             if let name = autoPauseTriggerDisplayName, !name.isEmpty {
-                return "Paused while \(name) is running — model unloaded to free memory."
+                return "Paused while \(name) is running. The speech model was unloaded to free memory."
             }
-            return "Paused by a listed app — model unloaded to free memory."
+            return "Paused by a listed app. The speech model was unloaded to free memory."
         }
         switch lastModelUnloadReason {
         case .idleKeepAlive:
@@ -653,7 +653,7 @@ final class AppState: ObservableObject {
         modelKeepAlive.cancel()
 
         if isRecording || appStatus == .recording {
-            VocaLogger.warning(.appState, "Auto-pause entered while recording — stopping without inject")
+            VocaLogger.warning(.appState, "Auto-pause entered while recording: stopping without inject")
             _ = await stopAudioEngine()
             isRecording = false
             audioLevel = 0
@@ -813,7 +813,7 @@ final class AppState: ObservableObject {
         }
 
         if isAutoPaused {
-            let message = "Dictation is paused while a configured app is running."
+            let message = "Dictation is paused while a listed app is running."
             VocaLogger.info(.appState, message)
             showTemporaryError(message)
             return
@@ -842,7 +842,7 @@ final class AppState: ObservableObject {
             appStatus = .processing
             await ensureModelLoaded()
             guard whisperService.isModelLoaded else {
-                showTemporaryError("Failed to load the speech model. Try again from Settings → Speech Model.")
+                showTemporaryError("Could not load the speech model. Open Settings → Speech Model and try again.")
                 return
             }
             appStatus = .idle

--- a/Sources/VocaMac/Models/AppState.swift
+++ b/Sources/VocaMac/Models/AppState.swift
@@ -69,6 +69,9 @@ final class AppState: ObservableObject {
     /// The most recent transcription result
     @Published var lastTranscription: VocaTranscription?
 
+    /// Last Settings → Test Dictation result (shown in the sidebar footer; not injected).
+    @Published var settingsTestResultText: String?
+
     /// Error message to display, if any
     @Published var errorMessage: String?
 
@@ -822,7 +825,7 @@ final class AppState: ObservableObject {
         }
     }
 
-    func stopRecordingAndTranscribe() async {
+    func stopRecordingAndTranscribe(injectResult: Bool = true) async {
         // Accept stop if we're recording OR if the audio engine thinks
         // it's recording (covers stuck-state recovery scenarios where
         // isRecording and appStatus may be out of sync).
@@ -873,8 +876,6 @@ final class AppState: ObservableObject {
             // Update stats
             statsManager.recordTranscription(result)
 
-            // Inject text at cursor position
-            // by WhisperService to remove hallucination tokens like [BLANK_AUDIO])
             let trimmedText = result.text.trimmingCharacters(in: .whitespacesAndNewlines)
             if !trimmedText.isEmpty {
                 let polished = DictationOutputFormatter.apply(
@@ -882,12 +883,20 @@ final class AppState: ObservableObject {
                     autoCapitalize: autoCapitalize,
                     appendTrailingSpace: appendTrailingSpace
                 )
-                textInjector.inject(
-                    text: polished,
-                    preserveClipboard: preserveClipboard
-                )
+                if injectResult {
+                    textInjector.inject(
+                        text: polished,
+                        preserveClipboard: preserveClipboard
+                    )
+                } else {
+                    // Settings Test Dictation: show only in the sidebar footer.
+                    settingsTestResultText = polished
+                }
             } else {
                 VocaLogger.info(.appState, "Transcription produced no usable text (silence or blank audio)")
+                if !injectResult {
+                    settingsTestResultText = nil
+                }
             }
 
             cursorOverlay.hide()

--- a/Sources/VocaMac/Models/AppState.swift
+++ b/Sources/VocaMac/Models/AppState.swift
@@ -153,6 +153,18 @@ final class AppState: ObservableObject {
     /// True while a configured auto-pause app is running and dictation is blocked.
     @Published var isAutoPaused: Bool = false
 
+    /// Last reason the speech model was unloaded (nil while a model is loaded).
+    @Published var lastModelUnloadReason: ModelUnloadReason?
+
+    /// Display name of the app that triggered the current auto-pause, if any.
+    @Published var autoPauseTriggerDisplayName: String?
+
+    /// Approximate process RSS (MB) sampled just before the last unload.
+    @Published var processMemoryBeforeUnloadMB: Double?
+
+    /// Approximate process RSS (MB) sampled right after the last unload.
+    @Published var processMemoryAfterUnloadMB: Double?
+
     private var hotKeySafetyTimeout: Double {
         Double(maxRecordingDuration) + 5.0
     }
@@ -575,12 +587,54 @@ final class AppState: ObservableObject {
     func unloadActiveModel(reason: ModelUnloadReason) async {
         VocaLogger.info(.appState, "Unloading model (reason=\(reason.rawValue))")
         modelKeepAlive.cancel()
+        let beforeMB = ProcessMonitor.currentResidentMemoryMB()
+        processMemoryBeforeUnloadMB = beforeMB
         await whisperService.unloadModel()
+        // Give the allocator a beat to release pages before sampling again.
+        try? await Task.sleep(nanoseconds: 150_000_000)
+        let afterMB = ProcessMonitor.currentResidentMemoryMB()
+        processMemoryAfterUnloadMB = afterMB
+        lastModelUnloadReason = reason
         for i in availableModels.indices {
             availableModels[i].isActive = false
             availableModels[i].isLoading = false
         }
         currentModel = nil
+        VocaLogger.info(
+            .appState,
+            "Unload complete (reason=\(reason.rawValue), RSS \(String(format: "%.0f", beforeMB))→\(String(format: "%.0f", afterMB)) MB)"
+        )
+    }
+
+    /// Approximate RAM freed by the last unload, when both samples exist.
+    var approximateMemoryFreedMB: Double? {
+        guard let before = processMemoryBeforeUnloadMB,
+              let after = processMemoryAfterUnloadMB,
+              before > after else {
+            return nil
+        }
+        return before - after
+    }
+
+    /// User-facing summary of why the model is currently unloaded.
+    var modelUnloadStatusMessage: String? {
+        guard !whisperService.isModelLoaded else { return nil }
+        if isAutoPaused {
+            if let name = autoPauseTriggerDisplayName, !name.isEmpty {
+                return "Paused while \(name) is running — model unloaded to free memory."
+            }
+            return "Paused by a listed app — model unloaded to free memory."
+        }
+        switch lastModelUnloadReason {
+        case .idleKeepAlive:
+            return "Model unloaded after idle timeout. Next dictation reloads it."
+        case .autoPause:
+            return "Model unloaded by auto-pause."
+        case .manual:
+            return "Model unloaded."
+        case .none:
+            return nil
+        }
     }
 
     /// Ensure a model is loaded before dictation (lazy reload after idle unload).
@@ -595,6 +649,7 @@ final class AppState: ObservableObject {
 
     private func handleAutoPauseEntered() async {
         isAutoPaused = true
+        autoPauseTriggerDisplayName = autoPauseMonitor.activeTrigger?.displayName
         modelKeepAlive.cancel()
 
         if isRecording || appStatus == .recording {
@@ -609,11 +664,14 @@ final class AppState: ObservableObject {
 
         if whisperService.isModelLoaded {
             await unloadActiveModel(reason: .autoPause)
+        } else {
+            lastModelUnloadReason = .autoPause
         }
     }
 
     private func handleAutoPauseCleared() async {
         isAutoPaused = false
+        autoPauseTriggerDisplayName = nil
         // Warm-reload so the next hotkey is ready (Linux behavior).
         await ensureModelLoaded()
         modelKeepAlive.bump()
@@ -1079,6 +1137,9 @@ final class AppState: ObservableObject {
                 }
             }
 
+            lastModelUnloadReason = nil
+            processMemoryBeforeUnloadMB = nil
+            processMemoryAfterUnloadMB = nil
             VocaLogger.info(.appState, "Model ready: \(resolvedSize.displayName)")
         } catch {
             // A newer load superseded this one; do not restore over it.

--- a/Sources/VocaMac/Models/SettingsPage.swift
+++ b/Sources/VocaMac/Models/SettingsPage.swift
@@ -1,0 +1,47 @@
+// SettingsPage.swift
+// VocaMac
+//
+// Sidebar page identifiers for the searchable settings shell.
+
+import Foundation
+import SwiftUI
+
+/// Top-level settings topics shown in the left sidebar.
+enum SettingsPage: String, CaseIterable, Identifiable, Hashable {
+    case dictation
+    case speechModel
+    case audio
+    case performance
+    case application
+    case stats
+    case advanced
+    case about
+
+    var id: String { rawValue }
+
+    var title: String {
+        switch self {
+        case .dictation: return "Dictation"
+        case .speechModel: return "Speech Model"
+        case .audio: return "Audio"
+        case .performance: return "Performance"
+        case .application: return "Application"
+        case .stats: return "Stats"
+        case .advanced: return "Advanced"
+        case .about: return "About"
+        }
+    }
+
+    var systemImage: String {
+        switch self {
+        case .dictation: return "mic"
+        case .speechModel: return "brain"
+        case .audio: return "waveform"
+        case .performance: return "bolt.circle"
+        case .application: return "gearshape"
+        case .stats: return "chart.xyaxis.line"
+        case .advanced: return "ladybug"
+        case .about: return "info.circle"
+        }
+    }
+}

--- a/Sources/VocaMac/Models/SettingsSearchIndex.swift
+++ b/Sources/VocaMac/Models/SettingsSearchIndex.swift
@@ -1,0 +1,220 @@
+// SettingsSearchIndex.swift
+// VocaMac
+//
+// Lightweight searchable index over settings controls (no third-party deps).
+
+import Foundation
+
+/// One searchable settings control / topic entry.
+struct SettingsSearchEntry: Hashable, Identifiable {
+    let id: String
+    let page: SettingsPage
+    let title: String
+    let subtitle: String?
+    let keywords: [String]
+
+    init(
+        id: String,
+        page: SettingsPage,
+        title: String,
+        subtitle: String? = nil,
+        keywords: [String] = []
+    ) {
+        self.id = id
+        self.page = page
+        self.title = title
+        self.subtitle = subtitle
+        self.keywords = keywords
+    }
+}
+
+/// Indexes settings controls for live sidebar search.
+enum SettingsSearchIndex {
+
+    /// Full catalog of searchable settings rows.
+    static let entries: [SettingsSearchEntry] = [
+        // Dictation
+        SettingsSearchEntry(
+            id: "activation-mode",
+            page: .dictation,
+            title: "Activation Mode",
+            subtitle: "Push to talk or double-tap toggle",
+            keywords: ["hotkey", "ptt", "toggle", "hold"]
+        ),
+        SettingsSearchEntry(
+            id: "hotkey",
+            page: .dictation,
+            title: "Hotkey",
+            subtitle: "Activation key",
+            keywords: ["shortcut", "option", "key"]
+        ),
+        SettingsSearchEntry(
+            id: "trailing-space",
+            page: .dictation,
+            title: "Trailing Space After Dictation",
+            subtitle: "Space between utterances",
+            keywords: ["space", "output", "glue", "whitespace"]
+        ),
+        SettingsSearchEntry(
+            id: "auto-capitalize",
+            page: .dictation,
+            title: "Auto-Capitalize Sentences",
+            subtitle: "Capitalize after punctuation",
+            keywords: ["capitalize", "output", "sentence", "punctuation"]
+        ),
+
+        // Speech Model
+        SettingsSearchEntry(
+            id: "models",
+            page: .speechModel,
+            title: "Speech Models",
+            subtitle: "Download and select engines",
+            keywords: ["whisper", "parakeet", "sherpa", "apple", "model", "download"]
+        ),
+        SettingsSearchEntry(
+            id: "language",
+            page: .speechModel,
+            title: "Transcription Language",
+            subtitle: "Auto-detect or pick a language",
+            keywords: ["language", "locale", "english", "hungarian"]
+        ),
+        SettingsSearchEntry(
+            id: "translation",
+            page: .speechModel,
+            title: "Translation",
+            subtitle: "Translate speech to English",
+            keywords: ["translate", "english"]
+        ),
+        SettingsSearchEntry(
+            id: "vocabulary",
+            page: .speechModel,
+            title: "Custom Vocabulary",
+            subtitle: "Hint proper nouns to Whisper",
+            keywords: ["vocab", "dictionary", "terms"]
+        ),
+
+        // Audio
+        SettingsSearchEntry(
+            id: "microphone",
+            page: .audio,
+            title: "Microphone",
+            subtitle: "Input device",
+            keywords: ["mic", "device", "input", "audio"]
+        ),
+        SettingsSearchEntry(
+            id: "silence",
+            page: .audio,
+            title: "Silence Detection",
+            subtitle: "Auto-stop after silence",
+            keywords: ["vad", "silence", "sensitivity", "threshold"]
+        ),
+        SettingsSearchEntry(
+            id: "sound-effects",
+            page: .audio,
+            title: "Sound Effects",
+            subtitle: "Start and stop cues",
+            keywords: ["sound", "beep", "audio"]
+        ),
+
+        // Performance
+        SettingsSearchEntry(
+            id: "auto-pause",
+            page: .performance,
+            title: "Auto-Pause for Apps",
+            subtitle: "Unload while listed apps run",
+            keywords: ["pause", "game", "app", "offload", "unload"]
+        ),
+        SettingsSearchEntry(
+            id: "idle-unload",
+            page: .performance,
+            title: "Unload Model When Idle",
+            subtitle: "Keep-alive timeout",
+            keywords: ["idle", "keepalive", "keep-alive", "battery", "ram", "unload"]
+        ),
+        SettingsSearchEntry(
+            id: "resources",
+            page: .speechModel,
+            title: "Resource Usage",
+            subtitle: "CPU and memory",
+            keywords: ["cpu", "memory", "ram", "resources"]
+        ),
+
+        // Application
+        SettingsSearchEntry(
+            id: "launch-at-login",
+            page: .application,
+            title: "Launch at Login",
+            keywords: ["startup", "login"]
+        ),
+        SettingsSearchEntry(
+            id: "clipboard",
+            page: .application,
+            title: "Preserve Clipboard",
+            keywords: ["clipboard", "paste"]
+        ),
+        SettingsSearchEntry(
+            id: "cursor-overlay",
+            page: .application,
+            title: "Cursor Mic Indicator",
+            keywords: ["overlay", "cursor", "indicator"]
+        ),
+
+        // Stats / Advanced / About
+        SettingsSearchEntry(
+            id: "stats",
+            page: .stats,
+            title: "Usage Stats",
+            keywords: ["streak", "words", "history"]
+        ),
+        SettingsSearchEntry(
+            id: "logs",
+            page: .advanced,
+            title: "Debug Logs",
+            keywords: ["log", "debug", "export"]
+        ),
+        SettingsSearchEntry(
+            id: "permissions",
+            page: .advanced,
+            title: "Permissions",
+            keywords: ["mic", "accessibility", "input monitoring"]
+        ),
+        SettingsSearchEntry(
+            id: "updates",
+            page: .about,
+            title: "Updates",
+            keywords: ["version", "release", "nightly", "update"]
+        ),
+    ]
+
+    /// Entries whose title, subtitle, or keywords contain `query` (case-insensitive).
+    static func matches(query: String) -> [SettingsSearchEntry] {
+        let trimmed = query.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return entries }
+
+        let needle = trimmed.lowercased()
+        return entries.filter { entry in
+            if entry.title.lowercased().contains(needle) { return true }
+            if let subtitle = entry.subtitle, subtitle.lowercased().contains(needle) { return true }
+            return entry.keywords.contains { $0.lowercased().contains(needle) }
+        }
+    }
+
+    /// Match counts keyed by page (pages with zero matches omitted).
+    static func matchCounts(query: String) -> [SettingsPage: Int] {
+        let trimmed = query.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return [:] }
+
+        var counts: [SettingsPage: Int] = [:]
+        for entry in matches(query: trimmed) {
+            counts[entry.page, default: 0] += 1
+        }
+        return counts
+    }
+
+    /// First page that has matches, or nil when the query is empty / no hits.
+    static func firstMatchingPage(query: String) -> SettingsPage? {
+        let trimmed = query.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return nil }
+        return matches(query: trimmed).first?.page
+    }
+}

--- a/Sources/VocaMac/Models/SettingsSearchIndex.swift
+++ b/Sources/VocaMac/Models/SettingsSearchIndex.swift
@@ -133,10 +133,17 @@ enum SettingsSearchIndex {
         ),
         SettingsSearchEntry(
             id: "resources",
-            page: .speechModel,
+            page: .advanced,
             title: "Resource Usage",
-            subtitle: "CPU and memory",
-            keywords: ["cpu", "memory", "ram", "resources"]
+            subtitle: "App CPU and memory",
+            keywords: ["cpu", "memory", "ram", "resources", "system"]
+        ),
+        SettingsSearchEntry(
+            id: "system-info",
+            page: .advanced,
+            title: "System Information",
+            subtitle: "CPU, RAM, Metal",
+            keywords: ["system", "metal", "device", "hardware"]
         ),
 
         // Application

--- a/Sources/VocaMac/Models/SettingsSearchIndex.swift
+++ b/Sources/VocaMac/Models/SettingsSearchIndex.swift
@@ -118,6 +118,13 @@ enum SettingsSearchIndex {
 
         // Performance
         SettingsSearchEntry(
+            id: "model-status",
+            page: .performance,
+            title: "Model Status",
+            subtitle: "Loaded or unloaded",
+            keywords: ["loaded", "unload", "ram", "memory", "status", "pause"]
+        ),
+        SettingsSearchEntry(
             id: "auto-pause",
             page: .performance,
             title: "Auto-Pause for Apps",

--- a/Sources/VocaMac/Models/SettingsSearchIndex.swift
+++ b/Sources/VocaMac/Models/SettingsSearchIndex.swift
@@ -155,8 +155,9 @@ enum SettingsSearchIndex {
         SettingsSearchEntry(
             id: "cursor-overlay",
             page: .application,
-            title: "Cursor Mic Indicator",
-            keywords: ["overlay", "cursor", "indicator"]
+            title: "Recording Overlay",
+            subtitle: "Style and position near the cursor",
+            keywords: ["overlay", "cursor", "indicator", "mic", "position", "style"]
         ),
 
         // Stats / Advanced / About

--- a/Sources/VocaMac/Models/TranscriptionEngine.swift
+++ b/Sources/VocaMac/Models/TranscriptionEngine.swift
@@ -10,6 +10,13 @@ import Foundation
 /// services that must read the same setting outside the view layer.
 enum PreferenceKey {
     static let selectedLanguage = "vocamac.selectedLanguage"
+    static let appendTrailingSpace = "vocamac.appendTrailingSpace"
+    static let autoCapitalize = "vocamac.autoCapitalize"
+    static let autoPauseEnabled = "vocamac.autoPause.enabled"
+    static let autoPauseApps = "vocamac.autoPause.apps"
+    static let autoPausePollInterval = "vocamac.autoPause.pollIntervalSeconds"
+    static let modelKeepAliveEnabled = "vocamac.modelKeepAlive.enabled"
+    static let modelKeepAliveIdleTimeout = "vocamac.modelKeepAlive.idleTimeoutSeconds"
 }
 
 /// The on-device inference engine backing a model in the catalog.

--- a/Sources/VocaMac/Models/TranscriptionLanguage.swift
+++ b/Sources/VocaMac/Models/TranscriptionLanguage.swift
@@ -1,0 +1,75 @@
+// TranscriptionLanguage.swift
+// VocaMac
+//
+// Selectable transcription language catalog (ISO 639-1 codes WhisperKit accepts).
+
+import Foundation
+
+/// A language the user can pin for recognition (or auto-detect).
+struct TranscriptionLanguage: Identifiable, Hashable {
+    /// ISO 639-1 code, or `"auto"` for detection.
+    let code: String
+    let displayName: String
+
+    var id: String { code }
+
+    static let auto = TranscriptionLanguage(code: "auto", displayName: "Auto-detect")
+
+    /// Expanded catalog aligned with VocaLinux speech language choices.
+    /// Codes are ISO 639-1 so WhisperKit / Apple Speech / sherpa routing stay valid.
+    static let catalog: [TranscriptionLanguage] = [
+        .auto,
+        TranscriptionLanguage(code: "en", displayName: "English"),
+        TranscriptionLanguage(code: "es", displayName: "Spanish"),
+        TranscriptionLanguage(code: "fr", displayName: "French"),
+        TranscriptionLanguage(code: "de", displayName: "German"),
+        TranscriptionLanguage(code: "it", displayName: "Italian"),
+        TranscriptionLanguage(code: "pt", displayName: "Portuguese"),
+        TranscriptionLanguage(code: "nl", displayName: "Dutch"),
+        TranscriptionLanguage(code: "pl", displayName: "Polish"),
+        TranscriptionLanguage(code: "ru", displayName: "Russian"),
+        TranscriptionLanguage(code: "uk", displayName: "Ukrainian"),
+        TranscriptionLanguage(code: "cs", displayName: "Czech"),
+        TranscriptionLanguage(code: "sk", displayName: "Slovak"),
+        TranscriptionLanguage(code: "hu", displayName: "Hungarian"),
+        TranscriptionLanguage(code: "ro", displayName: "Romanian"),
+        TranscriptionLanguage(code: "bg", displayName: "Bulgarian"),
+        TranscriptionLanguage(code: "hr", displayName: "Croatian"),
+        TranscriptionLanguage(code: "sr", displayName: "Serbian"),
+        TranscriptionLanguage(code: "sv", displayName: "Swedish"),
+        TranscriptionLanguage(code: "da", displayName: "Danish"),
+        TranscriptionLanguage(code: "no", displayName: "Norwegian"),
+        TranscriptionLanguage(code: "fi", displayName: "Finnish"),
+        TranscriptionLanguage(code: "el", displayName: "Greek"),
+        TranscriptionLanguage(code: "tr", displayName: "Turkish"),
+        TranscriptionLanguage(code: "ar", displayName: "Arabic"),
+        TranscriptionLanguage(code: "he", displayName: "Hebrew"),
+        TranscriptionLanguage(code: "fa", displayName: "Persian"),
+        TranscriptionLanguage(code: "hi", displayName: "Hindi"),
+        TranscriptionLanguage(code: "bn", displayName: "Bengali"),
+        TranscriptionLanguage(code: "ta", displayName: "Tamil"),
+        TranscriptionLanguage(code: "th", displayName: "Thai"),
+        TranscriptionLanguage(code: "vi", displayName: "Vietnamese"),
+        TranscriptionLanguage(code: "id", displayName: "Indonesian"),
+        TranscriptionLanguage(code: "ms", displayName: "Malay"),
+        TranscriptionLanguage(code: "zh", displayName: "Chinese"),
+        TranscriptionLanguage(code: "ja", displayName: "Japanese"),
+        TranscriptionLanguage(code: "ko", displayName: "Korean"),
+        TranscriptionLanguage(code: "ca", displayName: "Catalan"),
+    ]
+
+    /// Languages excluding auto-detect, sorted by display name.
+    static var selectable: [TranscriptionLanguage] {
+        catalog.filter { $0.code != "auto" }
+            .sorted { $0.displayName.localizedCaseInsensitiveCompare($1.displayName) == .orderedAscending }
+    }
+
+    /// Filter the catalog by display name or code.
+    static func filtered(search: String) -> [TranscriptionLanguage] {
+        let needle = search.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        guard !needle.isEmpty else { return catalog }
+        return catalog.filter {
+            $0.displayName.lowercased().contains(needle) || $0.code.lowercased().contains(needle)
+        }
+    }
+}

--- a/Sources/VocaMac/Services/AutoPauseMonitor.swift
+++ b/Sources/VocaMac/Services/AutoPauseMonitor.swift
@@ -1,0 +1,254 @@
+// AutoPauseMonitor.swift
+// VocaMac
+//
+// Unloads the speech model while configured apps are running and blocks
+// dictation until they exit. Mac adapter for VocaLinux auto-pause (#592).
+
+import Foundation
+import AppKit
+
+// MARK: - Models
+
+/// A user-configured app that should trigger auto-pause while running.
+struct AutoPauseAppEntry: Codable, Identifiable, Hashable {
+    /// Stable identity: prefers bundle ID, falls back to process name.
+    var id: String
+    /// User-facing name shown in Settings.
+    var displayName: String
+    /// Bundle identifier when known (GUI apps).
+    var bundleIdentifier: String?
+    /// Executable / process basename (CLI tools, games, fallback).
+    var processName: String?
+
+    init(
+        id: String,
+        displayName: String,
+        bundleIdentifier: String? = nil,
+        processName: String? = nil
+    ) {
+        self.id = id
+        self.displayName = displayName
+        self.bundleIdentifier = bundleIdentifier
+        self.processName = processName
+    }
+
+    /// Build an entry from a running application snapshot.
+    static func from(snapshot: RunningAppSnapshot) -> AutoPauseAppEntry {
+        let bundleID = snapshot.bundleIdentifier
+        let process = snapshot.processName
+        let id = bundleID ?? process ?? snapshot.displayName
+        return AutoPauseAppEntry(
+            id: id,
+            displayName: snapshot.displayName,
+            bundleIdentifier: bundleID,
+            processName: process
+        )
+    }
+}
+
+/// Lightweight view of a running process used for matching and the picker UI.
+struct RunningAppSnapshot: Hashable {
+    var displayName: String
+    var bundleIdentifier: String?
+    var processName: String?
+}
+
+// MARK: - Pure matching
+
+enum AutoPauseMatching {
+    /// Normalize a process or configured name for comparison.
+    static func normalizeProcessName(_ name: String) -> String {
+        let trimmed = name.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return "" }
+        let base = (trimmed as NSString).lastPathComponent.lowercased()
+        if base.hasSuffix(".exe") {
+            return String(base.dropLast(4))
+        }
+        return base
+    }
+
+    /// Return true when any configured entry matches a running snapshot.
+    ///
+    /// Matching is case-insensitive on bundle ID equality **or** executable
+    /// basename equality. An empty configured list never matches.
+    static func anyConfiguredAppRunning(
+        configured: [AutoPauseAppEntry],
+        running: [RunningAppSnapshot]
+    ) -> Bool {
+        guard !configured.isEmpty else { return false }
+
+        for entry in configured {
+            let entryBundle = entry.bundleIdentifier?.lowercased()
+            let entryProcess = entry.processName.map { normalizeProcessName($0) }
+                ?? normalizeProcessName(entry.id)
+
+            for snap in running {
+                if let entryBundle, let snapBundle = snap.bundleIdentifier?.lowercased(),
+                   entryBundle == snapBundle {
+                    return true
+                }
+                if let snapProcess = snap.processName.map({ normalizeProcessName($0) }),
+                   !entryProcess.isEmpty, entryProcess == snapProcess {
+                    return true
+                }
+                if let snapBundle = snap.bundleIdentifier.map({ normalizeProcessName($0) }),
+                   !entryProcess.isEmpty, entryProcess == snapBundle {
+                    return true
+                }
+            }
+        }
+        return false
+    }
+
+    /// Snapshot regular (and accessory) apps from NSWorkspace.
+    static func workspaceRunningApps() -> [RunningAppSnapshot] {
+        NSWorkspace.shared.runningApplications.compactMap { app in
+            // Skip our own process and background-only agents without a name.
+            if app.bundleIdentifier == Bundle.main.bundleIdentifier {
+                return nil
+            }
+            let display = app.localizedName ?? app.bundleIdentifier ?? app.executableURL?.lastPathComponent
+            guard let display, !display.isEmpty else { return nil }
+            return RunningAppSnapshot(
+                displayName: display,
+                bundleIdentifier: app.bundleIdentifier,
+                processName: app.executableURL?.lastPathComponent ?? app.localizedName
+            )
+        }
+    }
+}
+
+// MARK: - Monitor
+
+/// Polls for configured processes and fires pause/resume callbacks on transitions.
+@MainActor
+final class AutoPauseMonitor: ObservableObject {
+
+    static let defaultPollIntervalSeconds: TimeInterval = 5
+    static let minPollIntervalSeconds: TimeInterval = 1
+    static let maxPollIntervalSeconds: TimeInterval = 60
+
+    /// Called once when the match set becomes non-empty.
+    var onPause: (() -> Void)?
+    /// Called once when the match set becomes empty after a pause.
+    var onResume: (() -> Void)?
+
+    /// Re-read every poll so Settings changes apply without restart.
+    var getConfig: () -> (enabled: Bool, apps: [AutoPauseAppEntry], pollInterval: TimeInterval)
+
+    /// Injectable process snapshot for tests.
+    var processSnapshot: () -> [RunningAppSnapshot]
+
+    @Published private(set) var isPaused: Bool = false
+    private(set) var isRunning: Bool = false
+
+    private var timer: Timer?
+    private var lastPollInterval: TimeInterval = defaultPollIntervalSeconds
+
+    init(
+        getConfig: @escaping () -> (enabled: Bool, apps: [AutoPauseAppEntry], pollInterval: TimeInterval) = {
+            (false, [], defaultPollIntervalSeconds)
+        },
+        processSnapshot: @escaping () -> [RunningAppSnapshot] = AutoPauseMatching.workspaceRunningApps,
+        onPause: (() -> Void)? = nil,
+        onResume: (() -> Void)? = nil
+    ) {
+        self.getConfig = getConfig
+        self.processSnapshot = processSnapshot
+        self.onPause = onPause
+        self.onResume = onResume
+    }
+
+    deinit {
+        timer?.invalidate()
+    }
+
+    /// Start periodic polling. Safe to call if already started.
+    func start() {
+        guard !isRunning else { return }
+        isRunning = true
+        scheduleTimer(immediate: true)
+        VocaLogger.info(.general, "Auto-pause monitor started")
+    }
+
+    /// Stop polling.
+    func stop() {
+        isRunning = false
+        timer?.invalidate()
+        timer = nil
+        VocaLogger.info(.general, "Auto-pause monitor stopped")
+    }
+
+    /// Run a single poll cycle. Returns whether a configured process matched.
+    @discardableResult
+    func checkOnce() -> Bool {
+        let (enabled, apps, _) = readConfig()
+        guard enabled else {
+            clearPauseIfNeeded()
+            return false
+        }
+
+        let matched = AutoPauseMatching.anyConfiguredAppRunning(
+            configured: apps,
+            running: processSnapshot()
+        )
+        if matched {
+            enterPauseIfNeeded()
+        } else {
+            clearPauseIfNeeded()
+        }
+        return matched
+    }
+
+    private func readConfig() -> (Bool, [AutoPauseAppEntry], TimeInterval) {
+        let config = getConfig()
+        let interval = Self.clampPollInterval(config.pollInterval)
+        return (config.enabled, config.apps, interval)
+    }
+
+    static func clampPollInterval(_ seconds: TimeInterval) -> TimeInterval {
+        min(maxPollIntervalSeconds, max(minPollIntervalSeconds, seconds))
+    }
+
+    private func scheduleTimer(immediate: Bool) {
+        timer?.invalidate()
+        let (_, _, interval) = readConfig()
+        lastPollInterval = interval
+
+        if immediate {
+            checkOnce()
+        }
+
+        let timer = Timer.scheduledTimer(withTimeInterval: interval, repeats: true) { [weak self] _ in
+            Task { @MainActor in
+                self?.pollFromTimer()
+            }
+        }
+        // Allow firing while UI tracking runs (settings window scroll, etc.).
+        RunLoop.main.add(timer, forMode: .common)
+        self.timer = timer
+    }
+
+    private func pollFromTimer() {
+        guard isRunning else { return }
+        let (_, _, interval) = readConfig()
+        if abs(interval - lastPollInterval) > 0.01 {
+            scheduleTimer(immediate: false)
+        }
+        checkOnce()
+    }
+
+    private func enterPauseIfNeeded() {
+        guard !isPaused else { return }
+        isPaused = true
+        VocaLogger.info(.general, "Auto-pause: configured app detected")
+        onPause?()
+    }
+
+    private func clearPauseIfNeeded() {
+        guard isPaused else { return }
+        isPaused = false
+        VocaLogger.info(.general, "Auto-pause cleared")
+        onResume?()
+    }
+}

--- a/Sources/VocaMac/Services/AutoPauseMonitor.swift
+++ b/Sources/VocaMac/Services/AutoPauseMonitor.swift
@@ -75,7 +75,15 @@ enum AutoPauseMatching {
         configured: [AutoPauseAppEntry],
         running: [RunningAppSnapshot]
     ) -> Bool {
-        guard !configured.isEmpty else { return false }
+        firstMatchingConfiguredApp(configured: configured, running: running) != nil
+    }
+
+    /// First configured entry that matches a running snapshot, if any.
+    static func firstMatchingConfiguredApp(
+        configured: [AutoPauseAppEntry],
+        running: [RunningAppSnapshot]
+    ) -> AutoPauseAppEntry? {
+        guard !configured.isEmpty else { return nil }
 
         for entry in configured {
             let entryBundle = entry.bundleIdentifier?.lowercased()
@@ -85,19 +93,19 @@ enum AutoPauseMatching {
             for snap in running {
                 if let entryBundle, let snapBundle = snap.bundleIdentifier?.lowercased(),
                    entryBundle == snapBundle {
-                    return true
+                    return entry
                 }
                 if let snapProcess = snap.processName.map({ normalizeProcessName($0) }),
                    !entryProcess.isEmpty, entryProcess == snapProcess {
-                    return true
+                    return entry
                 }
                 if let snapBundle = snap.bundleIdentifier.map({ normalizeProcessName($0) }),
                    !entryProcess.isEmpty, entryProcess == snapBundle {
-                    return true
+                    return entry
                 }
             }
         }
-        return false
+        return nil
     }
 
     /// Snapshot regular (and accessory) apps from NSWorkspace.
@@ -140,6 +148,8 @@ final class AutoPauseMonitor: ObservableObject {
     var processSnapshot: () -> [RunningAppSnapshot]
 
     @Published private(set) var isPaused: Bool = false
+    /// The configured app that currently triggers auto-pause, if any.
+    @Published private(set) var activeTrigger: AutoPauseAppEntry?
     private(set) var isRunning: Bool = false
 
     private var timer: Timer?
@@ -184,20 +194,24 @@ final class AutoPauseMonitor: ObservableObject {
     func checkOnce() -> Bool {
         let (enabled, apps, _) = readConfig()
         guard enabled else {
+            activeTrigger = nil
             clearPauseIfNeeded()
             return false
         }
 
-        let matched = AutoPauseMatching.anyConfiguredAppRunning(
+        let matchedEntry = AutoPauseMatching.firstMatchingConfiguredApp(
             configured: apps,
             running: processSnapshot()
         )
-        if matched {
+        if let matchedEntry {
+            activeTrigger = matchedEntry
             enterPauseIfNeeded()
+            return true
         } else {
+            activeTrigger = nil
             clearPauseIfNeeded()
+            return false
         }
-        return matched
     }
 
     private func readConfig() -> (Bool, [AutoPauseAppEntry], TimeInterval) {
@@ -248,6 +262,7 @@ final class AutoPauseMonitor: ObservableObject {
     private func clearPauseIfNeeded() {
         guard isPaused else { return }
         isPaused = false
+        activeTrigger = nil
         VocaLogger.info(.general, "Auto-pause cleared")
         onResume?()
     }

--- a/Sources/VocaMac/Services/AutoPauseMonitor.swift
+++ b/Sources/VocaMac/Services/AutoPauseMonitor.swift
@@ -124,9 +124,9 @@ enum AutoPauseMatching {
 @MainActor
 final class AutoPauseMonitor: ObservableObject {
 
-    static let defaultPollIntervalSeconds: TimeInterval = 5
-    static let minPollIntervalSeconds: TimeInterval = 1
-    static let maxPollIntervalSeconds: TimeInterval = 60
+    nonisolated static let defaultPollIntervalSeconds: TimeInterval = 5
+    nonisolated static let minPollIntervalSeconds: TimeInterval = 1
+    nonisolated static let maxPollIntervalSeconds: TimeInterval = 60
 
     /// Called once when the match set becomes non-empty.
     var onPause: (() -> Void)?

--- a/Sources/VocaMac/Services/CursorOverlayManager.swift
+++ b/Sources/VocaMac/Services/CursorOverlayManager.swift
@@ -17,9 +17,9 @@ enum OverlayLayout {
         case .off:
             return .zero
         case .minimal:
-            return CGSize(width: 128, height: 44)
+            return CGSize(width: 108, height: 44)
         case .live:
-            return CGSize(width: 272, height: 72)
+            return CGSize(width: 240, height: 72)
         }
     }
 }
@@ -107,15 +107,7 @@ final class CursorOverlayManager {
     /// Timer for the recording duration shown by the live panel.
     private var elapsedTimer: Timer?
 
-    /// Called when the user cancels the active recording.
-    private var cancelHandler: (() -> Void)?
-
     // MARK: - Public API
-
-    /// Registers the action invoked by the overlay's cancel button.
-    func setCancelHandler(_ handler: @escaping () -> Void) {
-        cancelHandler = handler
-    }
 
     /// Shows the recording overlay using the requested style and position.
     func show(style: OverlayStyle, position: OverlayPosition) {
@@ -138,11 +130,7 @@ final class CursorOverlayManager {
         }
 
         let size = overlaySize
-        let hosting = NSHostingView(
-            rootView: HandyOverlayView(viewModel: viewModel) { [weak self] in
-                self?.cancelHandler?()
-            }
-        )
+        let hosting = NSHostingView(rootView: HandyOverlayView(viewModel: viewModel))
         hosting.frame = NSRect(origin: .zero, size: size)
 
         let panel = NSPanel(
@@ -156,9 +144,8 @@ final class CursorOverlayManager {
         panel.hasShadow = false
         panel.level = .statusBar
         panel.collectionBehavior = [.canJoinAllSpaces, .fullScreenAuxiliary]
-        // The panel remains non-activating, but the cancel button still needs to
-        // receive clicks. Its small footprint does not cover the target field.
-        panel.ignoresMouseEvents = false
+        // Overlay is display-only; clicks pass through so the target app keeps focus.
+        panel.ignoresMouseEvents = true
         panel.hidesOnDeactivate = false
         panel.isMovableByWindowBackground = false
         panel.contentView = hosting
@@ -436,11 +423,10 @@ enum OverlayWaveformMetrics {
 
 struct HandyOverlayView: View {
     @ObservedObject var viewModel: MicIndicatorViewModel
-    let onCancel: () -> Void
 
     @State private var isPulsing = false
 
-    private let recordingColor = Color(nsColor: .systemRed)
+    private let recordingColor = Color(nsColor: BrandAssets.brandGreen)
     private let processingColor = Color(red: 0.749, green: 0.353, blue: 0.949)
     private let panelColor = Color(red: 0.105, green: 0.108, blue: 0.118)
 
@@ -483,7 +469,7 @@ struct HandyOverlayView: View {
 
     private var liveHeader: some View {
         HStack(spacing: 7) {
-            statusDot
+            brandMarkBadge
 
             Text(viewModel.phase == .recording ? "Listening" : "Transcribing")
                 .font(.system(size: 13, weight: .medium))
@@ -505,23 +491,9 @@ struct HandyOverlayView: View {
     }
 
     private var livePanelContent: some View {
-        HStack(spacing: 10) {
-            VStack(spacing: 0) {
-                liveHeader
-                liveControlRow
-            }
-            .frame(maxWidth: .infinity)
-
-            Rectangle()
-                .fill(Color.white.opacity(viewModel.phase == .recording ? 0.09 : 0))
-                .frame(width: 1, height: 34)
-
-            if viewModel.phase == .recording {
-                cancelButton
-            } else {
-                Color.clear
-                    .frame(width: 24, height: 24)
-            }
+        VStack(spacing: 0) {
+            liveHeader
+            liveControlRow
         }
         .padding(.horizontal, 12)
         .padding(.vertical, 8)
@@ -556,7 +528,7 @@ struct HandyOverlayView: View {
     private var minimalControlRow: some View {
         HStack(spacing: 8) {
             if viewModel.phase == .recording {
-                statusDot
+                brandMarkBadge
                 waveform
             } else {
                 ProgressView()
@@ -566,10 +538,6 @@ struct HandyOverlayView: View {
                 Text("Transcribing…")
                     .font(.system(size: 12, weight: .medium))
                     .foregroundStyle(.white.opacity(0.68))
-            }
-
-            if viewModel.phase == .recording {
-                cancelButton
             }
         }
         .padding(.horizontal, 10)
@@ -601,43 +569,36 @@ struct HandyOverlayView: View {
         .accessibilityLabel("Microphone level")
     }
 
-    private var statusDot: some View {
+    private var brandMarkBadge: some View {
         ZStack {
             if viewModel.phase == .recording {
                 Circle()
-                    .fill(recordingColor.opacity(0.24))
-                    .frame(width: 13, height: 13)
-                    .scaleEffect(isPulsing ? 1 : 0.72)
-                    .opacity(isPulsing ? 0.38 : 0.9)
+                    .fill(recordingColor.opacity(0.22))
+                    .frame(width: 22, height: 22)
+                    .scaleEffect(isPulsing ? 1.08 : 0.86)
+                    .opacity(isPulsing ? 0.45 : 0.85)
             }
 
-            Circle()
-                .fill(viewModel.phase == .recording ? recordingColor : processingColor)
-                .frame(width: 6, height: 6)
-                .shadow(
-                    color: (viewModel.phase == .recording ? recordingColor : processingColor).opacity(0.55),
-                    radius: 4
-                )
-        }
-        .frame(width: 13, height: 13)
-    }
-
-    private var cancelButton: some View {
-        Button(action: onCancel) {
-            Image(systemName: "xmark")
-                .font(.system(size: 9, weight: .semibold))
-                .foregroundStyle(.white.opacity(0.70))
-                .frame(width: 24, height: 24)
-                .background(Color.white.opacity(0.08), in: Circle())
-                .overlay {
-                    Circle()
-                        .stroke(Color.white.opacity(0.08), lineWidth: 1)
+            Group {
+                if let mark = BrandAssets.mark {
+                    Image(nsImage: mark)
+                        .resizable()
+                        .renderingMode(.template)
+                        .scaledToFit()
+                        .frame(width: 12, height: 12)
+                } else {
+                    Image(systemName: "mic.fill")
+                        .font(.system(size: 10, weight: .semibold))
                 }
+            }
+            .foregroundStyle(viewModel.phase == .recording ? recordingColor : processingColor)
+            .shadow(
+                color: (viewModel.phase == .recording ? recordingColor : processingColor).opacity(0.45),
+                radius: 4
+            )
         }
-        .buttonStyle(.plain)
-        .contentShape(Circle())
-        .help("Cancel recording")
-        .accessibilityLabel("Cancel recording")
+        .frame(width: 22, height: 22)
+        .accessibilityLabel(viewModel.phase == .recording ? "Recording" : "Transcribing")
     }
 
     private var formattedElapsed: String {

--- a/Sources/VocaMac/Services/CursorOverlayManager.swift
+++ b/Sources/VocaMac/Services/CursorOverlayManager.swift
@@ -449,7 +449,7 @@ struct HandyOverlayView: View {
     @State private var hasEntered = false
 
     private let brandGreen = Color(nsColor: BrandAssets.brandGreen)
-    private let processingColor = Color(red: 0.62, green: 0.28, blue: 0.92)
+    private let processingColor = Color(nsColor: .systemYellow)
 
     private var isDark: Bool { colorScheme == .dark }
 

--- a/Sources/VocaMac/Services/CursorOverlayManager.swift
+++ b/Sources/VocaMac/Services/CursorOverlayManager.swift
@@ -144,6 +144,8 @@ final class CursorOverlayManager {
         let size = overlaySize
         let hosting = NSHostingView(rootView: HandyOverlayView(viewModel: viewModel))
         hosting.frame = NSRect(origin: .zero, size: size)
+        // Follow the system appearance so SwiftUI colorScheme stays in sync.
+        hosting.appearance = nil
 
         let panel = NSPanel(
             contentRect: NSRect(origin: .zero, size: size),
@@ -156,6 +158,7 @@ final class CursorOverlayManager {
         panel.hasShadow = false
         panel.level = .statusBar
         panel.collectionBehavior = [.canJoinAllSpaces, .fullScreenAuxiliary]
+        panel.appearance = nil
         // Overlay is display-only; clicks pass through so the target app keeps focus.
         panel.ignoresMouseEvents = true
         panel.hidesOnDeactivate = false
@@ -203,8 +206,9 @@ final class CursorOverlayManager {
 
     /// Updates the current audio level used to animate the waveform.
     func updateAudioLevel(_ level: Float) {
-        let target = min(max(level, 0), 1)
-        let smoothing: Float = target > viewModel.audioLevel ? 0.58 : 0.22
+        // Mild pre-gain so quiet speech still drives a lively waveform.
+        let target = min(max(level * 2.6, 0), 1)
+        let smoothing: Float = target > viewModel.audioLevel ? 0.78 : 0.28
         viewModel.audioLevel += (target - viewModel.audioLevel) * smoothing
         viewModel.waveformTick &+= 1
     }
@@ -420,12 +424,16 @@ final class MicIndicatorViewModel: ObservableObject {
 enum OverlayWaveformMetrics {
     static let barProfile: [CGFloat] = [0.42, 0.68, 0.92, 0.70, 1.0, 0.78, 0.88, 0.60, 0.38]
 
+    /// Amplifies quiet speech so the bars react clearly without needing to shout.
+    static let inputGain: CGFloat = 3.4
+
     static func heights(for level: Float, tick: Int = 0, maximumHeight: CGFloat = 18) -> [CGFloat] {
-        let normalized = min(max(CGFloat(level), 0), 1)
-        let shaped = pow(normalized, 0.62)
+        let boosted = min(1, max(0, CGFloat(level) * inputGain))
+        // Lower exponent = more height from mid/quiet levels.
+        let shaped = pow(boosted, 0.42)
         return barProfile.enumerated().map { index, profile in
-            let phase = Double(tick) * 0.78 + Double(index) * 1.31
-            let movement = CGFloat(0.88 + sin(phase) * 0.12)
+            let phase = Double(tick) * 0.95 + Double(index) * 1.31
+            let movement = CGFloat(0.78 + sin(phase) * 0.22)
             return min(maximumHeight, max(3, 3 + shaped * profile * movement * (maximumHeight - 3)))
         }
     }
@@ -435,16 +443,57 @@ enum OverlayWaveformMetrics {
 
 struct HandyOverlayView: View {
     @ObservedObject var viewModel: MicIndicatorViewModel
+    @Environment(\.colorScheme) private var colorScheme
 
     @State private var isPulsing = false
+    @State private var hasEntered = false
 
-    private let recordingColor = Color(nsColor: BrandAssets.brandGreen)
-    private let processingColor = Color(red: 0.749, green: 0.353, blue: 0.949)
-    private let panelColor = Color(red: 0.105, green: 0.108, blue: 0.118)
+    private let brandGreen = Color(nsColor: BrandAssets.brandGreen)
+    private let processingColor = Color(red: 0.62, green: 0.28, blue: 0.92)
+
+    private var isDark: Bool { colorScheme == .dark }
+
+    private var panelFill: Color {
+        isDark
+            ? Color(red: 0.16, green: 0.17, blue: 0.19)
+            : Color(red: 0.99, green: 0.99, blue: 1.0)
+    }
+
+    private var primaryText: Color {
+        isDark ? Color.white.opacity(0.96) : Color(red: 0.08, green: 0.1, blue: 0.12)
+    }
+
+    private var secondaryText: Color {
+        isDark ? Color.white.opacity(0.68) : Color.black.opacity(0.52)
+    }
+
+    private var tertiaryFill: Color {
+        isDark ? Color.white.opacity(0.1) : Color.black.opacity(0.06)
+    }
+
+    private var strokeBase: Color {
+        isDark ? Color.white.opacity(0.22) : Color.black.opacity(0.14)
+    }
+
+    private var waveformColor: Color {
+        viewModel.phase == .recording ? brandGreen : processingColor
+    }
+
+    private var accentColor: Color {
+        viewModel.phase == .recording ? brandGreen : processingColor
+    }
+
+    private var slideInOffset: CGFloat {
+        switch viewModel.position {
+        case .top:
+            return -42
+        case .bottom, .nearCursor:
+            return 42
+        }
+    }
 
     var body: some View {
         let content = OverlayLayout.contentSize(for: viewModel.style)
-        let glowColor = viewModel.phase == .recording ? recordingColor : processingColor
 
         Group {
             if viewModel.style == .live {
@@ -454,30 +503,65 @@ struct HandyOverlayView: View {
             }
         }
         .frame(width: content.width, height: content.height)
-        .background(panelColor.opacity(0.98))
+        .background(panelFill)
         .clipShape(RoundedRectangle(cornerRadius: cornerRadius, style: .continuous))
         .overlay {
             RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
                 .stroke(
                     viewModel.phase == .recording
-                        ? recordingColor.opacity(isPulsing ? 0.85 : 0.45)
-                        : Color.white.opacity(0.13),
-                    lineWidth: viewModel.phase == .recording ? 1.4 : 1
+                        ? brandGreen.opacity(isPulsing ? 0.95 : 0.55)
+                        : strokeBase,
+                    lineWidth: viewModel.phase == .recording ? 1.6 : 1
                 )
         }
-        .shadow(color: glowColor.opacity(viewModel.phase == .recording ? (isPulsing ? 0.7 : 0.35) : 0.25), radius: 10, y: 0)
-        .shadow(color: glowColor.opacity(viewModel.phase == .recording ? 0.35 : 0.12), radius: 18, y: 0)
+        .shadow(
+            color: accentColor.opacity(viewModel.phase == .recording ? (isPulsing ? 0.75 : 0.4) : 0.28),
+            radius: 11,
+            y: 0
+        )
+        .shadow(
+            color: Color.black.opacity(isDark ? 0.45 : 0.18),
+            radius: 8,
+            y: 3
+        )
         // Transparent bleed so the glow is not clipped by the NSPanel bounds.
         .padding(OverlayLayout.glowBleed)
         .frame(width: panelSize.width, height: panelSize.height)
-        .opacity(viewModel.isActive ? 1 : 0)
-        .scaleEffect(viewModel.isActive ? 1 : 0.96)
-        .animation(.easeOut(duration: 0.18), value: viewModel.isActive)
+        .opacity(viewModel.isActive && hasEntered ? 1 : 0)
+        .offset(y: hasEntered ? 0 : slideInOffset)
+        .scaleEffect(hasEntered ? 1 : 0.94)
+        .animation(.spring(response: 0.38, dampingFraction: 0.82), value: hasEntered)
         .animation(.easeInOut(duration: 0.16), value: viewModel.phase)
         .animation(.easeInOut(duration: 0.9), value: isPulsing)
         .onAppear {
             withAnimation(.easeInOut(duration: 0.9).repeatForever(autoreverses: true)) {
                 isPulsing = true
+            }
+            playEntranceIfNeeded()
+        }
+        .onChange(of: viewModel.isActive) { _, active in
+            if active {
+                playEntranceIfNeeded()
+            } else {
+                hasEntered = false
+            }
+        }
+        .onChange(of: viewModel.position) { _, _ in
+            // Re-run entrance when the anchor edge changes between shows.
+            if viewModel.isActive {
+                hasEntered = false
+                playEntranceIfNeeded()
+            }
+        }
+    }
+
+    private func playEntranceIfNeeded() {
+        guard viewModel.isActive else { return }
+        hasEntered = false
+        // Defer one turn so the off-screen offset is committed before animating in.
+        DispatchQueue.main.async {
+            withAnimation(.spring(response: 0.38, dampingFraction: 0.82)) {
+                hasEntered = true
             }
         }
     }
@@ -495,18 +579,18 @@ struct HandyOverlayView: View {
             brandMarkBadge
 
             Text(viewModel.phase == .recording ? "Listening" : "Transcribing")
-                .font(.system(size: 13, weight: .medium))
-                .foregroundStyle(.white.opacity(0.92))
+                .font(.system(size: 13, weight: .semibold))
+                .foregroundStyle(primaryText)
 
             Spacer()
 
             if viewModel.phase == .recording {
                 Text(formattedElapsed)
                     .font(.system(size: 11, weight: .medium, design: .monospaced))
-                    .foregroundStyle(.white.opacity(0.62))
+                    .foregroundStyle(secondaryText)
                     .padding(.horizontal, 7)
                     .padding(.vertical, 3)
-                    .background(Color.white.opacity(0.07), in: Capsule())
+                    .background(tertiaryFill, in: Capsule())
             }
         }
         .frame(maxWidth: .infinity)
@@ -530,7 +614,7 @@ struct HandyOverlayView: View {
 
                 Text("Speak naturally")
                     .font(.system(size: 11, weight: .medium))
-                    .foregroundStyle(.white.opacity(0.46))
+                    .foregroundStyle(secondaryText)
             } else {
                 ProgressView()
                     .controlSize(.small)
@@ -538,7 +622,7 @@ struct HandyOverlayView: View {
 
                 Text("Turning speech into text…")
                     .font(.system(size: 12, weight: .medium))
-                    .foregroundStyle(.white.opacity(0.68))
+                    .foregroundStyle(secondaryText)
             }
 
             Spacer(minLength: 0)
@@ -559,8 +643,8 @@ struct HandyOverlayView: View {
                     .tint(processingColor)
 
                 Text("Transcribing…")
-                    .font(.system(size: 12, weight: .medium))
-                    .foregroundStyle(.white.opacity(0.68))
+                    .font(.system(size: 12, weight: .semibold))
+                    .foregroundStyle(primaryText)
             }
         }
         .padding(.horizontal, 10)
@@ -580,13 +664,13 @@ struct HandyOverlayView: View {
         return HStack(spacing: spacing) {
             ForEach(Array(heights.enumerated()), id: \.offset) { _, height in
                 Capsule()
-                    .fill(Color.white.opacity(0.88))
+                    .fill(waveformColor)
                     .frame(width: barWidth, height: height)
             }
         }
         .frame(height: maximumHeight)
         .animation(
-            .interactiveSpring(response: 0.20, dampingFraction: 0.72, blendDuration: 0.08),
+            .interactiveSpring(response: 0.18, dampingFraction: 0.68, blendDuration: 0.06),
             value: viewModel.waveformTick
         )
         .accessibilityLabel("Microphone level")
@@ -596,10 +680,10 @@ struct HandyOverlayView: View {
         ZStack {
             if viewModel.phase == .recording {
                 Circle()
-                    .fill(recordingColor.opacity(0.22))
+                    .fill(brandGreen.opacity(isDark ? 0.28 : 0.18))
                     .frame(width: 22, height: 22)
                     .scaleEffect(isPulsing ? 1.08 : 0.86)
-                    .opacity(isPulsing ? 0.45 : 0.85)
+                    .opacity(isPulsing ? 0.55 : 0.9)
             }
 
             Group {
@@ -614,11 +698,8 @@ struct HandyOverlayView: View {
                         .font(.system(size: 10, weight: .semibold))
                 }
             }
-            .foregroundStyle(viewModel.phase == .recording ? recordingColor : processingColor)
-            .shadow(
-                color: (viewModel.phase == .recording ? recordingColor : processingColor).opacity(0.45),
-                radius: 4
-            )
+            .foregroundStyle(accentColor)
+            .shadow(color: accentColor.opacity(0.4), radius: 3)
         }
         .frame(width: 22, height: 22)
         .accessibilityLabel(viewModel.phase == .recording ? "Recording" : "Transcribing")

--- a/Sources/VocaMac/Services/CursorOverlayManager.swift
+++ b/Sources/VocaMac/Services/CursorOverlayManager.swift
@@ -12,7 +12,10 @@ import SwiftUI
 
 /// Shared overlay dimensions keep the AppKit panel and SwiftUI content in sync.
 enum OverlayLayout {
-    static func size(for style: OverlayStyle) -> CGSize {
+    /// Extra transparent margin so brand-green glow is not clipped by the panel.
+    static let glowBleed: CGFloat = 14
+
+    static func contentSize(for style: OverlayStyle) -> CGSize {
         switch style {
         case .off:
             return .zero
@@ -21,6 +24,15 @@ enum OverlayLayout {
         case .live:
             return CGSize(width: 240, height: 72)
         }
+    }
+
+    static func size(for style: OverlayStyle) -> CGSize {
+        let content = contentSize(for: style)
+        guard content != .zero else { return .zero }
+        return CGSize(
+            width: content.width + glowBleed * 2,
+            height: content.height + glowBleed * 2
+        )
     }
 }
 
@@ -431,6 +443,9 @@ struct HandyOverlayView: View {
     private let panelColor = Color(red: 0.105, green: 0.108, blue: 0.118)
 
     var body: some View {
+        let content = OverlayLayout.contentSize(for: viewModel.style)
+        let glowColor = viewModel.phase == .recording ? recordingColor : processingColor
+
         Group {
             if viewModel.style == .live {
                 livePanelContent
@@ -438,20 +453,28 @@ struct HandyOverlayView: View {
                 minimalControlRow
             }
         }
-        .frame(width: panelSize.width, height: panelSize.height)
+        .frame(width: content.width, height: content.height)
         .background(panelColor.opacity(0.98))
         .clipShape(RoundedRectangle(cornerRadius: cornerRadius, style: .continuous))
         .overlay {
             RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
-                .stroke(Color.white.opacity(0.13), lineWidth: 1)
+                .stroke(
+                    viewModel.phase == .recording
+                        ? recordingColor.opacity(isPulsing ? 0.85 : 0.45)
+                        : Color.white.opacity(0.13),
+                    lineWidth: viewModel.phase == .recording ? 1.4 : 1
+                )
         }
-        // Keep the surface inside the exact-size transparent NSPanel. An outer
-        // SwiftUI shadow is clipped to the panel's rectangular window bounds,
-        // which leaves square artifacts behind the rounded corners.
+        .shadow(color: glowColor.opacity(viewModel.phase == .recording ? (isPulsing ? 0.7 : 0.35) : 0.25), radius: 10, y: 0)
+        .shadow(color: glowColor.opacity(viewModel.phase == .recording ? 0.35 : 0.12), radius: 18, y: 0)
+        // Transparent bleed so the glow is not clipped by the NSPanel bounds.
+        .padding(OverlayLayout.glowBleed)
+        .frame(width: panelSize.width, height: panelSize.height)
         .opacity(viewModel.isActive ? 1 : 0)
         .scaleEffect(viewModel.isActive ? 1 : 0.96)
         .animation(.easeOut(duration: 0.18), value: viewModel.isActive)
         .animation(.easeInOut(duration: 0.16), value: viewModel.phase)
+        .animation(.easeInOut(duration: 0.9), value: isPulsing)
         .onAppear {
             withAnimation(.easeInOut(duration: 0.9).repeatForever(autoreverses: true)) {
                 isPulsing = true

--- a/Sources/VocaMac/Services/CursorOverlayManager.swift
+++ b/Sources/VocaMac/Services/CursorOverlayManager.swift
@@ -612,7 +612,7 @@ struct HandyOverlayView: View {
             if viewModel.phase == .recording {
                 waveform
 
-                Text("Speak naturally")
+                Text("Speak now")
                     .font(.system(size: 11, weight: .medium))
                     .foregroundStyle(secondaryText)
             } else {
@@ -620,7 +620,7 @@ struct HandyOverlayView: View {
                     .controlSize(.small)
                     .tint(processingColor)
 
-                Text("Turning speech into text…")
+                Text("Transcribing…")
                     .font(.system(size: 12, weight: .medium))
                     .foregroundStyle(secondaryText)
             }

--- a/Sources/VocaMac/Services/DictationOutputFormatter.swift
+++ b/Sources/VocaMac/Services/DictationOutputFormatter.swift
@@ -22,7 +22,7 @@ enum DictationOutputFormatter {
         var result = String(text.prefix(1)).uppercased() + text.dropFirst()
 
         // Capitalize after sentence-ending punctuation + whitespace.
-        // Mirrors VocaLinux: ([.!?])(\s+)([a-z]) — ASCII lowercase only so
+        // Mirrors VocaLinux: ([.!?])(\s+)([a-z]). ASCII lowercase only so
         // URLs and decimals without a space stay untouched.
         let pattern = #"([.!?])(\s+)([a-z])"#
         guard let regex = try? NSRegularExpression(pattern: pattern) else {

--- a/Sources/VocaMac/Services/DictationOutputFormatter.swift
+++ b/Sources/VocaMac/Services/DictationOutputFormatter.swift
@@ -1,0 +1,79 @@
+// DictationOutputFormatter.swift
+// VocaMac
+//
+// Pure helpers that polish transcribed text before injection.
+// Ports VocaLinux trailing-space (#608) and sentence capitalization (#554).
+
+import Foundation
+
+/// Formats completed dictation utterances for injection at the cursor.
+enum DictationOutputFormatter {
+
+    /// Capitalize the first letter of each sentence.
+    ///
+    /// Uppercases the first character of the string and any lowercase letter
+    /// that follows sentence-ending punctuation (`.`, `!`, `?`) plus whitespace.
+    /// Leaves URLs (`example.com`), decimals (`3.14`), and abbreviations without
+    /// trailing space untouched. Idempotent on already-capitalized text.
+    static func capitalizeSentences(_ text: String) -> String {
+        guard !text.isEmpty else { return text }
+
+        var characters = Array(text)
+        characters[0] = Character(characters[0].uppercased())
+
+        var index = 1
+        while index < characters.count {
+            let current = characters[index]
+            if current == "." || current == "!" || current == "?" {
+                var whitespaceEnd = index + 1
+                while whitespaceEnd < characters.count && characters[whitespaceEnd].isWhitespace {
+                    whitespaceEnd += 1
+                }
+                if whitespaceEnd > index + 1, whitespaceEnd < characters.count {
+                    let candidate = characters[whitespaceEnd]
+                    if candidate.isLetter && candidate.isLowercase {
+                        characters[whitespaceEnd] = Character(candidate.uppercased())
+                    }
+                    index = whitespaceEnd
+                    continue
+                }
+            }
+            index += 1
+        }
+
+        return String(characters)
+    }
+
+    /// Append a trailing space so consecutive dictation sessions do not glue.
+    ///
+    /// Skips empty text, text that already ends with whitespace, and text that
+    /// ends with a newline (paragraph breaks should not gain a trailing space).
+    static func appendTrailingSpace(_ text: String) -> String {
+        guard !text.isEmpty else { return text }
+        if text.last?.isWhitespace == true {
+            return text
+        }
+        return text + " "
+    }
+
+    /// Apply capitalization and/or trailing-space polish in that order.
+    ///
+    /// - Parameters:
+    ///   - text: Already-trimmed utterance text (caller trims before calling).
+    ///   - autoCapitalize: When true, run `capitalizeSentences`.
+    ///   - appendTrailingSpace: When true, run `appendTrailingSpace`.
+    static func apply(
+        _ text: String,
+        autoCapitalize: Bool,
+        appendTrailingSpace: Bool
+    ) -> String {
+        var result = text
+        if autoCapitalize {
+            result = capitalizeSentences(result)
+        }
+        if appendTrailingSpace {
+            result = self.appendTrailingSpace(result)
+        }
+        return result
+    }
+}

--- a/Sources/VocaMac/Services/DictationOutputFormatter.swift
+++ b/Sources/VocaMac/Services/DictationOutputFormatter.swift
@@ -18,30 +18,26 @@ enum DictationOutputFormatter {
     static func capitalizeSentences(_ text: String) -> String {
         guard !text.isEmpty else { return text }
 
-        var characters = Array(text)
-        characters[0] = Character(characters[0].uppercased())
+        // Capitalize the first character without assuming a single Unicode scalar.
+        var result = String(text.prefix(1)).uppercased() + text.dropFirst()
 
-        var index = 1
-        while index < characters.count {
-            let current = characters[index]
-            if current == "." || current == "!" || current == "?" {
-                var whitespaceEnd = index + 1
-                while whitespaceEnd < characters.count && characters[whitespaceEnd].isWhitespace {
-                    whitespaceEnd += 1
-                }
-                if whitespaceEnd > index + 1, whitespaceEnd < characters.count {
-                    let candidate = characters[whitespaceEnd]
-                    if candidate.isLetter && candidate.isLowercase {
-                        characters[whitespaceEnd] = Character(candidate.uppercased())
-                    }
-                    index = whitespaceEnd
-                    continue
-                }
-            }
-            index += 1
+        // Capitalize after sentence-ending punctuation + whitespace.
+        // Mirrors VocaLinux: ([.!?])(\s+)([a-z]) — ASCII lowercase only so
+        // URLs and decimals without a space stay untouched.
+        let pattern = #"([.!?])(\s+)([a-z])"#
+        guard let regex = try? NSRegularExpression(pattern: pattern) else {
+            return result
         }
 
-        return String(characters)
+        let nsRange = NSRange(result.startIndex..<result.endIndex, in: result)
+        let matches = regex.matches(in: result, range: nsRange)
+        // Apply from the end so earlier ranges stay valid.
+        for match in matches.reversed() {
+            guard let letterRange = Range(match.range(at: 3), in: result) else { continue }
+            result.replaceSubrange(letterRange, with: result[letterRange].uppercased())
+        }
+
+        return result
     }
 
     /// Append a trailing space so consecutive dictation sessions do not glue.

--- a/Sources/VocaMac/Services/ModelKeepAlive.swift
+++ b/Sources/VocaMac/Services/ModelKeepAlive.swift
@@ -1,0 +1,144 @@
+// ModelKeepAlive.swift
+// VocaMac
+//
+// Unloads the speech model after a configurable idle timeout.
+// Mac adapter for VocaLinux model keep-alive / idle unload (#592).
+
+import Foundation
+
+/// Schedules idle unload of the speech model after inactivity.
+@MainActor
+final class ModelKeepAlive: ObservableObject {
+
+    static let defaultIdleTimeoutSeconds: TimeInterval = 300
+    static let minIdleTimeoutSeconds: TimeInterval = 60
+    static let maxIdleTimeoutSeconds: TimeInterval = 3600
+
+    /// Re-read on each bump so Settings changes apply without restart.
+    var getConfig: () -> (enabled: Bool, idleTimeoutSeconds: TimeInterval)
+
+    /// Called once when the idle timeout elapses and unload is safe.
+    var onIdleUnload: (() -> Void)?
+
+    /// Unload only runs when this returns true (idle + not auto-paused + model loaded).
+    var isSafeToUnload: () -> Bool
+
+    /// When false, tests drive `fireIfDue()` without a real Timer.
+    var useTimer: Bool
+
+    @Published private(set) var isArmed: Bool = false
+    private(set) var isRunning: Bool = false
+
+    private var timer: Timer?
+
+    init(
+        getConfig: @escaping () -> (enabled: Bool, idleTimeoutSeconds: TimeInterval) = {
+            (false, defaultIdleTimeoutSeconds)
+        },
+        onIdleUnload: (() -> Void)? = nil,
+        isSafeToUnload: @escaping () -> Bool = { true },
+        useTimer: Bool = true
+    ) {
+        self.getConfig = getConfig
+        self.onIdleUnload = onIdleUnload
+        self.isSafeToUnload = isSafeToUnload
+        self.useTimer = useTimer
+    }
+
+    deinit {
+        timer?.invalidate()
+    }
+
+    /// Mark the helper as running. Safe to call if already started.
+    func start() {
+        guard !isRunning else { return }
+        isRunning = true
+        VocaLogger.info(.general, "Model keep-alive started")
+    }
+
+    /// Cancel any pending timer and mark stopped.
+    func stop() {
+        isRunning = false
+        cancel()
+        VocaLogger.info(.general, "Model keep-alive stopped")
+    }
+
+    /// Reset the idle deadline from now (call when recognition becomes idle).
+    func bump() {
+        guard isRunning else { return }
+
+        let (enabled, timeout) = readConfig()
+        guard enabled else {
+            cancel()
+            return
+        }
+
+        schedule(timeout)
+    }
+
+    /// Cancel any pending idle unload (call while recording/processing/auto-paused).
+    func cancel() {
+        timer?.invalidate()
+        timer = nil
+        isArmed = false
+    }
+
+    /// Manually run the idle unload path (tests / non-timer). Returns true if fired.
+    @discardableResult
+    func fireIfDue() -> Bool {
+        guard isRunning, isArmed else { return false }
+        return fireUnload()
+    }
+
+    static func clampIdleTimeout(_ seconds: TimeInterval) -> TimeInterval {
+        let value = seconds.isFinite ? seconds : defaultIdleTimeoutSeconds
+        return min(maxIdleTimeoutSeconds, max(minIdleTimeoutSeconds, value))
+    }
+
+    private func readConfig() -> (Bool, TimeInterval) {
+        let config = getConfig()
+        return (config.enabled, Self.clampIdleTimeout(config.idleTimeoutSeconds))
+    }
+
+    private func schedule(_ timeoutSeconds: TimeInterval) {
+        cancel()
+        isArmed = true
+
+        guard useTimer else { return }
+
+        let delay = max(1, timeoutSeconds)
+        let timer = Timer.scheduledTimer(withTimeInterval: delay, repeats: false) { [weak self] _ in
+            Task { @MainActor in
+                self?.timer = nil
+                _ = self?.fireUnload()
+            }
+        }
+        RunLoop.main.add(timer, forMode: .common)
+        self.timer = timer
+    }
+
+    @discardableResult
+    private func fireUnload() -> Bool {
+        guard isRunning else {
+            isArmed = false
+            return false
+        }
+
+        let (enabled, _) = readConfig()
+        guard enabled else {
+            isArmed = false
+            return false
+        }
+
+        guard isSafeToUnload() else {
+            VocaLogger.debug(.general, "Keep-alive unload skipped: not safe to unload")
+            isArmed = false
+            return false
+        }
+
+        isArmed = false
+        VocaLogger.info(.general, "Model keep-alive idle timeout reached — unloading model")
+        onIdleUnload?()
+        return true
+    }
+}

--- a/Sources/VocaMac/Services/ModelKeepAlive.swift
+++ b/Sources/VocaMac/Services/ModelKeepAlive.swift
@@ -10,9 +10,9 @@ import Foundation
 @MainActor
 final class ModelKeepAlive: ObservableObject {
 
-    static let defaultIdleTimeoutSeconds: TimeInterval = 300
-    static let minIdleTimeoutSeconds: TimeInterval = 60
-    static let maxIdleTimeoutSeconds: TimeInterval = 3600
+    nonisolated static let defaultIdleTimeoutSeconds: TimeInterval = 300
+    nonisolated static let minIdleTimeoutSeconds: TimeInterval = 60
+    nonisolated static let maxIdleTimeoutSeconds: TimeInterval = 3600
 
     /// Re-read on each bump so Settings changes apply without restart.
     var getConfig: () -> (enabled: Bool, idleTimeoutSeconds: TimeInterval)

--- a/Sources/VocaMac/Services/ModelKeepAlive.swift
+++ b/Sources/VocaMac/Services/ModelKeepAlive.swift
@@ -137,7 +137,7 @@ final class ModelKeepAlive: ObservableObject {
         }
 
         isArmed = false
-        VocaLogger.info(.general, "Model keep-alive idle timeout reached — unloading model")
+        VocaLogger.info(.general, "Model keep-alive idle timeout reached: unloading model")
         onIdleUnload?()
         return true
     }

--- a/Sources/VocaMac/Services/ServiceProtocols.swift
+++ b/Sources/VocaMac/Services/ServiceProtocols.swift
@@ -89,7 +89,6 @@ protocol CursorOverlayManaging: AnyObject {
     func hide()
     func transitionToProcessing()
     func updateAudioLevel(_ level: Float)
-    func setCancelHandler(_ handler: @escaping () -> Void)
 }
 
 // MARK: - ModelManaging

--- a/Sources/VocaMac/Services/ServiceProtocols.swift
+++ b/Sources/VocaMac/Services/ServiceProtocols.swift
@@ -133,6 +133,8 @@ protocol SpeechTranscribing: AnyObject {
     var isModelLoaded: Bool { get }
     func transcribe(audioData: [Float], language: String?, translate: Bool, vocabulary: String) async throws -> VocaTranscription
     func _loadModel(name: String?, folder: URL?, onPhaseChange: ((String) -> Void)?) async throws
+    /// Release the currently loaded model (and any sibling engines) to free memory.
+    func unloadModel() async
 }
 
 extension SpeechTranscribing {

--- a/Sources/VocaMac/Services/SleepWakeMonitor.swift
+++ b/Sources/VocaMac/Services/SleepWakeMonitor.swift
@@ -1,0 +1,64 @@
+// SleepWakeMonitor.swift
+// VocaMac
+//
+// Subscribes to NSWorkspace sleep/wake notifications for recovery hooks.
+
+import Foundation
+import AppKit
+
+/// Observes system sleep and wake to harden audio/hotkey/model keep-alive recovery.
+@MainActor
+final class SleepWakeMonitor {
+
+    var onWillSleep: (() -> Void)?
+    var onDidWake: (() -> Void)?
+
+    private var sleepObserver: NSObjectProtocol?
+    private var wakeObserver: NSObjectProtocol?
+    private(set) var isRunning = false
+
+    func start() {
+        guard !isRunning else { return }
+        isRunning = true
+
+        let center = NSWorkspace.shared.notificationCenter
+        sleepObserver = center.addObserver(
+            forName: NSWorkspace.willSleepNotification,
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            MainActor.assumeIsolated {
+                VocaLogger.info(.general, "System will sleep")
+                self?.onWillSleep?()
+            }
+        }
+
+        wakeObserver = center.addObserver(
+            forName: NSWorkspace.didWakeNotification,
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            MainActor.assumeIsolated {
+                VocaLogger.info(.general, "System did wake")
+                self?.onDidWake?()
+            }
+        }
+    }
+
+    func stop() {
+        isRunning = false
+        let center = NSWorkspace.shared.notificationCenter
+        if let sleepObserver {
+            center.removeObserver(sleepObserver)
+            self.sleepObserver = nil
+        }
+        if let wakeObserver {
+            center.removeObserver(wakeObserver)
+            self.wakeObserver = nil
+        }
+    }
+
+    deinit {
+        // Observers removed on stop(); avoid touching MainActor state from deinit.
+    }
+}

--- a/Sources/VocaMac/Services/TranscriptionRouter.swift
+++ b/Sources/VocaMac/Services/TranscriptionRouter.swift
@@ -146,4 +146,22 @@ extension TranscriptionRouter: SpeechTranscribing {
             }
         }
     }
+
+    /// Unload every engine so only cold-start memory remains.
+    ///
+    /// Serialized with load/transcribe so a hotkey cannot decode against an
+    /// engine that is mid-teardown.
+    func unloadModel() async {
+        do {
+            try await operationSerializer.run { [self] in
+                whisper.unloadModel()
+                await parakeet.unloadModelAndWait()
+                appleSpeech.unloadModel()
+                sherpa.unloadModel()
+            }
+        } catch {
+            // Unload paths do not throw today; keep the queue resilient if that changes.
+            VocaLogger.error(.general, "Model unload failed: \(error.localizedDescription)")
+        }
+    }
 }

--- a/Sources/VocaMac/Views/MenuBarView.swift
+++ b/Sources/VocaMac/Views/MenuBarView.swift
@@ -164,13 +164,13 @@ struct MenuBarView: View {
 
             Spacer()
 
-            // CPU & RAM usage display
+            // CPU & RAM usage display (whole VocaMac process, not model-only)
             HStack(spacing: 10) {
                 ResourceBadge(
                     icon: "cpu",
                     value: String(format: "%.0f%%", processMonitor.cpuUsage),
                     details: [
-                        ("CPU Usage", String(format: "%.1f%%", processMonitor.cpuUsage)),
+                        ("App CPU", String(format: "%.1f%%", processMonitor.cpuUsage)),
                         ("Threads", "\(processMonitor.threadCount)"),
                         ("Cores", "\(ProcessInfo.processInfo.activeProcessorCount)"),
                     ]
@@ -180,8 +180,8 @@ struct MenuBarView: View {
                     icon: "memorychip",
                     value: formattedMemory(processMonitor.memoryMB),
                     details: [
-                        ("Resident", String(format: "%.1f MB", processMonitor.memoryMB)),
-                        ("Peak", String(format: "%.1f MB", processMonitor.memoryPeakMB)),
+                        ("App Memory (RSS)", String(format: "%.1f MB", processMonitor.memoryMB)),
+                        ("Peak RSS (this session)", String(format: "%.1f MB", processMonitor.memoryPeakMB)),
                         ("System", "\(ProcessInfo.processInfo.physicalMemory / (1024 * 1024 * 1024)) GB"),
                     ]
                 )
@@ -371,26 +371,6 @@ struct MenuBarView: View {
                     Spacer()
                     Text("⌘,")
                         .foregroundStyle(.secondary)
-                }
-                .font(.body)
-                .padding(.vertical, 6)
-                .padding(.horizontal, 8)
-                .frame(maxWidth: .infinity, alignment: .leading)
-                .contentShape(Rectangle())
-                .background(
-                    RoundedRectangle(cornerRadius: 6)
-                        .fill(Color.primary.opacity(0.0001))
-                )
-            }
-            .buttonStyle(MenuRowButtonStyle())
-
-            Button {
-                NotificationCenter.default.post(name: .showOnboarding, object: nil)
-            } label: {
-                HStack {
-                    Image(systemName: "wand.and.stars")
-                    Text("Setup Wizard")
-                    Spacer()
                 }
                 .font(.body)
                 .padding(.vertical, 6)

--- a/Sources/VocaMac/Views/MenuBarView.swift
+++ b/Sources/VocaMac/Views/MenuBarView.swift
@@ -466,9 +466,9 @@ struct MenuBarView: View {
         if appState.isAutoPaused { return .orange }
         switch appState.appStatus {
         case .idle:       return .green
-        case .recording:  return .red
-        case .processing: return .orange
-        case .error:      return .yellow
+        case .recording:  return Color(nsColor: BrandAssets.brandGreen)
+        case .processing: return .yellow
+        case .error:      return .orange
         }
     }
 

--- a/Sources/VocaMac/Views/MenuBarView.swift
+++ b/Sources/VocaMac/Views/MenuBarView.swift
@@ -142,7 +142,7 @@ struct MenuBarView: View {
                     .fontWeight(.semibold)
 
                 if let model = appState.currentModel {
-                    Text("Model: \(model.size.displayName) · ~\(String(format: "%.1f", model.size.ramRequiredGB)) GB")
+                    Text("Model: \(model.size.displayName) (~\(String(format: "%.1f", model.size.ramRequiredGB)) GB)")
                         .font(.subheadline)
                         .foregroundStyle(.secondary)
                 } else if appState.whisperService.isModelLoaded {
@@ -164,12 +164,12 @@ struct MenuBarView: View {
                         .font(.subheadline)
                         .foregroundStyle(.orange)
                 } else if appState.isAutoPaused {
-                    Text(appState.autoPauseTriggerDisplayName.map { "Unloaded · paused for \($0)" }
-                         ?? "Unloaded · auto-paused")
+                    Text(appState.autoPauseTriggerDisplayName.map { "Unloaded (paused for \($0))" }
+                         ?? "Unloaded (auto-paused)")
                         .font(.subheadline)
                         .foregroundStyle(.orange)
                 } else if appState.lastModelUnloadReason == .idleKeepAlive {
-                    Text("Unloaded · idle timeout")
+                    Text("Unloaded (idle timeout)")
                         .font(.subheadline)
                         .foregroundStyle(.orange)
                 } else {
@@ -238,7 +238,7 @@ struct MenuBarView: View {
                             .foregroundStyle(.primary)
                             .fixedSize(horizontal: false, vertical: true)
                         if let freed = appState.approximateMemoryFreedMB {
-                            Text(String(format: "About %.0f MB process memory was released.", freed))
+                            Text(String(format: "About %.0f MB of process memory was released.", freed))
                                 .font(.caption2)
                                 .foregroundStyle(.secondary)
                         }
@@ -452,7 +452,7 @@ struct MenuBarView: View {
 
     private var statusText: String {
         if appState.isAutoPaused {
-            return appState.autoPauseTriggerDisplayName.map { "Paused · \($0)" } ?? "Auto-paused"
+            return appState.autoPauseTriggerDisplayName.map { "Paused (\($0))" } ?? "Auto-paused"
         }
         switch appState.appStatus {
         case .idle:       return "Ready"

--- a/Sources/VocaMac/Views/MenuBarView.swift
+++ b/Sources/VocaMac/Views/MenuBarView.swift
@@ -26,6 +26,19 @@ final class ProcessMonitor: ObservableObject {
 
     deinit { timer?.invalidate() }
 
+    /// One-shot resident memory sample for the current process (MB).
+    static func currentResidentMemoryMB() -> Double {
+        var taskInfo = mach_task_basic_info()
+        var count = mach_msg_type_number_t(MemoryLayout<mach_task_basic_info>.size) / 4
+        let kr = withUnsafeMutablePointer(to: &taskInfo) {
+            $0.withMemoryRebound(to: integer_t.self, capacity: Int(count)) {
+                task_info(mach_task_self_, task_flavor_t(MACH_TASK_BASIC_INFO), $0, &count)
+            }
+        }
+        guard kr == KERN_SUCCESS else { return 0 }
+        return Double(taskInfo.resident_size) / (1024 * 1024)
+    }
+
     func refresh() {
         // --- Memory via mach_task_basic_info ---
         var taskInfo = mach_task_basic_info()
@@ -129,18 +142,15 @@ struct MenuBarView: View {
                     .fontWeight(.semibold)
 
                 if let model = appState.currentModel {
-                    // Model is loaded and ready
-                    Text("Model: \(model.size.displayName)")
+                    Text("Model: \(model.size.displayName) · ~\(String(format: "%.1f", model.size.ramRequiredGB)) GB")
                         .font(.subheadline)
                         .foregroundStyle(.secondary)
                 } else if appState.whisperService.isModelLoaded {
-                    // Loaded but currentModel wasn't set (shouldn't happen, but safety net)
                     Text("Model: \(appState.whisperService.loadedModelName ?? "Loaded")")
                         .font(.subheadline)
                         .foregroundStyle(.secondary)
                 } else if let downloadingModel = appState.availableModels.first(where: { $0.downloadProgress != nil }),
                           let progress = downloadingModel.downloadProgress {
-                    // A model is being downloaded — show progress
                     VStack(alignment: .leading, spacing: 4) {
                         Text("Downloading \(downloadingModel.size.displayName)… \(Int(progress * 100))%")
                             .font(.subheadline)
@@ -150,12 +160,19 @@ struct MenuBarView: View {
                             .tint(.orange)
                     }
                 } else if let loadingModel = appState.availableModels.first(where: { $0.isLoading }) {
-                    // A model is being loaded (already downloaded, now initializing)
                     Text("Loading \(loadingModel.size.displayName)…")
                         .font(.subheadline)
                         .foregroundStyle(.orange)
+                } else if appState.isAutoPaused {
+                    Text(appState.autoPauseTriggerDisplayName.map { "Unloaded · paused for \($0)" }
+                         ?? "Unloaded · auto-paused")
+                        .font(.subheadline)
+                        .foregroundStyle(.orange)
+                } else if appState.lastModelUnloadReason == .idleKeepAlive {
+                    Text("Unloaded · idle timeout")
+                        .font(.subheadline)
+                        .foregroundStyle(.orange)
                 } else {
-                    // Fallback: no model loaded and nothing actively in progress
                     Text("No model loaded")
                         .font(.subheadline)
                         .foregroundStyle(.orange)
@@ -208,6 +225,28 @@ struct MenuBarView: View {
                 Text(activationModeHint)
                     .font(.caption)
                     .foregroundStyle(.secondary)
+            }
+
+            if let unloadMessage = appState.modelUnloadStatusMessage,
+               appState.appStatus == .idle || appState.isAutoPaused {
+                HStack(alignment: .top, spacing: 8) {
+                    Image(systemName: appState.isAutoPaused ? "pause.circle.fill" : "memorychip")
+                        .foregroundStyle(.orange)
+                    VStack(alignment: .leading, spacing: 2) {
+                        Text(unloadMessage)
+                            .font(.caption)
+                            .foregroundStyle(.primary)
+                            .fixedSize(horizontal: false, vertical: true)
+                        if let freed = appState.approximateMemoryFreedMB {
+                            Text(String(format: "About %.0f MB process memory was released.", freed))
+                                .font(.caption2)
+                                .foregroundStyle(.secondary)
+                        }
+                    }
+                }
+                .padding(10)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .background(Color.orange.opacity(0.12), in: RoundedRectangle(cornerRadius: 8, style: .continuous))
             }
 
             // Audio level indicator (visible during recording)
@@ -412,6 +451,9 @@ struct MenuBarView: View {
     // MARK: - Helpers
 
     private var statusText: String {
+        if appState.isAutoPaused {
+            return appState.autoPauseTriggerDisplayName.map { "Paused · \($0)" } ?? "Auto-paused"
+        }
         switch appState.appStatus {
         case .idle:       return "Ready"
         case .recording:  return "Recording..."
@@ -421,6 +463,7 @@ struct MenuBarView: View {
     }
 
     private var statusColor: Color {
+        if appState.isAutoPaused { return .orange }
         switch appState.appStatus {
         case .idle:       return .green
         case .recording:  return .red

--- a/Sources/VocaMac/Views/SettingsView.swift
+++ b/Sources/VocaMac/Views/SettingsView.swift
@@ -17,7 +17,7 @@ struct SettingsView: View {
     @State private var selectedPage: SettingsPage? = .dictation
     @State private var searchText = ""
     @State private var pageBeforeSearch: SettingsPage = .dictation
-    /// Manual sidebar visibility — avoids NavigationSplitView's relocating system toggles.
+    /// Manual sidebar visibility. Avoids NavigationSplitView relocating system toggles.
     @State private var isSidebarVisible = true
 
     private var matchCounts: [SettingsPage: Int] {
@@ -133,7 +133,7 @@ struct SettingsView: View {
     }
 }
 
-// MARK: - Sidebar Search (System Settings–style)
+// MARK: - Sidebar Search (System Settings style)
 
 /// Pill search field pinned to the top of the settings sidebar.
 struct SettingsSidebarSearchField: View {
@@ -341,13 +341,13 @@ struct DictationSettingsPage: View {
             Section("Output") {
                 Toggle("Trailing Space After Dictation", isOn: $appState.appendTrailingSpace)
 
-                Text("Adds a space after each completed utterance so the next dictation session does not glue onto the previous sentence.")
+                Text("Adds a space after each utterance so the next dictation does not stick to the previous one.")
                     .font(.caption)
                     .foregroundStyle(.secondary)
 
                 Toggle("Auto-Capitalize Sentences", isOn: $appState.autoCapitalize)
 
-                Text("Capitalizes the start of each utterance and letters that follow sentence-ending punctuation. Already-capitalized text is left alone.")
+                Text("Capitalizes the start of each utterance and letters after . ! or ?. Skips text that is already capitalized.")
                     .font(.caption)
                     .foregroundStyle(.secondary)
             }
@@ -507,12 +507,12 @@ struct PerformanceSettingsTab: View {
                         .font(.caption)
                         .foregroundStyle(.orange)
                     if let freed = appState.approximateMemoryFreedMB {
-                        Text(String(format: "Approx. %.0f MB process RSS dropped on unload.", freed))
+                        Text(String(format: "About %.0f MB of process memory was released on unload.", freed))
                             .font(.caption2)
                             .foregroundStyle(.secondary)
                     }
                 } else {
-                    Text("No speech model is currently resident.")
+                    Text("No speech model is loaded right now.")
                         .font(.caption)
                         .foregroundStyle(.secondary)
                 }
@@ -521,13 +521,13 @@ struct PerformanceSettingsTab: View {
             Section("Auto-Pause for Apps") {
                 Toggle("Pause Dictation for Listed Apps", isOn: $appState.autoPauseEnabled)
 
-                Text("While a listed app is running, VocaMac unloads the speech model and blocks dictation. The model reloads when none of the listed apps remain.")
+                Text("When a listed app is running, VocaMac unloads the speech model and blocks dictation. The model reloads once none of those apps are still running.")
                     .font(.caption)
                     .foregroundStyle(.secondary)
 
                 Group {
                     if appState.autoPauseApps.isEmpty {
-                        Text("No apps in the list yet. Add one with “Choose Running App…”")
+                        Text("No apps in the list yet. Use Choose Running App… to add one.")
                             .foregroundStyle(.secondary)
                     } else {
                         ForEach(appState.autoPauseApps) { app in
@@ -576,7 +576,7 @@ struct PerformanceSettingsTab: View {
             Section("Unload When Idle") {
                 Toggle("Unload Model When Idle", isOn: $appState.modelKeepAliveEnabled)
 
-                Text("After you stop dictating, unload the model to free RAM. The next dictation session reloads it (cold start may take a moment).")
+                Text("Unload the model after you stop dictating to free RAM. The next dictation reloads it, which can take a moment.")
                     .font(.caption)
                     .foregroundStyle(.secondary)
 
@@ -631,7 +631,7 @@ struct AutoPauseAppPickerSheet: View {
             Text("Choose Running App")
                 .font(.headline)
 
-            Text("Select an app to pause dictation while it is running.")
+            Text("Pick an app. Dictation pauses while that app is running.")
                 .font(.caption)
                 .foregroundStyle(.secondary)
 
@@ -798,7 +798,7 @@ struct ModelSettingsTab: View {
                         VStack(alignment: .leading, spacing: 2) {
                             Text("Recommended for your device: **\(recommendedSize.displayName)**")
                                 .font(.callout)
-                            Text("Based on WhisperKit's tuned variants for your chip — not your RAM.")
+                            Text("Based on WhisperKit's tuned variants for your chip, not your RAM.")
                                 .font(.caption2)
                                 .foregroundStyle(.tertiary)
                         }
@@ -862,8 +862,8 @@ struct ModelSettingsTab: View {
                     Toggle("Enable translation", isOn: $appState.translationEnabled)
 
                     Text(appState.translationEnabled
-                         ? "Speech will be translated to the selected language (or English if Auto-detect)."
-                         : "Speech will be transcribed as-is in the spoken language. The language setting is used as a recognition hint only.")
+                         ? "Speech is translated to the selected language (or English if set to Auto-detect)."
+                         : "Speech is transcribed as spoken. The language setting is only a recognition hint.")
                         .font(.caption)
                         .foregroundStyle(.secondary)
                 }
@@ -889,8 +889,8 @@ struct ModelSettingsTab: View {
 
                     let count = WhisperService.vocabularyTerms(from: appState.customVocabulary).count
                     Text(count == 0
-                         ? "Add names, jargon, or proper nouns (one per line, or comma-separated) that get mis-transcribed."
-                         : "\(count) term\(count == 1 ? "" : "s"). Keep the list short — the model can only use the first 50 to 100 words as a hint.")
+                         ? "Add names, jargon, or proper nouns (one per line or comma-separated) that get mis-transcribed."
+                         : "\(count) term\(count == 1 ? "" : "s"). Keep the list short; the model can only use the first 50 to 100 words as a hint.")
                         .font(.caption)
                         .foregroundStyle(.secondary)
                 }
@@ -1397,7 +1397,7 @@ struct AboutTab: View {
            let size = appState.modelManager.modelSize(from: name) {
             return size.engine.displayName
         }
-        return "—"
+        return "-"
     }
 
     private var appVersionDisplay: String {
@@ -1487,7 +1487,7 @@ struct DebugTab: View {
                 .frame(maxWidth: .infinity, alignment: .leading)
                 .padding(.vertical, 4)
 
-                Text("Process-wide usage for VocaMac, refreshed every few seconds — not model-only VRAM/ANE accounting.")
+                Text("This is VocaMac's process usage, refreshed every few seconds. It is not a model-only VRAM or ANE reading.")
                     .font(.caption)
                     .foregroundStyle(.secondary)
             }

--- a/Sources/VocaMac/Views/SettingsView.swift
+++ b/Sources/VocaMac/Views/SettingsView.swift
@@ -36,10 +36,22 @@ struct SettingsView: View {
     var body: some View {
         NavigationSplitView {
             List(selection: $selectedPage) {
-                ForEach(visiblePages) { page in
-                    Label(page.title, systemImage: page.systemImage)
-                        .badge(hasSearchQuery ? (matchCounts[page] ?? 0) : 0)
-                        .tag(page)
+                Section {
+                    ForEach(visiblePages) { page in
+                        Label(page.title, systemImage: page.systemImage)
+                            .badge(hasSearchQuery ? (matchCounts[page] ?? 0) : 0)
+                            .tag(page)
+                    }
+                } header: {
+                    HStack(spacing: 8) {
+                        BrandLogoView(size: 22)
+                        Text("VocaMac")
+                            .font(.headline)
+                            .foregroundStyle(.primary)
+                    }
+                    .padding(.vertical, 4)
+                    .accessibilityElement(children: .combine)
+                    .accessibilityLabel("VocaMac Settings")
                 }
             }
             .listStyle(.sidebar)
@@ -75,7 +87,9 @@ struct SettingsView: View {
             }
             .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
         }
-        .searchable(text: $searchText, prompt: "Search settings")
+        // Keep search anchored in the sidebar so collapsing the column does not
+        // shove the field across the toolbar.
+        .searchable(text: $searchText, placement: .sidebar, prompt: "Search settings")
         .onChange(of: searchText) { _, newValue in
             let trimmed = newValue.trimmingCharacters(in: .whitespacesAndNewlines)
             if trimmed.isEmpty {
@@ -108,6 +122,13 @@ struct SettingsSidebarFooter: View {
             || appState.appStatus == .processing
     }
 
+    private var resultText: String? {
+        let text = appState.settingsTestResultText?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        guard let text, !text.isEmpty else { return nil }
+        return text
+    }
+
     var body: some View {
         VStack(alignment: .leading, spacing: 8) {
             HStack(spacing: 8) {
@@ -132,28 +153,37 @@ struct SettingsSidebarFooter: View {
                     Capsule()
                         .fill(Color.secondary.opacity(0.15))
                     Capsule()
-                        .fill(appState.appStatus == .recording ? Color.red : Color.accentColor)
+                        .fill(appState.appStatus == .recording
+                              ? Color(nsColor: BrandAssets.brandGreen)
+                              : Color.accentColor)
                         .frame(width: max(4, geo.size.width * CGFloat(min(max(appState.audioLevel, 0), 1))))
                 }
             }
             .frame(height: isActiveSession ? 8 : 5)
             .animation(.easeInOut(duration: 0.15), value: isActiveSession)
 
-            if let text = appState.lastTranscription?.text.trimmingCharacters(in: .whitespacesAndNewlines),
-               !text.isEmpty,
-               !isActiveSession {
-                Text(text)
-                    .font(.caption2)
-                    .foregroundStyle(.secondary)
-                    .lineLimit(2)
-                    .frame(maxWidth: .infinity, alignment: .leading)
+            Group {
+                if let resultText, !isActiveSession {
+                    Text(resultText)
+                        .font(.caption2)
+                        .foregroundStyle(.secondary)
+                        .lineLimit(3)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                } else if !isActiveSession {
+                    Text("Results appear here")
+                        .font(.caption2)
+                        .foregroundStyle(.tertiary)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                }
             }
+            .frame(minHeight: 28, alignment: .topLeading)
 
             Button {
                 Task { @MainActor in
                     if appState.isRecording || appState.appStatus == .recording {
-                        await appState.stopRecordingAndTranscribe()
+                        await appState.stopRecordingAndTranscribe(injectResult: false)
                     } else {
+                        appState.settingsTestResultText = nil
                         await appState.startRecording()
                     }
                 }
@@ -166,10 +196,6 @@ struct SettingsSidebarFooter: View {
             }
             .controlSize(.small)
             .disabled(appState.isAutoPaused && !appState.isRecording)
-
-            Text("Result appears here. Text also injects into the focused app.")
-                .font(.caption2)
-                .foregroundStyle(.tertiary)
         }
         .padding(12)
         .background(.bar)
@@ -189,7 +215,7 @@ struct SettingsSidebarFooter: View {
         if appState.isAutoPaused { return .orange }
         switch appState.appStatus {
         case .idle: return .green
-        case .recording: return .red
+        case .recording: return Color(nsColor: BrandAssets.brandGreen)
         case .processing: return .purple
         case .error: return .orange
         }
@@ -1297,27 +1323,49 @@ struct DebugTab: View {
         Form {
             if let capabilities = appState.systemCapabilities {
                 Section("System Information") {
-                    LabeledContent("CPU", value: capabilities.processorName)
-                    LabeledContent("RAM", value: "\(capabilities.physicalMemoryGB) GB")
-                    LabeledContent("Metal", value: capabilities.supportsMetalAcceleration ? "Yes" : "No")
+                    HStack(spacing: 16) {
+                        SystemInfoPill(icon: "cpu", label: "CPU", value: capabilities.processorName)
+                        SystemInfoPill(icon: "memorychip", label: "RAM", value: "\(capabilities.physicalMemoryGB) GB")
+                        SystemInfoPill(
+                            icon: "bolt.fill",
+                            label: "Metal",
+                            value: capabilities.supportsMetalAcceleration ? "Yes" : "No"
+                        )
+                    }
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .padding(.vertical, 4)
                 }
             }
 
             Section("Resource Usage") {
-                LabeledContent("App CPU", value: String(format: "%.1f%%", processMonitor.cpuUsage))
-                LabeledContent(
-                    "App Memory (RSS)",
-                    value: processMonitor.memoryMB >= 1024
-                        ? String(format: "%.1f GB", processMonitor.memoryMB / 1024)
-                        : String(format: "%.0f MB", processMonitor.memoryMB)
-                )
-                LabeledContent(
-                    "Peak RSS (this session)",
-                    value: processMonitor.memoryPeakMB >= 1024
-                        ? String(format: "%.1f GB", processMonitor.memoryPeakMB / 1024)
-                        : String(format: "%.0f MB", processMonitor.memoryPeakMB)
-                )
-                LabeledContent("Threads", value: "\(processMonitor.threadCount)")
+                HStack(spacing: 12) {
+                    SystemInfoPill(
+                        icon: "cpu",
+                        label: "App CPU",
+                        value: String(format: "%.1f%%", processMonitor.cpuUsage)
+                    )
+                    SystemInfoPill(
+                        icon: "memorychip",
+                        label: "Memory",
+                        value: processMonitor.memoryMB >= 1024
+                            ? String(format: "%.1f GB", processMonitor.memoryMB / 1024)
+                            : String(format: "%.0f MB", processMonitor.memoryMB)
+                    )
+                    SystemInfoPill(
+                        icon: "chart.line.uptrend.xyaxis",
+                        label: "Peak",
+                        value: processMonitor.memoryPeakMB >= 1024
+                            ? String(format: "%.1f GB", processMonitor.memoryPeakMB / 1024)
+                            : String(format: "%.0f MB", processMonitor.memoryPeakMB)
+                    )
+                    SystemInfoPill(
+                        icon: "arrow.triangle.branch",
+                        label: "Threads",
+                        value: "\(processMonitor.threadCount)"
+                    )
+                }
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding(.vertical, 4)
 
                 Text("Process-wide usage for VocaMac, refreshed every few seconds — not model-only VRAM/ANE accounting.")
                     .font(.caption)

--- a/Sources/VocaMac/Views/SettingsView.swift
+++ b/Sources/VocaMac/Views/SettingsView.swift
@@ -35,22 +35,20 @@ struct SettingsView: View {
 
     var body: some View {
         NavigationSplitView {
-            VStack(spacing: 0) {
-                List(selection: $selectedPage) {
-                    ForEach(visiblePages) { page in
-                        Label(page.title, systemImage: page.systemImage)
-                            .badge(hasSearchQuery ? (matchCounts[page] ?? 0) : 0)
-                            .tag(page)
-                    }
+            List(selection: $selectedPage) {
+                ForEach(visiblePages) { page in
+                    Label(page.title, systemImage: page.systemImage)
+                        .badge(hasSearchQuery ? (matchCounts[page] ?? 0) : 0)
+                        .tag(page)
                 }
-                .listStyle(.sidebar)
-
+            }
+            .listStyle(.sidebar)
+            .overlay {
                 if hasSearchQuery && visiblePages.isEmpty {
                     ContentUnavailableView.search(text: searchText)
-                        .frame(maxHeight: 160)
                 }
-
-                Divider()
+            }
+            .safeAreaInset(edge: .bottom, spacing: 0) {
                 SettingsSidebarFooter()
             }
             .navigationSplitViewColumnWidth(min: 180, ideal: 200, max: 260)
@@ -104,6 +102,12 @@ struct SettingsView: View {
 struct SettingsSidebarFooter: View {
     @EnvironmentObject var appState: AppState
 
+    private var isActiveSession: Bool {
+        appState.isRecording
+            || appState.appStatus == .recording
+            || appState.appStatus == .processing
+    }
+
     var body: some View {
         VStack(alignment: .leading, spacing: 8) {
             HStack(spacing: 8) {
@@ -112,8 +116,10 @@ struct SettingsSidebarFooter: View {
                     .frame(width: 8, height: 8)
                 Text(statusLabel)
                     .font(.caption)
-                    .foregroundStyle(.secondary)
-                Spacer()
+                    .fontWeight(isActiveSession ? .semibold : .regular)
+                    .foregroundStyle(isActiveSession ? .primary : .secondary)
+                    .lineLimit(2)
+                Spacer(minLength: 0)
                 if appState.isAutoPaused {
                     Text("Paused")
                         .font(.caption2)
@@ -126,38 +132,44 @@ struct SettingsSidebarFooter: View {
                     Capsule()
                         .fill(Color.secondary.opacity(0.15))
                     Capsule()
-                        .fill(Color.accentColor)
+                        .fill(appState.appStatus == .recording ? Color.red : Color.accentColor)
                         .frame(width: max(4, geo.size.width * CGFloat(min(max(appState.audioLevel, 0), 1))))
                 }
             }
-            .frame(height: 4)
+            .frame(height: isActiveSession ? 8 : 5)
+            .animation(.easeInOut(duration: 0.15), value: isActiveSession)
 
-            HStack(spacing: 8) {
-                Button {
-                    Task { @MainActor in
-                        if appState.isRecording || appState.appStatus == .recording {
-                            await appState.stopRecordingAndTranscribe()
-                        } else {
-                            await appState.startRecording()
-                        }
-                    }
-                } label: {
-                    Label(
-                        appState.isRecording ? "Stop Dictation" : "Test Dictation",
-                        systemImage: appState.isRecording ? "stop.fill" : "mic.fill"
-                    )
-                }
-                .controlSize(.small)
-                .disabled(appState.isAutoPaused && !appState.isRecording)
-
-                Spacer()
-
-                Button("Close") {
-                    NSApp.keyWindow?.close()
-                }
-                .controlSize(.small)
-                .keyboardShortcut(.cancelAction)
+            if let text = appState.lastTranscription?.text.trimmingCharacters(in: .whitespacesAndNewlines),
+               !text.isEmpty,
+               !isActiveSession {
+                Text(text)
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
+                    .lineLimit(2)
+                    .frame(maxWidth: .infinity, alignment: .leading)
             }
+
+            Button {
+                Task { @MainActor in
+                    if appState.isRecording || appState.appStatus == .recording {
+                        await appState.stopRecordingAndTranscribe()
+                    } else {
+                        await appState.startRecording()
+                    }
+                }
+            } label: {
+                Label(
+                    appState.isRecording || appState.appStatus == .recording ? "Stop Dictation" : "Test Dictation",
+                    systemImage: appState.isRecording || appState.appStatus == .recording ? "stop.fill" : "mic.fill"
+                )
+                .frame(maxWidth: .infinity)
+            }
+            .controlSize(.small)
+            .disabled(appState.isAutoPaused && !appState.isRecording)
+
+            Text("Result appears here. Text also injects into the focused app.")
+                .font(.caption2)
+                .foregroundStyle(.tertiary)
         }
         .padding(12)
         .background(.bar)
@@ -167,8 +179,8 @@ struct SettingsSidebarFooter: View {
         if appState.isAutoPaused { return "Auto-paused" }
         switch appState.appStatus {
         case .idle: return "Ready"
-        case .recording: return "Recording"
-        case .processing: return "Processing"
+        case .recording: return "Recording…"
+        case .processing: return "Transcribing…"
         case .error: return appState.errorMessage ?? "Error"
         }
     }
@@ -513,15 +525,13 @@ struct AutoPauseAppPickerSheet: View {
 
 struct ModelSettingsTab: View {
     @EnvironmentObject var appState: AppState
-    @StateObject private var processMonitor = ProcessMonitor()
     @State private var languageSearch = ""
 
-    /// When true, show language / translation / vocabulary above the catalog.
+    /// When true, show language / translation / vocabulary below the catalog.
     var showsLanguageHints: Bool = false
 
     init(showsLanguageHints: Bool = false) {
         self.showsLanguageHints = showsLanguageHints
-        _processMonitor = StateObject(wrappedValue: ProcessMonitor())
     }
 
     /// Catalog entries grouped by engine, preserving catalog order within
@@ -537,6 +547,11 @@ struct ModelSettingsTab: View {
         TranscriptionLanguage.filtered(search: languageSearch)
     }
 
+    private var activeEngine: TranscriptionEngine? {
+        appState.currentModel?.size.engine
+            ?? ModelSize(rawValue: appState.selectedModelSize)?.engine
+    }
+
     private func engineIconName(_ engine: TranscriptionEngine) -> String {
         switch engine {
         case .parakeet:    return "bolt.fill"
@@ -549,69 +564,6 @@ struct ModelSettingsTab: View {
     var body: some View {
         ScrollView {
             VStack(alignment: .leading, spacing: 16) {
-                if showsLanguageHints {
-                    languageAndHintsSection
-                }
-
-                // System info
-                if let capabilities = appState.systemCapabilities {
-                    GroupBox {
-                        VStack(alignment: .leading, spacing: 6) {
-                            Label("System Information", systemImage: "cpu")
-                                .font(.headline)
-                                .padding(.bottom, 4)
-
-                            HStack(spacing: 24) {
-                                SystemInfoPill(icon: "cpu", label: "CPU", value: capabilities.processorName)
-                                SystemInfoPill(icon: "memorychip", label: "RAM", value: "\(capabilities.physicalMemoryGB) GB")
-                                SystemInfoPill(icon: "bolt.fill", label: "Metal", value: capabilities.supportsMetalAcceleration ? "Yes" : "No")
-                            }
-                            .frame(maxWidth: .infinity, alignment: .leading)
-
-                        }
-                        .padding(4)
-                    }
-                }
-
-                // Resource usage
-                GroupBox {
-                    VStack(alignment: .leading, spacing: 6) {
-                        Label("Resource Usage", systemImage: "gauge.with.dots.needle.bottom.50percent")
-                            .font(.headline)
-                            .padding(.bottom, 4)
-
-                        HStack(spacing: 24) {
-                            SystemInfoPill(
-                                icon: "cpu",
-                                label: "CPU",
-                                value: String(format: "%.1f%%", processMonitor.cpuUsage)
-                            )
-                            SystemInfoPill(
-                                icon: "memorychip",
-                                label: "Memory",
-                                value: processMonitor.memoryMB >= 1024
-                                    ? String(format: "%.1f GB", processMonitor.memoryMB / 1024)
-                                    : String(format: "%.0f MB", processMonitor.memoryMB)
-                            )
-                            SystemInfoPill(
-                                icon: "chart.line.uptrend.xyaxis",
-                                label: "Peak",
-                                value: processMonitor.memoryPeakMB >= 1024
-                                    ? String(format: "%.1f GB", processMonitor.memoryPeakMB / 1024)
-                                    : String(format: "%.0f MB", processMonitor.memoryPeakMB)
-                            )
-                            SystemInfoPill(
-                                icon: "arrow.triangle.branch",
-                                label: "Threads",
-                                value: "\(processMonitor.threadCount)"
-                            )
-                        }
-                        .frame(maxWidth: .infinity, alignment: .leading)
-                    }
-                    .padding(4)
-                }
-
-                // Currently active model
                 if let current = appState.currentModel {
                     GroupBox {
                         HStack {
@@ -714,6 +666,10 @@ struct ModelSettingsTab: View {
                         .font(.caption)
                         .foregroundStyle(.secondary)
                 }
+
+                if showsLanguageHints {
+                    languageAndHintsSection
+                }
             }
             .padding()
         }
@@ -754,51 +710,43 @@ struct ModelSettingsTab: View {
                         .foregroundStyle(.secondary)
                 }
 
-                Divider()
+                if activeEngine?.supportsTranslation == true {
+                    Divider()
 
-                Toggle("Enable translation", isOn: $appState.translationEnabled)
+                    Toggle("Enable translation", isOn: $appState.translationEnabled)
 
-                Text(appState.translationEnabled
-                     ? "Speech will be translated to the selected language (or English if Auto-detect)."
-                     : "Speech will be transcribed as-is in the spoken language. The language setting is used as a recognition hint only.")
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
-
-                if let engine = appState.currentModel?.size.engine, !engine.supportsTranslation {
-                    Text("Translation is only available with Whisper models. The active model (\(engine.displayName)) transcribes without translating.")
+                    Text(appState.translationEnabled
+                         ? "Speech will be translated to the selected language (or English if Auto-detect)."
+                         : "Speech will be transcribed as-is in the spoken language. The language setting is used as a recognition hint only.")
                         .font(.caption)
-                        .foregroundStyle(.orange)
+                        .foregroundStyle(.secondary)
                 }
 
-                Divider()
+                if activeEngine?.supportsCustomVocabulary == true {
+                    Divider()
 
-                Text("Custom Vocabulary")
-                    .font(.subheadline.weight(.semibold))
+                    Text("Custom Vocabulary")
+                        .font(.subheadline.weight(.semibold))
 
-                TextEditor(text: $appState.customVocabulary)
-                    .font(.body)
-                    .frame(minHeight: 90)
-                    .overlay(alignment: .topLeading) {
-                        if appState.customVocabulary.isEmpty {
-                            Text("kubectl, PostgreSQL, nginx, Grafana")
-                                .foregroundStyle(.tertiary)
-                                .padding(.top, 8)
-                                .padding(.leading, 5)
-                                .allowsHitTesting(false)
+                    TextEditor(text: $appState.customVocabulary)
+                        .font(.body)
+                        .frame(minHeight: 90)
+                        .overlay(alignment: .topLeading) {
+                            if appState.customVocabulary.isEmpty {
+                                Text("kubectl, PostgreSQL, nginx, Grafana")
+                                    .foregroundStyle(.tertiary)
+                                    .padding(.top, 8)
+                                    .padding(.leading, 5)
+                                    .allowsHitTesting(false)
+                            }
                         }
-                    }
 
-                let count = WhisperService.vocabularyTerms(from: appState.customVocabulary).count
-                Text(count == 0
-                     ? "Add names, jargon, or proper nouns (one per line, or comma-separated) that get mis-transcribed."
-                     : "\(count) term\(count == 1 ? "" : "s"). Keep the list short — the model can only use the first 50 to 100 words as a hint.")
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
-
-                if let engine = appState.currentModel?.size.engine, !engine.supportsCustomVocabulary {
-                    Text("Custom vocabulary is only applied by Whisper models. The active model (\(engine.displayName)) ignores these terms.")
+                    let count = WhisperService.vocabularyTerms(from: appState.customVocabulary).count
+                    Text(count == 0
+                         ? "Add names, jargon, or proper nouns (one per line, or comma-separated) that get mis-transcribed."
+                         : "\(count) term\(count == 1 ? "" : "s"). Keep the list short — the model can only use the first 50 to 100 words as a hint.")
                         .font(.caption)
-                        .foregroundStyle(.orange)
+                        .foregroundStyle(.secondary)
                 }
             }
             .padding(4)
@@ -1176,126 +1124,134 @@ struct AboutTab: View {
     @State private var updateInfoForSheet: UpdateInfo?
 
     var body: some View {
-        VStack(spacing: 16) {
-            Spacer()
+        ScrollView {
+            VStack(spacing: 16) {
+                BrandLogoView(size: 64)
 
-            BrandLogoView(size: 64)
+                Text("VocaMac")
+                    .font(.largeTitle)
+                    .fontWeight(.bold)
 
-            // App name and version
-            Text("VocaMac")
-                .font(.largeTitle)
-                .fontWeight(.bold)
+                Text("Your voice, your Mac, your privacy.\nOpen-source dictation powered by AI.")
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+                    .multilineTextAlignment(.center)
+                    .fixedSize(horizontal: false, vertical: true)
 
-            Text("Your voice, your Mac, your privacy.\nOpen-source dictation powered by AI.")
-                .font(.subheadline)
-                .foregroundStyle(.secondary)
-                .multilineTextAlignment(.center)
-                .fixedSize(horizontal: false, vertical: true)
+                Text("Version \(appVersionDisplay) (\(buildChannelLabel))")
+                    .font(.caption)
+                    .foregroundStyle(.tertiary)
 
-            Text("Version \(appVersionDisplay) (\(buildChannelLabel))")
-                .font(.caption)
-                .foregroundStyle(.tertiary)
-
-            Button {
-                Task { @MainActor in
-                    await appState.updateChecker.checkForUpdates()
-                    switch appState.updateChecker.updateState {
-                    case .updateAvailable(let info), .updateAvailableViaHomebrew(let info, _):
-                        updateInfoForSheet = info
-                        showingUpdateSheet = true
-                    default:
-                        break
+                Button {
+                    Task { @MainActor in
+                        await appState.updateChecker.checkForUpdates()
+                        switch appState.updateChecker.updateState {
+                        case .updateAvailable(let info), .updateAvailableViaHomebrew(let info, _):
+                            updateInfoForSheet = info
+                            showingUpdateSheet = true
+                        default:
+                            break
+                        }
+                    }
+                } label: {
+                    if case .checking = appState.updateChecker.updateState {
+                        HStack(spacing: 6) {
+                            ProgressView()
+                                .controlSize(.small)
+                            Text("Checking for Updates...")
+                        }
+                        .font(.caption)
+                    } else {
+                        Label("Check for Updates...", systemImage: "arrow.triangle.2.circlepath")
+                            .font(.caption)
                     }
                 }
-            } label: {
-                if case .checking = appState.updateChecker.updateState {
-                    HStack(spacing: 6) {
-                        ProgressView()
-                            .controlSize(.small)
-                        Text("Checking for Updates...")
+                .buttonStyle(.plain)
+                .foregroundStyle(.blue)
+
+                Text(updateStatusText)
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
+                    .multilineTextAlignment(.center)
+
+                Divider()
+                    .frame(width: 200)
+
+                GroupBox {
+                    VStack(alignment: .leading, spacing: 4) {
+                        if let capabilities = appState.systemCapabilities {
+                            InfoRow2(label: "Device", value: capabilities.processorName)
+                            InfoRow2(label: "Architecture", value: capabilities.isAppleSilicon ? "Apple Silicon (ARM64)" : "Intel (x86_64)")
+                            InfoRow2(label: "Neural Engine", value: capabilities.supportsMetalAcceleration ? "Available" : "Not Available")
+                        }
+                        InfoRow2(label: "Engine", value: activeEngineLabel)
+                        InfoRow2(label: "Model", value: appState.whisperService.loadedModelName ?? "Not loaded")
+                        InfoRow2(label: "Storage", value: appState.modelManager.diskUsageDescription())
                     }
                     .font(.caption)
-                } else {
-                    Label("Check for Updates...", systemImage: "arrow.triangle.2.circlepath")
+                    .padding(4)
+                }
+                .frame(maxWidth: 340)
+
+                Divider()
+                    .frame(width: 200)
+
+                HStack(spacing: 16) {
+                    Link(destination: URL(string: "https://vocamac.com")!) {
+                        Label("Website", systemImage: "globe")
+                    }
+                    Link(destination: URL(string: "https://github.com/VocaHQ/vocamac")!) {
+                        Label("GitHub", systemImage: "chevron.left.forwardslash.chevron.right")
+                    }
+                    Link(destination: URL(string: "https://github.com/argmaxinc/WhisperKit")!) {
+                        Label("WhisperKit", systemImage: "waveform")
+                    }
+                }
+                .font(.caption)
+
+                Divider()
+                    .frame(width: 200)
+
+                Button {
+                    NotificationCenter.default.post(name: .showOnboarding, object: nil)
+                } label: {
+                    Label("Show Setup Wizard…", systemImage: "wand.and.stars")
                         .font(.caption)
                 }
-            }
-            .buttonStyle(.plain)
-            .foregroundStyle(.blue)
+                .buttonStyle(.plain)
+                .foregroundStyle(.blue)
+                .help("Re-run the first-launch setup wizard")
 
-            Text(updateStatusText)
-                .font(.caption2)
-                .foregroundStyle(.secondary)
-
-            Divider()
-                .frame(width: 200)
-
-            // Tech info
-            GroupBox {
-                VStack(alignment: .leading, spacing: 4) {
-                    if let capabilities = appState.systemCapabilities {
-                        InfoRow2(label: "Device", value: capabilities.processorName)
-                        InfoRow2(label: "Architecture", value: capabilities.isAppleSilicon ? "Apple Silicon (ARM64)" : "Intel (x86_64)")
-                        InfoRow2(label: "Neural Engine", value: capabilities.supportsMetalAcceleration ? "Available" : "Not Available")
-                    }
-                    InfoRow2(label: "Engine", value: "WhisperKit")
-                    InfoRow2(label: "Model", value: appState.whisperService.loadedModelName ?? "Not loaded")
-                    InfoRow2(label: "Storage", value: appState.modelManager.diskUsageDescription())
+                HStack(spacing: 0) {
+                    Text("Made with ❤️ by ")
+                        .font(.caption2)
+                        .foregroundStyle(.tertiary)
+                    Link("Jatin Kumar Malik", destination: URL(string: "https://x.com/intent/user?screen_name=jatinkrmalik")!)
+                        .font(.caption2)
                 }
-                .font(.caption)
-                .padding(4)
+                .padding(.top, 8)
             }
-            .frame(width: 300)
-
-            Divider()
-                .frame(width: 200)
-
-            // Links
-            HStack(spacing: 16) {
-                Link(destination: URL(string: "https://vocamac.com")!) {
-                    Label("Website", systemImage: "globe")
-                }
-                Link(destination: URL(string: "https://github.com/VocaHQ/vocamac")!) {
-                    Label("GitHub", systemImage: "chevron.left.forwardslash.chevron.right")
-                }
-                Link(destination: URL(string: "https://github.com/argmaxinc/WhisperKit")!) {
-                    Label("WhisperKit", systemImage: "waveform")
-                }
-            }
-            .font(.caption)
-
-            Divider()
-                .frame(width: 200)
-
-            Button(action: {
-                NotificationCenter.default.post(name: .showOnboarding, object: nil)
-            }) {
-                Label("Show Setup Wizard…", systemImage: "wand.and.stars")
-                    .font(.caption)
-            }
-            .buttonStyle(.plain)
-            .foregroundStyle(.blue)
-            .help("Re-run the first-launch setup wizard")
-
-            Spacer()
-
-            HStack(spacing: 0) {
-                Text("Made with ❤️ by ")
-                    .font(.caption2)
-                    .foregroundStyle(.tertiary)
-                Link("Jatin Kumar Malik", destination: URL(string: "https://x.com/intent/user?screen_name=jatinkrmalik")!)
-                    .font(.caption2)
-            }
-            .padding(.bottom, 8)
+            .frame(maxWidth: 420)
+            .frame(maxWidth: .infinity)
+            .padding(24)
         }
-        .frame(maxWidth: .infinity)
-        .padding()
         .sheet(isPresented: $showingUpdateSheet) {
             if let info = updateInfoForSheet {
                 UpdateDetailView(info: info, isPresented: $showingUpdateSheet)
                     .environmentObject(appState)
             }
         }
+    }
+
+    private var activeEngineLabel: String {
+        if let engine = appState.currentModel?.size.engine {
+            return engine.displayName
+        }
+        if let name = appState.whisperService.loadedModelName,
+           let size = appState.modelManager.modelSize(from: name) {
+            return size.engine.displayName
+        }
+        return "—"
     }
 
     private var appVersionDisplay: String {
@@ -1334,10 +1290,40 @@ struct AboutTab: View {
 
 struct DebugTab: View {
     @EnvironmentObject var appState: AppState
+    @StateObject private var processMonitor = ProcessMonitor()
     @State private var logEntryCount: Int = VocaLogger.logEntryCount
 
     var body: some View {
         Form {
+            if let capabilities = appState.systemCapabilities {
+                Section("System Information") {
+                    LabeledContent("CPU", value: capabilities.processorName)
+                    LabeledContent("RAM", value: "\(capabilities.physicalMemoryGB) GB")
+                    LabeledContent("Metal", value: capabilities.supportsMetalAcceleration ? "Yes" : "No")
+                }
+            }
+
+            Section("Resource Usage") {
+                LabeledContent("App CPU", value: String(format: "%.1f%%", processMonitor.cpuUsage))
+                LabeledContent(
+                    "App Memory (RSS)",
+                    value: processMonitor.memoryMB >= 1024
+                        ? String(format: "%.1f GB", processMonitor.memoryMB / 1024)
+                        : String(format: "%.0f MB", processMonitor.memoryMB)
+                )
+                LabeledContent(
+                    "Peak RSS (this session)",
+                    value: processMonitor.memoryPeakMB >= 1024
+                        ? String(format: "%.1f GB", processMonitor.memoryPeakMB / 1024)
+                        : String(format: "%.0f MB", processMonitor.memoryPeakMB)
+                )
+                LabeledContent("Threads", value: "\(processMonitor.threadCount)")
+
+                Text("Process-wide usage for VocaMac, refreshed every few seconds — not model-only VRAM/ANE accounting.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+
             // Permissions
             Section("Permissions") {
                 PermissionRow(

--- a/Sources/VocaMac/Views/SettingsView.swift
+++ b/Sources/VocaMac/Views/SettingsView.swift
@@ -2,71 +2,199 @@
 // VocaMac
 //
 // Settings window for VocaMac configuration.
-// Organized into tabs: General, Models, Audio, Debug, About.
+// Left sidebar topics with live search and a persistent dictation footer.
 
 import SwiftUI
+import AppKit
 
 extension Notification.Name {
     static let showOnboarding = Notification.Name("com.vocamac.showOnboarding")
 }
 
 struct SettingsView: View {
+    @EnvironmentObject var appState: AppState
+
+    @State private var selectedPage: SettingsPage? = .dictation
+    @State private var searchText = ""
+    @State private var pageBeforeSearch: SettingsPage = .dictation
+
+    private var matchCounts: [SettingsPage: Int] {
+        SettingsSearchIndex.matchCounts(query: searchText)
+    }
+
+    private var visiblePages: [SettingsPage] {
+        let trimmed = searchText.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return SettingsPage.allCases }
+        let counts = matchCounts
+        return SettingsPage.allCases.filter { counts[$0, default: 0] > 0 }
+    }
+
+    private var hasSearchQuery: Bool {
+        !searchText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+    }
+
     var body: some View {
-        TabView {
-            GeneralSettingsTab()
-                .tabItem {
-                    Label("General", systemImage: "gear")
+        NavigationSplitView {
+            VStack(spacing: 0) {
+                List(selection: $selectedPage) {
+                    ForEach(visiblePages) { page in
+                        Label(page.title, systemImage: page.systemImage)
+                            .badge(hasSearchQuery ? (matchCounts[page] ?? 0) : 0)
+                            .tag(page)
+                    }
+                }
+                .listStyle(.sidebar)
+
+                if hasSearchQuery && visiblePages.isEmpty {
+                    ContentUnavailableView.search(text: searchText)
+                        .frame(maxHeight: 160)
                 }
 
-            ModelSettingsTab()
-                .tabItem {
-                    Label("Models", systemImage: "brain")
+                Divider()
+                SettingsSidebarFooter()
+            }
+            .navigationSplitViewColumnWidth(min: 180, ideal: 200, max: 260)
+        } detail: {
+            Group {
+                switch selectedPage ?? .dictation {
+                case .dictation:
+                    DictationSettingsPage()
+                case .speechModel:
+                    SpeechModelSettingsPage()
+                case .audio:
+                    AudioSettingsTab()
+                case .performance:
+                    PerformanceSettingsTab()
+                case .application:
+                    ApplicationSettingsPage()
+                case .stats:
+                    StatsSettingsTab()
+                case .advanced:
+                    DebugTab()
+                case .about:
+                    AboutTab()
                 }
-
-            StatsSettingsTab()
-                .tabItem {
-                    Label("Stats", systemImage: "chart.xyaxis.line")
-                }
-
-            AudioSettingsTab()
-                .tabItem {
-                    Label("Audio", systemImage: "waveform")
-                }
-
-            PerformanceSettingsTab()
-                .tabItem {
-                    Label("Performance", systemImage: "bolt.circle")
-                }
-
-            DebugTab()
-                .tabItem {
-                    Label("Debug", systemImage: "ladybug")
-                }
-
-            AboutTab()
-                .tabItem {
-                    Label("About", systemImage: "info.circle")
-                }
+            }
+            .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
         }
-        .frame(minWidth: 560, minHeight: 520)
+        .searchable(text: $searchText, prompt: "Search settings")
+        .onChange(of: searchText) { _, newValue in
+            let trimmed = newValue.trimmingCharacters(in: .whitespacesAndNewlines)
+            if trimmed.isEmpty {
+                selectedPage = pageBeforeSearch
+                return
+            }
+            if let current = selectedPage, matchCounts[current, default: 0] == 0 {
+                selectedPage = SettingsSearchIndex.firstMatchingPage(query: trimmed)
+            } else if selectedPage == nil {
+                selectedPage = SettingsSearchIndex.firstMatchingPage(query: trimmed)
+            }
+        }
+        .onChange(of: selectedPage) { _, newValue in
+            if !hasSearchQuery, let newValue {
+                pageBeforeSearch = newValue
+            }
+        }
+        .frame(minWidth: 720, minHeight: 520)
     }
 }
 
-// MARK: - General Settings
+// MARK: - Sidebar Footer
 
-struct GeneralSettingsTab: View {
+struct SettingsSidebarFooter: View {
+    @EnvironmentObject var appState: AppState
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            HStack(spacing: 8) {
+                Circle()
+                    .fill(statusColor)
+                    .frame(width: 8, height: 8)
+                Text(statusLabel)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                Spacer()
+                if appState.isAutoPaused {
+                    Text("Paused")
+                        .font(.caption2)
+                        .foregroundStyle(.orange)
+                }
+            }
+
+            GeometryReader { geo in
+                ZStack(alignment: .leading) {
+                    Capsule()
+                        .fill(Color.secondary.opacity(0.15))
+                    Capsule()
+                        .fill(Color.accentColor)
+                        .frame(width: max(4, geo.size.width * CGFloat(min(max(appState.audioLevel, 0), 1))))
+                }
+            }
+            .frame(height: 4)
+
+            HStack(spacing: 8) {
+                Button {
+                    Task { @MainActor in
+                        if appState.isRecording || appState.appStatus == .recording {
+                            await appState.stopRecordingAndTranscribe()
+                        } else {
+                            await appState.startRecording()
+                        }
+                    }
+                } label: {
+                    Label(
+                        appState.isRecording ? "Stop Dictation" : "Test Dictation",
+                        systemImage: appState.isRecording ? "stop.fill" : "mic.fill"
+                    )
+                }
+                .controlSize(.small)
+                .disabled(appState.isAutoPaused && !appState.isRecording)
+
+                Spacer()
+
+                Button("Close") {
+                    NSApp.keyWindow?.close()
+                }
+                .controlSize(.small)
+                .keyboardShortcut(.cancelAction)
+            }
+        }
+        .padding(12)
+        .background(.bar)
+    }
+
+    private var statusLabel: String {
+        if appState.isAutoPaused { return "Auto-paused" }
+        switch appState.appStatus {
+        case .idle: return "Ready"
+        case .recording: return "Recording"
+        case .processing: return "Processing"
+        case .error: return appState.errorMessage ?? "Error"
+        }
+    }
+
+    private var statusColor: Color {
+        if appState.isAutoPaused { return .orange }
+        switch appState.appStatus {
+        case .idle: return .green
+        case .recording: return .red
+        case .processing: return .purple
+        case .error: return .orange
+        }
+    }
+}
+
+// MARK: - Dictation Settings
+
+struct DictationSettingsPage: View {
     @EnvironmentObject var appState: AppState
 
     var body: some View {
         Form {
-            // Activation Mode
             Section("Activation Mode") {
                 Picker("Mode", selection: $appState.activationMode) {
                     ForEach(ActivationMode.allCases) { mode in
-                        VStack(alignment: .leading) {
-                            Text(mode.displayName)
-                        }
-                        .tag(mode)
+                        Text(mode.displayName).tag(mode)
                     }
                 }
                 .pickerStyle(.radioGroup)
@@ -79,7 +207,6 @@ struct GeneralSettingsTab: View {
                     .foregroundStyle(.secondary)
             }
 
-            // Hotkey
             Section("Hotkey") {
                 HotKeySelectionControl(
                     pickerLabel: "Activation Key",
@@ -110,101 +237,6 @@ struct GeneralSettingsTab: View {
                 }
             }
 
-            // Language
-            Section("Transcription Language") {
-                Picker("Language", selection: $appState.selectedLanguage) {
-                    Text("Auto-detect").tag("auto")
-                    Divider()
-                    Group {
-                        Text("English").tag("en")
-                        Text("Spanish").tag("es")
-                        Text("French").tag("fr")
-                        Text("German").tag("de")
-                        Text("Italian").tag("it")
-                        Text("Portuguese").tag("pt")
-                        Text("Dutch").tag("nl")
-                    }
-                    Divider()
-                    Group {
-                        Text("Chinese").tag("zh")
-                        Text("Japanese").tag("ja")
-                        Text("Korean").tag("ko")
-                        Text("Hindi").tag("hi")
-                        Text("Arabic").tag("ar")
-                        Text("Russian").tag("ru")
-                        Text("Turkish").tag("tr")
-                        Text("Polish").tag("pl")
-                        Text("Swedish").tag("sv")
-                        Text("Ukrainian").tag("uk")
-                    }
-                }
-
-                Text("Auto-detect works well for most cases. Set a specific language for better accuracy.")
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
-
-                if let model = appState.currentModel?.size, model.bindsLanguageAtLoadTime {
-                    Text("\(model.displayName) applies the language when it loads, so changing it reloads the model.")
-                        .font(.caption)
-                        .foregroundStyle(.secondary)
-                }
-            }
-            .onChange(of: appState.selectedLanguage) {
-                Task { @MainActor in
-                    await appState.reloadModelForLanguageChangeIfNeeded()
-                }
-            }
-
-            // Translation
-            Section("Translation") {
-                Toggle("Enable translation", isOn: $appState.translationEnabled)
-
-                Text(appState.translationEnabled
-                    ? "Speech will be translated to the selected language (or English if Auto-detect)."
-                    : "Speech will be transcribed as-is in the spoken language. The language setting is used as a recognition hint only.")
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
-
-                if let engine = appState.currentModel?.size.engine, !engine.supportsTranslation {
-                    Text("Translation is only available with Whisper models. The active model (\(engine.displayName)) transcribes without translating.")
-                        .font(.caption)
-                        .foregroundStyle(.orange)
-                }
-            }
-
-            // Custom Vocabulary
-            Section("Custom Vocabulary") {
-                TextEditor(text: $appState.customVocabulary)
-                    .font(.body)
-                    .frame(minHeight: 90)
-                    .overlay(alignment: .topLeading) {
-                        if appState.customVocabulary.isEmpty {
-                            Text("kubectl, PostgreSQL, nginx, Grafana")
-                                .foregroundStyle(.tertiary)
-                                .padding(.top, 8)
-                                .padding(.leading, 5)
-                                .allowsHitTesting(false)
-                        }
-                    }
-
-                let count = WhisperService.vocabularyTerms(from: appState.customVocabulary).count
-                Text(count == 0
-                    ? "Add names, jargon, or proper nouns (one per line, or comma-separated) that get mis-transcribed. VocaMac hints these to the model so it spells them right."
-                    : "\(count) term\(count == 1 ? "" : "s"). Keep the list short, since the model can only use the first 50 to 100 words as a hint.")
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
-
-                Text("For best results, enter terms in the language you dictate and set a matching Transcription Language above. In Auto-detect, the terms can also nudge which language VocaMac picks.")
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
-
-                if let engine = appState.currentModel?.size.engine, !engine.supportsCustomVocabulary {
-                    Text("Custom vocabulary is only applied by Whisper models. The active model (\(engine.displayName)) ignores these terms.")
-                        .font(.caption)
-                        .foregroundStyle(.orange)
-                }
-            }
-
             Section("Output") {
                 Toggle("Trailing Space After Dictation", isOn: $appState.appendTrailingSpace)
 
@@ -218,7 +250,18 @@ struct GeneralSettingsTab: View {
                     .font(.caption)
                     .foregroundStyle(.secondary)
             }
+        }
+        .formStyle(.grouped)
+    }
+}
 
+// MARK: - Application Settings
+
+struct ApplicationSettingsPage: View {
+    @EnvironmentObject var appState: AppState
+
+    var body: some View {
+        Form {
             Section("Behavior") {
                 Toggle("Launch at Login", isOn: Binding(
                     get: { appState.launchAtLogin },
@@ -255,9 +298,16 @@ struct GeneralSettingsTab: View {
                 .pickerStyle(.radioGroup)
                 .disabled(appState.overlayStyle == .off)
             }
-
         }
         .formStyle(.grouped)
+    }
+}
+
+// MARK: - Speech Model Settings (catalog + language / translation / vocab)
+
+struct SpeechModelSettingsPage: View {
+    var body: some View {
+        ModelSettingsTab(showsLanguageHints: true)
     }
 }
 
@@ -464,6 +514,15 @@ struct AutoPauseAppPickerSheet: View {
 struct ModelSettingsTab: View {
     @EnvironmentObject var appState: AppState
     @StateObject private var processMonitor = ProcessMonitor()
+    @State private var languageSearch = ""
+
+    /// When true, show language / translation / vocabulary above the catalog.
+    var showsLanguageHints: Bool = false
+
+    init(showsLanguageHints: Bool = false) {
+        self.showsLanguageHints = showsLanguageHints
+        _processMonitor = StateObject(wrappedValue: ProcessMonitor())
+    }
 
     /// Catalog entries grouped by engine, preserving catalog order within
     /// each group. Engines with no available models are omitted.
@@ -472,6 +531,10 @@ struct ModelSettingsTab: View {
             let models = appState.availableModels.filter { $0.size.engine == engine }
             return models.isEmpty ? nil : (engine: engine, models: models)
         }
+    }
+
+    private var filteredLanguages: [TranscriptionLanguage] {
+        TranscriptionLanguage.filtered(search: languageSearch)
     }
 
     private func engineIconName(_ engine: TranscriptionEngine) -> String {
@@ -486,6 +549,10 @@ struct ModelSettingsTab: View {
     var body: some View {
         ScrollView {
             VStack(alignment: .leading, spacing: 16) {
+                if showsLanguageHints {
+                    languageAndHintsSection
+                }
+
                 // System info
                 if let capabilities = appState.systemCapabilities {
                     GroupBox {
@@ -649,6 +716,97 @@ struct ModelSettingsTab: View {
                 }
             }
             .padding()
+        }
+    }
+
+    private var languageAndHintsSection: some View {
+        GroupBox {
+            VStack(alignment: .leading, spacing: 12) {
+                Label("Language & Hints", systemImage: "globe")
+                    .font(.headline)
+
+                TextField("Search languages", text: $languageSearch)
+                    .textFieldStyle(.roundedBorder)
+
+                Picker("Language", selection: $appState.selectedLanguage) {
+                    ForEach(filteredLanguages) { language in
+                        Text(language.code == "auto"
+                             ? language.displayName
+                             : "\(language.displayName) (\(language.code))")
+                            .tag(language.code)
+                    }
+                }
+
+                if !filteredLanguages.contains(where: { $0.code == appState.selectedLanguage }),
+                   let current = TranscriptionLanguage.catalog.first(where: { $0.code == appState.selectedLanguage }) {
+                    Text("Current: \(current.displayName)")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+
+                Text("Auto-detect works well for most cases. Set a specific language for better accuracy.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+
+                if let model = appState.currentModel?.size, model.bindsLanguageAtLoadTime {
+                    Text("\(model.displayName) applies the language when it loads, so changing it reloads the model.")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+
+                Divider()
+
+                Toggle("Enable translation", isOn: $appState.translationEnabled)
+
+                Text(appState.translationEnabled
+                     ? "Speech will be translated to the selected language (or English if Auto-detect)."
+                     : "Speech will be transcribed as-is in the spoken language. The language setting is used as a recognition hint only.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+
+                if let engine = appState.currentModel?.size.engine, !engine.supportsTranslation {
+                    Text("Translation is only available with Whisper models. The active model (\(engine.displayName)) transcribes without translating.")
+                        .font(.caption)
+                        .foregroundStyle(.orange)
+                }
+
+                Divider()
+
+                Text("Custom Vocabulary")
+                    .font(.subheadline.weight(.semibold))
+
+                TextEditor(text: $appState.customVocabulary)
+                    .font(.body)
+                    .frame(minHeight: 90)
+                    .overlay(alignment: .topLeading) {
+                        if appState.customVocabulary.isEmpty {
+                            Text("kubectl, PostgreSQL, nginx, Grafana")
+                                .foregroundStyle(.tertiary)
+                                .padding(.top, 8)
+                                .padding(.leading, 5)
+                                .allowsHitTesting(false)
+                        }
+                    }
+
+                let count = WhisperService.vocabularyTerms(from: appState.customVocabulary).count
+                Text(count == 0
+                     ? "Add names, jargon, or proper nouns (one per line, or comma-separated) that get mis-transcribed."
+                     : "\(count) term\(count == 1 ? "" : "s"). Keep the list short — the model can only use the first 50 to 100 words as a hint.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+
+                if let engine = appState.currentModel?.size.engine, !engine.supportsCustomVocabulary {
+                    Text("Custom vocabulary is only applied by Whisper models. The active model (\(engine.displayName)) ignores these terms.")
+                        .font(.caption)
+                        .foregroundStyle(.orange)
+                }
+            }
+            .padding(4)
+        }
+        .onChange(of: appState.selectedLanguage) {
+            Task { @MainActor in
+                await appState.reloadModelForLanguageChangeIfNeeded()
+            }
         }
     }
 }

--- a/Sources/VocaMac/Views/SettingsView.swift
+++ b/Sources/VocaMac/Views/SettingsView.swift
@@ -479,6 +479,45 @@ struct PerformanceSettingsTab: View {
 
     var body: some View {
         Form {
+            Section("Model Status") {
+                HStack {
+                    Label(
+                        appState.whisperService.isModelLoaded ? "Model loaded" : "Model unloaded",
+                        systemImage: appState.whisperService.isModelLoaded ? "checkmark.circle.fill" : "memorychip"
+                    )
+                    .foregroundStyle(appState.whisperService.isModelLoaded ? .green : .orange)
+                    Spacer()
+                    if appState.whisperService.isModelLoaded {
+                        Text(loadedModelLabel)
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+                }
+
+                if appState.whisperService.isModelLoaded {
+                    if let estimate = estimatedModelRAMLabel {
+                        LabeledContent("Estimated model RAM", value: estimate)
+                    }
+                    LabeledContent(
+                        "App memory (RSS)",
+                        value: String(format: "%.0f MB", ProcessMonitor.currentResidentMemoryMB())
+                    )
+                } else if let message = appState.modelUnloadStatusMessage {
+                    Text(message)
+                        .font(.caption)
+                        .foregroundStyle(.orange)
+                    if let freed = appState.approximateMemoryFreedMB {
+                        Text(String(format: "Approx. %.0f MB process RSS dropped on unload.", freed))
+                            .font(.caption2)
+                            .foregroundStyle(.secondary)
+                    }
+                } else {
+                    Text("No speech model is currently resident.")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+            }
+
             Section("Auto-Pause for Apps") {
                 Toggle("Pause Dictation for Listed Apps", isOn: $appState.autoPauseEnabled)
 
@@ -524,9 +563,13 @@ struct PerformanceSettingsTab: View {
                 .opacity(appState.autoPauseEnabled ? 1 : 0.45)
 
                 if appState.isAutoPaused {
-                    Label("Dictation is currently paused by a listed app.", systemImage: "pause.circle.fill")
-                        .foregroundStyle(.orange)
-                        .font(.caption)
+                    Label(
+                        appState.autoPauseTriggerDisplayName.map { "Paused while \($0) is running." }
+                            ?? "Dictation is currently paused by a listed app.",
+                        systemImage: "pause.circle.fill"
+                    )
+                    .foregroundStyle(.orange)
+                    .font(.caption)
                 }
             }
 
@@ -559,6 +602,20 @@ struct PerformanceSettingsTab: View {
                 showingAppPicker = false
             }
         }
+    }
+
+    private var loadedModelLabel: String {
+        if let model = appState.currentModel {
+            return model.size.displayName
+        }
+        return appState.whisperService.loadedModelName ?? "Ready"
+    }
+
+    private var estimatedModelRAMLabel: String? {
+        let size = appState.currentModel?.size
+            ?? ModelSize(rawValue: appState.selectedModelSize)
+        guard let size else { return nil }
+        return String(format: "~%.1f GB", size.ramRequiredGB)
     }
 }
 

--- a/Sources/VocaMac/Views/SettingsView.swift
+++ b/Sources/VocaMac/Views/SettingsView.swift
@@ -36,22 +36,10 @@ struct SettingsView: View {
     var body: some View {
         NavigationSplitView {
             List(selection: $selectedPage) {
-                Section {
-                    ForEach(visiblePages) { page in
-                        Label(page.title, systemImage: page.systemImage)
-                            .badge(hasSearchQuery ? (matchCounts[page] ?? 0) : 0)
-                            .tag(page)
-                    }
-                } header: {
-                    HStack(spacing: 8) {
-                        BrandLogoView(size: 22)
-                        Text("VocaMac")
-                            .font(.headline)
-                            .foregroundStyle(.primary)
-                    }
-                    .padding(.vertical, 4)
-                    .accessibilityElement(children: .combine)
-                    .accessibilityLabel("VocaMac Settings")
+                ForEach(visiblePages) { page in
+                    Label(page.title, systemImage: page.systemImage)
+                        .badge(hasSearchQuery ? (matchCounts[page] ?? 0) : 0)
+                        .tag(page)
                 }
             }
             .listStyle(.sidebar)
@@ -60,10 +48,15 @@ struct SettingsView: View {
                     ContentUnavailableView.search(text: searchText)
                 }
             }
+            // System Settings–style: search lives at the top of the sidebar column
+            // (not the split-view toolbar), so collapsing the sidebar cannot shove it.
+            .safeAreaInset(edge: .top, spacing: 0) {
+                SettingsSidebarSearchField(text: $searchText)
+            }
             .safeAreaInset(edge: .bottom, spacing: 0) {
                 SettingsSidebarFooter()
             }
-            .navigationSplitViewColumnWidth(min: 180, ideal: 200, max: 260)
+            .navigationSplitViewColumnWidth(min: 200, ideal: 220, max: 280)
         } detail: {
             Group {
                 switch selectedPage ?? .dictation {
@@ -87,9 +80,6 @@ struct SettingsView: View {
             }
             .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
         }
-        // Keep search anchored in the sidebar so collapsing the column does not
-        // shove the field across the toolbar.
-        .searchable(text: $searchText, placement: .sidebar, prompt: "Search settings")
         .onChange(of: searchText) { _, newValue in
             let trimmed = newValue.trimmingCharacters(in: .whitespacesAndNewlines)
             if trimmed.isEmpty {
@@ -108,6 +98,47 @@ struct SettingsView: View {
             }
         }
         .frame(minWidth: 720, minHeight: 520)
+    }
+}
+
+// MARK: - Sidebar Search (System Settings–style)
+
+/// Pill search field pinned to the top of the settings sidebar.
+struct SettingsSidebarSearchField: View {
+    @Binding var text: String
+
+    var body: some View {
+        HStack(spacing: 6) {
+            Image(systemName: "magnifyingglass")
+                .font(.system(size: 13, weight: .medium))
+                .foregroundStyle(.secondary)
+
+            TextField("Search", text: $text)
+                .textFieldStyle(.plain)
+                .font(.body)
+
+            if !text.isEmpty {
+                Button {
+                    text = ""
+                } label: {
+                    Image(systemName: "xmark.circle.fill")
+                        .font(.system(size: 13))
+                        .foregroundStyle(.secondary)
+                }
+                .buttonStyle(.plain)
+                .accessibilityLabel("Clear search")
+            }
+        }
+        .padding(.horizontal, 8)
+        .padding(.vertical, 7)
+        .background(
+            RoundedRectangle(cornerRadius: 8, style: .continuous)
+                .fill(Color.primary.opacity(0.06))
+        )
+        .padding(.horizontal, 12)
+        .padding(.top, 8)
+        .padding(.bottom, 6)
+        .background(.bar)
     }
 }
 

--- a/Sources/VocaMac/Views/SettingsView.swift
+++ b/Sources/VocaMac/Views/SettingsView.swift
@@ -17,6 +17,8 @@ struct SettingsView: View {
     @State private var selectedPage: SettingsPage? = .dictation
     @State private var searchText = ""
     @State private var pageBeforeSearch: SettingsPage = .dictation
+    /// Drives a custom trailing toggle so the control stays pinned top-right.
+    @State private var columnVisibility: NavigationSplitViewVisibility = .all
 
     private var matchCounts: [SettingsPage: Int] {
         SettingsSearchIndex.matchCounts(query: searchText)
@@ -33,8 +35,12 @@ struct SettingsView: View {
         !searchText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
     }
 
+    private var isSidebarVisible: Bool {
+        columnVisibility != .detailOnly
+    }
+
     var body: some View {
-        NavigationSplitView {
+        NavigationSplitView(columnVisibility: $columnVisibility) {
             List(selection: $selectedPage) {
                 ForEach(visiblePages) { page in
                     Label(page.title, systemImage: page.systemImage)
@@ -80,6 +86,22 @@ struct SettingsView: View {
             }
             .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
         }
+        .toolbar {
+            // Always trailing (top-right). We remove the system sidebar toggle below
+            // so this control does not jump between leading and trailing.
+            ToolbarItem(placement: .primaryAction) {
+                Button {
+                    withAnimation(.snappy(duration: 0.2)) {
+                        columnVisibility = isSidebarVisible ? .detailOnly : .all
+                    }
+                } label: {
+                    Image(systemName: "sidebar.left")
+                }
+                .help(isSidebarVisible ? "Hide Sidebar" : "Show Sidebar")
+                .accessibilityLabel(isSidebarVisible ? "Hide Sidebar" : "Show Sidebar")
+            }
+        }
+        .modifier(RemoveSystemSidebarToggleModifier())
         .onChange(of: searchText) { _, newValue in
             let trimmed = newValue.trimmingCharacters(in: .whitespacesAndNewlines)
             if trimmed.isEmpty {
@@ -98,6 +120,18 @@ struct SettingsView: View {
             }
         }
         .frame(minWidth: 720, minHeight: 520)
+    }
+}
+
+/// Hides NavigationSplitView's built-in sidebar toggle (macOS 15+), which relocates
+/// when the column collapses. Older OS versions keep the system control as a fallback.
+private struct RemoveSystemSidebarToggleModifier: ViewModifier {
+    func body(content: Content) -> some View {
+        if #available(macOS 15.0, *) {
+            content.toolbar(removing: .sidebarToggle)
+        } else {
+            content
+        }
     }
 }
 

--- a/Sources/VocaMac/Views/SettingsView.swift
+++ b/Sources/VocaMac/Views/SettingsView.swift
@@ -17,8 +17,8 @@ struct SettingsView: View {
     @State private var selectedPage: SettingsPage? = .dictation
     @State private var searchText = ""
     @State private var pageBeforeSearch: SettingsPage = .dictation
-    /// Drives a custom trailing toggle so the control stays pinned top-right.
-    @State private var columnVisibility: NavigationSplitViewVisibility = .all
+    /// Manual sidebar visibility — avoids NavigationSplitView's relocating system toggles.
+    @State private var isSidebarVisible = true
 
     private var matchCounts: [SettingsPage: Int] {
         SettingsSearchIndex.matchCounts(query: searchText)
@@ -35,12 +35,58 @@ struct SettingsView: View {
         !searchText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
     }
 
-    private var isSidebarVisible: Bool {
-        columnVisibility != .detailOnly
+    var body: some View {
+        NavigationStack {
+            HStack(spacing: 0) {
+                if isSidebarVisible {
+                    settingsSidebar
+                        .frame(width: 220)
+                        .transition(.move(edge: .leading).combined(with: .opacity))
+
+                    Divider()
+                }
+
+                settingsDetail
+                    .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+            }
+            .toolbar {
+                ToolbarItem(placement: .primaryAction) {
+                    Button {
+                        withAnimation(.snappy(duration: 0.2)) {
+                            isSidebarVisible.toggle()
+                        }
+                    } label: {
+                        Image(systemName: "sidebar.left")
+                    }
+                    .help(isSidebarVisible ? "Hide Sidebar" : "Show Sidebar")
+                    .accessibilityLabel(isSidebarVisible ? "Hide Sidebar" : "Show Sidebar")
+                }
+            }
+            .onChange(of: searchText) { _, newValue in
+                let trimmed = newValue.trimmingCharacters(in: .whitespacesAndNewlines)
+                if trimmed.isEmpty {
+                    selectedPage = pageBeforeSearch
+                    return
+                }
+                if let current = selectedPage, matchCounts[current, default: 0] == 0 {
+                    selectedPage = SettingsSearchIndex.firstMatchingPage(query: trimmed)
+                } else if selectedPage == nil {
+                    selectedPage = SettingsSearchIndex.firstMatchingPage(query: trimmed)
+                }
+            }
+            .onChange(of: selectedPage) { _, newValue in
+                if !hasSearchQuery, let newValue {
+                    pageBeforeSearch = newValue
+                }
+            }
+        }
+        .frame(minWidth: 720, minHeight: 520)
     }
 
-    var body: some View {
-        NavigationSplitView(columnVisibility: $columnVisibility) {
+    private var settingsSidebar: some View {
+        VStack(spacing: 0) {
+            SettingsSidebarSearchField(text: $searchText)
+
             List(selection: $selectedPage) {
                 ForEach(visiblePages) { page in
                     Label(page.title, systemImage: page.systemImage)
@@ -49,88 +95,40 @@ struct SettingsView: View {
                 }
             }
             .listStyle(.sidebar)
+            .scrollContentBackground(.hidden)
             .overlay {
                 if hasSearchQuery && visiblePages.isEmpty {
                     ContentUnavailableView.search(text: searchText)
                 }
             }
-            // System Settings–style: search lives at the top of the sidebar column
-            // (not the split-view toolbar), so collapsing the sidebar cannot shove it.
-            .safeAreaInset(edge: .top, spacing: 0) {
-                SettingsSidebarSearchField(text: $searchText)
-            }
-            .safeAreaInset(edge: .bottom, spacing: 0) {
-                SettingsSidebarFooter()
-            }
-            .navigationSplitViewColumnWidth(min: 200, ideal: 220, max: 280)
-        } detail: {
-            Group {
-                switch selectedPage ?? .dictation {
-                case .dictation:
-                    DictationSettingsPage()
-                case .speechModel:
-                    SpeechModelSettingsPage()
-                case .audio:
-                    AudioSettingsTab()
-                case .performance:
-                    PerformanceSettingsTab()
-                case .application:
-                    ApplicationSettingsPage()
-                case .stats:
-                    StatsSettingsTab()
-                case .advanced:
-                    DebugTab()
-                case .about:
-                    AboutTab()
-                }
-            }
-            .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
-        }
-        .toolbar {
-            // Always trailing (top-right). We remove the system sidebar toggle below
-            // so this control does not jump between leading and trailing.
-            ToolbarItem(placement: .primaryAction) {
-                Button {
-                    withAnimation(.snappy(duration: 0.2)) {
-                        columnVisibility = isSidebarVisible ? .detailOnly : .all
-                    }
-                } label: {
-                    Image(systemName: "sidebar.left")
-                }
-                .help(isSidebarVisible ? "Hide Sidebar" : "Show Sidebar")
-                .accessibilityLabel(isSidebarVisible ? "Hide Sidebar" : "Show Sidebar")
-            }
-        }
-        .modifier(RemoveSystemSidebarToggleModifier())
-        .onChange(of: searchText) { _, newValue in
-            let trimmed = newValue.trimmingCharacters(in: .whitespacesAndNewlines)
-            if trimmed.isEmpty {
-                selectedPage = pageBeforeSearch
-                return
-            }
-            if let current = selectedPage, matchCounts[current, default: 0] == 0 {
-                selectedPage = SettingsSearchIndex.firstMatchingPage(query: trimmed)
-            } else if selectedPage == nil {
-                selectedPage = SettingsSearchIndex.firstMatchingPage(query: trimmed)
-            }
-        }
-        .onChange(of: selectedPage) { _, newValue in
-            if !hasSearchQuery, let newValue {
-                pageBeforeSearch = newValue
-            }
-        }
-        .frame(minWidth: 720, minHeight: 520)
-    }
-}
 
-/// Hides NavigationSplitView's built-in sidebar toggle (macOS 15+), which relocates
-/// when the column collapses. Older OS versions keep the system control as a fallback.
-private struct RemoveSystemSidebarToggleModifier: ViewModifier {
-    func body(content: Content) -> some View {
-        if #available(macOS 15.0, *) {
-            content.toolbar(removing: .sidebarToggle)
-        } else {
-            content
+            Divider()
+            SettingsSidebarFooter()
+        }
+        .background(.background)
+    }
+
+    @ViewBuilder
+    private var settingsDetail: some View {
+        Group {
+            switch selectedPage ?? .dictation {
+            case .dictation:
+                DictationSettingsPage()
+            case .speechModel:
+                SpeechModelSettingsPage()
+            case .audio:
+                AudioSettingsTab()
+            case .performance:
+                PerformanceSettingsTab()
+            case .application:
+                ApplicationSettingsPage()
+            case .stats:
+                StatsSettingsTab()
+            case .advanced:
+                DebugTab()
+            case .about:
+                AboutTab()
+            }
         }
     }
 }

--- a/Sources/VocaMac/Views/SettingsView.swift
+++ b/Sources/VocaMac/Views/SettingsView.swift
@@ -33,6 +33,11 @@ struct SettingsView: View {
                     Label("Audio", systemImage: "waveform")
                 }
 
+            PerformanceSettingsTab()
+                .tabItem {
+                    Label("Performance", systemImage: "bolt.circle")
+                }
+
             DebugTab()
                 .tabItem {
                     Label("Debug", systemImage: "ladybug")
@@ -200,6 +205,20 @@ struct GeneralSettingsTab: View {
                 }
             }
 
+            Section("Output") {
+                Toggle("Trailing Space After Dictation", isOn: $appState.appendTrailingSpace)
+
+                Text("Adds a space after each completed utterance so the next dictation session does not glue onto the previous sentence.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+
+                Toggle("Auto-Capitalize Sentences", isOn: $appState.autoCapitalize)
+
+                Text("Capitalizes the start of each utterance and letters that follow sentence-ending punctuation. Already-capitalized text is left alone.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+
             Section("Behavior") {
                 Toggle("Launch at Login", isOn: Binding(
                     get: { appState.launchAtLogin },
@@ -288,6 +307,154 @@ struct PermissionRow: View {
         case .granted: return .green
         case .notDetermined: return .orange
         case .denied: return .red
+        }
+    }
+}
+
+// MARK: - Performance Settings
+
+struct PerformanceSettingsTab: View {
+    @EnvironmentObject var appState: AppState
+    @State private var showingAppPicker = false
+
+    private let idleTimeoutChoices: [(label: String, seconds: Double)] = [
+        ("1 minute", 60),
+        ("2 minutes", 120),
+        ("5 minutes", 300),
+        ("10 minutes", 600),
+        ("15 minutes", 900),
+        ("30 minutes", 1800),
+    ]
+
+    var body: some View {
+        Form {
+            Section("Auto-Pause for Apps") {
+                Toggle("Pause Dictation for Listed Apps", isOn: $appState.autoPauseEnabled)
+
+                Text("While a listed app is running, VocaMac unloads the speech model and blocks dictation. The model reloads when none of the listed apps remain.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+
+                Group {
+                    if appState.autoPauseApps.isEmpty {
+                        Text("No apps in the list yet. Add one with “Choose Running App…”")
+                            .foregroundStyle(.secondary)
+                    } else {
+                        ForEach(appState.autoPauseApps) { app in
+                            HStack {
+                                VStack(alignment: .leading, spacing: 2) {
+                                    Text(app.displayName)
+                                    if let bundle = app.bundleIdentifier {
+                                        Text(bundle)
+                                            .font(.caption2)
+                                            .foregroundStyle(.tertiary)
+                                    } else if let process = app.processName {
+                                        Text(process)
+                                            .font(.caption2)
+                                            .foregroundStyle(.tertiary)
+                                    }
+                                }
+                                Spacer()
+                                Button(role: .destructive) {
+                                    appState.autoPauseApps.removeAll { $0.id == app.id }
+                                } label: {
+                                    Image(systemName: "minus.circle.fill")
+                                }
+                                .buttonStyle(.borderless)
+                            }
+                        }
+                    }
+
+                    Button("Choose Running App…") {
+                        showingAppPicker = true
+                    }
+                }
+                .disabled(!appState.autoPauseEnabled)
+                .opacity(appState.autoPauseEnabled ? 1 : 0.45)
+
+                if appState.isAutoPaused {
+                    Label("Dictation is currently paused by a listed app.", systemImage: "pause.circle.fill")
+                        .foregroundStyle(.orange)
+                        .font(.caption)
+                }
+            }
+
+            Section("Unload When Idle") {
+                Toggle("Unload Model When Idle", isOn: $appState.modelKeepAliveEnabled)
+
+                Text("After you stop dictating, unload the model to free RAM. The next dictation session reloads it (cold start may take a moment).")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+
+                Picker("Idle timeout", selection: $appState.modelKeepAliveIdleTimeoutSeconds) {
+                    ForEach(idleTimeoutChoices, id: \.seconds) { choice in
+                        Text(choice.label).tag(choice.seconds)
+                    }
+                }
+                .disabled(!appState.modelKeepAliveEnabled)
+                .opacity(appState.modelKeepAliveEnabled ? 1 : 0.45)
+            }
+        }
+        .formStyle(.grouped)
+        .sheet(isPresented: $showingAppPicker) {
+            AutoPauseAppPickerSheet { entry in
+                var apps = appState.autoPauseApps
+                if !apps.contains(where: { $0.id == entry.id }) {
+                    apps.append(entry)
+                    appState.autoPauseApps = apps
+                }
+                showingAppPicker = false
+            } onCancel: {
+                showingAppPicker = false
+            }
+        }
+    }
+}
+
+/// Picker sheet listing currently running apps for the auto-pause list.
+struct AutoPauseAppPickerSheet: View {
+    let onPick: (AutoPauseAppEntry) -> Void
+    let onCancel: () -> Void
+
+    @State private var apps: [RunningAppSnapshot] = []
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Text("Choose Running App")
+                .font(.headline)
+
+            Text("Select an app to pause dictation while it is running.")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+
+            List(apps, id: \.self) { snap in
+                Button {
+                    onPick(AutoPauseAppEntry.from(snapshot: snap))
+                } label: {
+                    VStack(alignment: .leading, spacing: 2) {
+                        Text(snap.displayName)
+                        if let bundle = snap.bundleIdentifier {
+                            Text(bundle)
+                                .font(.caption2)
+                                .foregroundStyle(.secondary)
+                        }
+                    }
+                }
+                .buttonStyle(.plain)
+            }
+            .frame(minHeight: 280)
+
+            HStack {
+                Spacer()
+                Button("Cancel", action: onCancel)
+                    .keyboardShortcut(.cancelAction)
+            }
+        }
+        .padding()
+        .frame(width: 420, height: 420)
+        .onAppear {
+            apps = AutoPauseMatching.workspaceRunningApps()
+                .sorted { $0.displayName.localizedCaseInsensitiveCompare($1.displayName) == .orderedAscending }
         }
     }
 }

--- a/Sources/VocaMac/Views/StatsSettingsTab.swift
+++ b/Sources/VocaMac/Views/StatsSettingsTab.swift
@@ -58,7 +58,7 @@ struct StatsSettingsTab: View {
                                 )
                             }
                             .controlSize(.small)
-                            .help("Copy a branded stats card image to the clipboard")
+                            .help("Copy a stats card image to the clipboard")
                         }
 
                         HStack(spacing: 0) {

--- a/Sources/VocaMac/Views/StatsSettingsTab.swift
+++ b/Sources/VocaMac/Views/StatsSettingsTab.swift
@@ -8,6 +8,7 @@ import SwiftUI
 struct StatsSettingsTab: View {
     @EnvironmentObject var appState: AppState
     @State private var showingResetConfirmation = false
+    @State private var shareCopied = false
 
     private static let durationFormatter: DateComponentsFormatter = {
         let formatter = DateComponentsFormatter()
@@ -38,9 +39,27 @@ struct StatsSettingsTab: View {
                 // Key Metrics
                 GroupBox {
                     VStack(alignment: .leading, spacing: 12) {
-                        Label("Lifetime Totals", systemImage: "chart.bar.fill")
-                            .font(.headline)
-                            .padding(.bottom, 4)
+                        HStack {
+                            Label("Lifetime Totals", systemImage: "chart.bar.fill")
+                                .font(.headline)
+                            Spacer()
+                            Button {
+                                let snapshot = StatsShareSnapshot.from(appState.statsManager.stats)
+                                if StatsShareExporter.copyImage(toClipboard: snapshot) {
+                                    shareCopied = true
+                                    DispatchQueue.main.asyncAfter(deadline: .now() + 2) {
+                                        shareCopied = false
+                                    }
+                                }
+                            } label: {
+                                Label(
+                                    shareCopied ? "Copied!" : "Share",
+                                    systemImage: shareCopied ? "checkmark" : "square.and.arrow.up"
+                                )
+                            }
+                            .controlSize(.small)
+                            .help("Copy a branded stats card image to the clipboard")
+                        }
 
                         HStack(spacing: 0) {
                             StatPill(

--- a/Sources/VocaMac/Views/StatsShareCard.swift
+++ b/Sources/VocaMac/Views/StatsShareCard.swift
@@ -51,7 +51,7 @@ struct StatsShareCard: View {
                     Text("VocaMac")
                         .font(.title2.weight(.bold))
                         .foregroundStyle(.white)
-                    Text("My dictation stats")
+                    Text("My usage")
                         .font(.subheadline)
                         .foregroundStyle(.white.opacity(0.55))
                 }

--- a/Sources/VocaMac/Views/StatsShareCard.swift
+++ b/Sources/VocaMac/Views/StatsShareCard.swift
@@ -1,0 +1,120 @@
+// StatsShareCard.swift
+// VocaMac
+//
+// Branded stats card rendered to an image and copied to the clipboard.
+
+import AppKit
+import SwiftUI
+
+/// Snapshot of stats used when rendering a shareable card.
+struct StatsShareSnapshot: Equatable {
+    var totalWords: Int
+    var totalTranscriptions: Int
+    var totalAudioDurationSeconds: Double
+    var averageWPM: Double
+    var currentStreak: Int
+    var bestStreak: Int
+
+    static func from(_ stats: UserStats) -> StatsShareSnapshot {
+        StatsShareSnapshot(
+            totalWords: stats.totalWords,
+            totalTranscriptions: stats.totalTranscriptions,
+            totalAudioDurationSeconds: stats.totalAudioDurationSeconds,
+            averageWPM: stats.averageWPM,
+            currentStreak: stats.currentStreak,
+            bestStreak: stats.bestStreak
+        )
+    }
+}
+
+struct StatsShareCard: View {
+    let snapshot: StatsShareSnapshot
+
+    private static let durationFormatter: DateComponentsFormatter = {
+        let formatter = DateComponentsFormatter()
+        formatter.allowedUnits = [.hour, .minute]
+        formatter.unitsStyle = .abbreviated
+        formatter.zeroFormattingBehavior = .dropAll
+        return formatter
+    }()
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 18) {
+            HStack(spacing: 12) {
+                BrandLogoView(size: 44)
+                VStack(alignment: .leading, spacing: 2) {
+                    Text("VocaMac")
+                        .font(.title2.weight(.bold))
+                    Text("My dictation stats")
+                        .font(.subheadline)
+                        .foregroundStyle(.secondary)
+                }
+                Spacer()
+            }
+
+            HStack(spacing: 12) {
+                shareMetric(title: "Words", value: "\(snapshot.totalWords)")
+                shareMetric(title: "Sessions", value: "\(snapshot.totalTranscriptions)")
+                shareMetric(
+                    title: "Time",
+                    value: Self.durationFormatter.string(from: snapshot.totalAudioDurationSeconds) ?? "0m"
+                )
+            }
+
+            HStack(spacing: 12) {
+                shareMetric(title: "Speed", value: String(format: "%.0f WPM", snapshot.averageWPM))
+                shareMetric(title: "Streak", value: "\(snapshot.currentStreak)d")
+                shareMetric(title: "Best", value: "\(snapshot.bestStreak)d")
+            }
+
+            Text("vocamac.com")
+                .font(.caption)
+                .foregroundStyle(.tertiary)
+                .frame(maxWidth: .infinity, alignment: .trailing)
+        }
+        .padding(24)
+        .frame(width: 520)
+        .background(
+            RoundedRectangle(cornerRadius: 20, style: .continuous)
+                .fill(Color(nsColor: .windowBackgroundColor))
+        )
+        .overlay {
+            RoundedRectangle(cornerRadius: 20, style: .continuous)
+                .stroke(Color.primary.opacity(0.08), lineWidth: 1)
+        }
+    }
+
+    private func shareMetric(title: String, value: String) -> some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Text(title.uppercased())
+                .font(.caption2.weight(.semibold))
+                .foregroundStyle(.secondary)
+            Text(value)
+                .font(.title3.weight(.bold))
+                .monospacedDigit()
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(12)
+        .background(Color.primary.opacity(0.05), in: RoundedRectangle(cornerRadius: 12, style: .continuous))
+    }
+}
+
+enum StatsShareExporter {
+    /// Renders the branded card and copies a PNG to the general pasteboard.
+    @MainActor
+    static func copyImage(toClipboard snapshot: StatsShareSnapshot) -> Bool {
+        let card = StatsShareCard(snapshot: snapshot)
+        let renderer = ImageRenderer(content: card)
+        renderer.scale = 2
+        guard let nsImage = renderer.nsImage,
+              let tiff = nsImage.tiffRepresentation,
+              let rep = NSBitmapImageRep(data: tiff),
+              let png = rep.representation(using: .png, properties: [:]) else {
+            return false
+        }
+
+        let pasteboard = NSPasteboard.general
+        pasteboard.clearContents()
+        return pasteboard.setData(png, forType: .png)
+    }
+}

--- a/Sources/VocaMac/Views/StatsShareCard.swift
+++ b/Sources/VocaMac/Views/StatsShareCard.swift
@@ -2,6 +2,7 @@
 // VocaMac
 //
 // Branded stats card rendered to an image and copied to the clipboard.
+// Forced dark appearance so clipboard shares match the in-app Stats look.
 
 import AppKit
 import SwiftUI
@@ -30,6 +31,10 @@ struct StatsShareSnapshot: Equatable {
 struct StatsShareCard: View {
     let snapshot: StatsShareSnapshot
 
+    private let cardBackground = Color(red: 0.11, green: 0.12, blue: 0.14)
+    private let chipBackground = Color.white.opacity(0.06)
+    private let brandGreen = Color(nsColor: BrandAssets.brandGreen)
+
     private static let durationFormatter: DateComponentsFormatter = {
         let formatter = DateComponentsFormatter()
         formatter.allowedUnits = [.hour, .minute]
@@ -39,63 +44,82 @@ struct StatsShareCard: View {
     }()
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 18) {
+        VStack(alignment: .leading, spacing: 20) {
             HStack(spacing: 12) {
-                BrandLogoView(size: 44)
-                VStack(alignment: .leading, spacing: 2) {
+                BrandLogoView(size: 48)
+                VStack(alignment: .leading, spacing: 3) {
                     Text("VocaMac")
                         .font(.title2.weight(.bold))
+                        .foregroundStyle(.white)
                     Text("My dictation stats")
                         .font(.subheadline)
-                        .foregroundStyle(.secondary)
+                        .foregroundStyle(.white.opacity(0.55))
                 }
                 Spacer()
             }
 
-            HStack(spacing: 12) {
-                shareMetric(title: "Words", value: "\(snapshot.totalWords)")
-                shareMetric(title: "Sessions", value: "\(snapshot.totalTranscriptions)")
+            HStack(spacing: 10) {
+                shareMetric(title: "Words", value: "\(snapshot.totalWords)", accent: .blue)
+                shareMetric(title: "Sessions", value: "\(snapshot.totalTranscriptions)", accent: .purple)
                 shareMetric(
                     title: "Time",
-                    value: Self.durationFormatter.string(from: snapshot.totalAudioDurationSeconds) ?? "0m"
+                    value: Self.durationFormatter.string(from: snapshot.totalAudioDurationSeconds) ?? "0m",
+                    accent: .orange
                 )
             }
 
-            HStack(spacing: 12) {
-                shareMetric(title: "Speed", value: String(format: "%.0f WPM", snapshot.averageWPM))
-                shareMetric(title: "Streak", value: "\(snapshot.currentStreak)d")
-                shareMetric(title: "Best", value: "\(snapshot.bestStreak)d")
+            HStack(spacing: 10) {
+                shareMetric(title: "Speed", value: String(format: "%.0f WPM", snapshot.averageWPM), accent: brandGreen)
+                shareMetric(title: "Streak", value: "\(snapshot.currentStreak)d", accent: .orange)
+                shareMetric(title: "Best", value: "\(snapshot.bestStreak)d", accent: Color(red: 1.0, green: 0.45, blue: 0.2))
             }
 
-            Text("vocamac.com")
-                .font(.caption)
-                .foregroundStyle(.tertiary)
-                .frame(maxWidth: .infinity, alignment: .trailing)
+            HStack {
+                Capsule()
+                    .fill(brandGreen.opacity(0.85))
+                    .frame(width: 28, height: 4)
+                Spacer()
+                Text("vocamac.com")
+                    .font(.caption.weight(.medium))
+                    .foregroundStyle(.white.opacity(0.4))
+            }
         }
-        .padding(24)
-        .frame(width: 520)
+        .padding(28)
+        .frame(width: 560)
         .background(
-            RoundedRectangle(cornerRadius: 20, style: .continuous)
-                .fill(Color(nsColor: .windowBackgroundColor))
+            RoundedRectangle(cornerRadius: 22, style: .continuous)
+                .fill(cardBackground)
         )
         .overlay {
-            RoundedRectangle(cornerRadius: 20, style: .continuous)
-                .stroke(Color.primary.opacity(0.08), lineWidth: 1)
+            RoundedRectangle(cornerRadius: 22, style: .continuous)
+                .stroke(
+                    LinearGradient(
+                        colors: [brandGreen.opacity(0.55), Color.white.opacity(0.08)],
+                        startPoint: .topLeading,
+                        endPoint: .bottomTrailing
+                    ),
+                    lineWidth: 1.2
+                )
         }
+        .environment(\.colorScheme, .dark)
     }
 
-    private func shareMetric(title: String, value: String) -> some View {
-        VStack(alignment: .leading, spacing: 4) {
+    private func shareMetric(title: String, value: String, accent: Color) -> some View {
+        VStack(alignment: .leading, spacing: 6) {
             Text(title.uppercased())
                 .font(.caption2.weight(.semibold))
-                .foregroundStyle(.secondary)
+                .foregroundStyle(.white.opacity(0.45))
             Text(value)
                 .font(.title3.weight(.bold))
                 .monospacedDigit()
+                .foregroundStyle(.white)
+            Capsule()
+                .fill(accent)
+                .frame(width: 18, height: 3)
         }
         .frame(maxWidth: .infinity, alignment: .leading)
-        .padding(12)
-        .background(Color.primary.opacity(0.05), in: RoundedRectangle(cornerRadius: 12, style: .continuous))
+        .padding(14)
+        .background(chipBackground, in: RoundedRectangle(cornerRadius: 14, style: .continuous))
     }
 }
 

--- a/Tests/VocaMacTests/AppStateRecordingTests.swift
+++ b/Tests/VocaMacTests/AppStateRecordingTests.swift
@@ -187,6 +187,48 @@ final class AppStateRecordingTests: XCTestCase {
                      "preserveClipboard should default to true")
     }
 
+    func testOutputPolishDefaults() {
+        let (appState, _) = AppState.makeTestState()
+        XCTAssertTrue(appState.appendTrailingSpace)
+        XCTAssertTrue(appState.autoCapitalize)
+        XCTAssertFalse(appState.autoPauseEnabled)
+        XCTAssertFalse(appState.modelKeepAliveEnabled)
+    }
+
+    func testStopRecordingInjectsPolishedText() async {
+        let (appState, mocks) = AppState.makeTestState()
+        mocks.audioEngine.stopRecordingResult = Array(repeating: Float(0.1), count: 16_000)
+        mocks.whisperService.mockTranscriptionResult = VocaTranscription(
+            text: "hello world. goodbye",
+            duration: 1.0,
+            detectedLanguage: "en",
+            audioLengthSeconds: 1.0,
+            modelUsed: .tiny
+        )
+        appState.appendTrailingSpace = true
+        appState.autoCapitalize = true
+        appState.isRecording = true
+        appState.appStatus = .recording
+
+        await appState.stopRecordingAndTranscribe()
+
+        XCTAssertEqual(mocks.textInjector.injectCallCount, 1)
+        XCTAssertEqual(mocks.textInjector.lastInjectedText, "Hello world. Goodbye ")
+        XCTAssertEqual(appState.appStatus, .idle)
+    }
+
+    func testStartRecordingBlockedWhenAutoPaused() async {
+        let (appState, mocks) = AppState.makeTestState()
+        appState.isAutoPaused = true
+
+        await appState.startRecording()
+
+        XCTAssertFalse(appState.isRecording)
+        XCTAssertEqual(mocks.audioEngine.lastSilenceThreshold, nil)
+        XCTAssertNotNil(appState.errorMessage)
+        XCTAssertTrue(appState.errorMessage?.contains("paused") == true)
+    }
+
     func testSoundEffectsEnabledDefault() {
         let (appState, _) = AppState.makeTestState()
 

--- a/Tests/VocaMacTests/AppStateRecordingTests.swift
+++ b/Tests/VocaMacTests/AppStateRecordingTests.swift
@@ -217,6 +217,28 @@ final class AppStateRecordingTests: XCTestCase {
         XCTAssertEqual(appState.appStatus, .idle)
     }
 
+    func testSettingsTestDictationDoesNotInject() async {
+        let (appState, mocks) = AppState.makeTestState()
+        mocks.audioEngine.stopRecordingResult = Array(repeating: Float(0.1), count: 16_000)
+        mocks.whisperService.mockTranscriptionResult = VocaTranscription(
+            text: "settings only",
+            duration: 1.0,
+            detectedLanguage: "en",
+            audioLengthSeconds: 1.0,
+            modelUsed: .tiny
+        )
+        appState.appendTrailingSpace = false
+        appState.autoCapitalize = true
+        appState.isRecording = true
+        appState.appStatus = .recording
+
+        await appState.stopRecordingAndTranscribe(injectResult: false)
+
+        XCTAssertEqual(mocks.textInjector.injectCallCount, 0)
+        XCTAssertEqual(appState.settingsTestResultText, "Settings only")
+        XCTAssertEqual(appState.appStatus, .idle)
+    }
+
     func testStartRecordingBlockedWhenAutoPaused() async {
         let (appState, mocks) = AppState.makeTestState()
         appState.isAutoPaused = true

--- a/Tests/VocaMacTests/AutoPauseMonitorTests.swift
+++ b/Tests/VocaMacTests/AutoPauseMonitorTests.swift
@@ -1,0 +1,150 @@
+// AutoPauseMonitorTests.swift
+// VocaMac Tests
+
+import XCTest
+@testable import VocaMac
+
+@MainActor
+final class AutoPauseMonitorTests: XCTestCase {
+
+    func testNormalizeProcessName() {
+        XCTAssertEqual(AutoPauseMatching.normalizeProcessName("  Foo.exe "), "foo")
+        XCTAssertEqual(AutoPauseMatching.normalizeProcessName("/usr/bin/Game"), "game")
+        XCTAssertEqual(AutoPauseMatching.normalizeProcessName(""), "")
+    }
+
+    func testEmptyConfiguredListNeverMatches() {
+        let running = [
+            RunningAppSnapshot(displayName: "Xcode", bundleIdentifier: "com.apple.dt.Xcode", processName: "Xcode")
+        ]
+        XCTAssertFalse(
+            AutoPauseMatching.anyConfiguredAppRunning(configured: [], running: running)
+        )
+    }
+
+    func testMatchByBundleIdentifier() {
+        let configured = [
+            AutoPauseAppEntry(
+                id: "com.valvesoftware.steam",
+                displayName: "Steam",
+                bundleIdentifier: "com.valvesoftware.steam",
+                processName: "steam_osx"
+            )
+        ]
+        let running = [
+            RunningAppSnapshot(
+                displayName: "Steam",
+                bundleIdentifier: "com.valvesoftware.steam",
+                processName: "steam_osx"
+            )
+        ]
+        XCTAssertTrue(AutoPauseMatching.anyConfiguredAppRunning(configured: configured, running: running))
+    }
+
+    func testMatchByProcessName() {
+        let configured = [
+            AutoPauseAppEntry(
+                id: "demo_game",
+                displayName: "demo_game",
+                bundleIdentifier: nil,
+                processName: "demo_game"
+            )
+        ]
+        let running = [
+            RunningAppSnapshot(displayName: "demo_game", bundleIdentifier: nil, processName: "demo_game")
+        ]
+        XCTAssertTrue(AutoPauseMatching.anyConfiguredAppRunning(configured: configured, running: running))
+    }
+
+    func testNoMatchWhenDifferentApps() {
+        let configured = [
+            AutoPauseAppEntry(id: "com.a", displayName: "A", bundleIdentifier: "com.a", processName: "A")
+        ]
+        let running = [
+            RunningAppSnapshot(displayName: "B", bundleIdentifier: "com.b", processName: "B")
+        ]
+        XCTAssertFalse(AutoPauseMatching.anyConfiguredAppRunning(configured: configured, running: running))
+    }
+
+    func testMonitorTransitionCallbacks() {
+        var paused = false
+        var pauseCount = 0
+        var resumeCount = 0
+        var snapshot: [RunningAppSnapshot] = []
+
+        let entry = AutoPauseAppEntry(
+            id: "com.test.game",
+            displayName: "Game",
+            bundleIdentifier: "com.test.game",
+            processName: "Game"
+        )
+
+        let monitor = AutoPauseMonitor(
+            getConfig: { (true, [entry], 5) },
+            processSnapshot: { snapshot },
+            onPause: {
+                paused = true
+                pauseCount += 1
+            },
+            onResume: {
+                paused = false
+                resumeCount += 1
+            }
+        )
+
+        XCTAssertFalse(monitor.checkOnce())
+        XCTAssertFalse(monitor.isPaused)
+
+        snapshot = [
+            RunningAppSnapshot(displayName: "Game", bundleIdentifier: "com.test.game", processName: "Game")
+        ]
+        XCTAssertTrue(monitor.checkOnce())
+        XCTAssertTrue(monitor.isPaused)
+        XCTAssertEqual(pauseCount, 1)
+
+        // Second poll while still matching must not re-fire onPause
+        XCTAssertTrue(monitor.checkOnce())
+        XCTAssertEqual(pauseCount, 1)
+
+        snapshot = []
+        XCTAssertFalse(monitor.checkOnce())
+        XCTAssertFalse(monitor.isPaused)
+        XCTAssertEqual(resumeCount, 1)
+        XCTAssertFalse(paused)
+    }
+
+    func testDisabledClearsPause() {
+        var resumeCount = 0
+        var enabled = true
+        let entry = AutoPauseAppEntry(
+            id: "com.test.game",
+            displayName: "Game",
+            bundleIdentifier: "com.test.game",
+            processName: "Game"
+        )
+        let snapshot = [
+            RunningAppSnapshot(displayName: "Game", bundleIdentifier: "com.test.game", processName: "Game")
+        ]
+
+        let monitor = AutoPauseMonitor(
+            getConfig: { (enabled, [entry], 5) },
+            processSnapshot: { snapshot },
+            onPause: {},
+            onResume: { resumeCount += 1 }
+        )
+
+        XCTAssertTrue(monitor.checkOnce())
+        XCTAssertTrue(monitor.isPaused)
+
+        enabled = false
+        XCTAssertFalse(monitor.checkOnce())
+        XCTAssertFalse(monitor.isPaused)
+        XCTAssertEqual(resumeCount, 1)
+    }
+
+    func testClampPollInterval() {
+        XCTAssertEqual(AutoPauseMonitor.clampPollInterval(0.5), 1)
+        XCTAssertEqual(AutoPauseMonitor.clampPollInterval(5), 5)
+        XCTAssertEqual(AutoPauseMonitor.clampPollInterval(120), 60)
+    }
+}

--- a/Tests/VocaMacTests/CursorOverlayTests.swift
+++ b/Tests/VocaMacTests/CursorOverlayTests.swift
@@ -126,10 +126,13 @@ final class OverlayWaveformMetricsTests: XCTestCase {
         let quiet = OverlayWaveformMetrics.heights(for: 0.1)
         let loud = OverlayWaveformMetrics.heights(for: 1.0)
         let overdriven = OverlayWaveformMetrics.heights(for: 4.0)
+        let whisper = OverlayWaveformMetrics.heights(for: 0.05)
 
         XCTAssertGreaterThan(loud.max() ?? 0, quiet.max() ?? 0)
         XCTAssertEqual(overdriven, loud)
         XCTAssertTrue(loud.allSatisfy { $0 <= 18 })
+        // Quiet speech should still lift bars well above the floor after gain.
+        XCTAssertGreaterThan(whisper.max() ?? 0, 5)
     }
 
     func testWaveformMovesBetweenAudioUpdates() {

--- a/Tests/VocaMacTests/CursorOverlayTests.swift
+++ b/Tests/VocaMacTests/CursorOverlayTests.swift
@@ -40,13 +40,13 @@ final class OverlaySettingsTests: XCTestCase {
 final class OverlayLayoutTests: XCTestCase {
 
     func testMinimalOverlayUsesCompactStableDimensions() {
-        XCTAssertEqual(OverlayLayout.size(for: .minimal), CGSize(width: 128, height: 44))
+        XCTAssertEqual(OverlayLayout.size(for: .minimal), CGSize(width: 108, height: 44))
     }
 
     func testLiveOverlayIsShorterThanTheOriginalPanel() {
         let size = OverlayLayout.size(for: .live)
 
-        XCTAssertEqual(size, CGSize(width: 272, height: 72))
+        XCTAssertEqual(size, CGSize(width: 240, height: 72))
         XCTAssertLessThan(size.width, 360)
     }
 }
@@ -56,7 +56,7 @@ final class OverlayLayoutTests: XCTestCase {
 final class OverlayPlacementTests: XCTestCase {
 
     private let visibleFrame = CGRect(x: 0, y: 0, width: 1_000, height: 700)
-    private let panelSize = CGSize(width: 128, height: 44)
+    private let panelSize = CGSize(width: 108, height: 44)
 
     func testPointOutsideScreenIsClampedBackIntoVisibleFrame() {
         let origin = OverlayPlacement.clampedOrigin(
@@ -65,7 +65,7 @@ final class OverlayPlacementTests: XCTestCase {
             visibleFrames: [visibleFrame]
         )
 
-        XCTAssertEqual(origin.x, 872)
+        XCTAssertEqual(origin.x, 892)
         XCTAssertEqual(origin.y, 200)
     }
 

--- a/Tests/VocaMacTests/CursorOverlayTests.swift
+++ b/Tests/VocaMacTests/CursorOverlayTests.swift
@@ -40,14 +40,19 @@ final class OverlaySettingsTests: XCTestCase {
 final class OverlayLayoutTests: XCTestCase {
 
     func testMinimalOverlayUsesCompactStableDimensions() {
-        XCTAssertEqual(OverlayLayout.size(for: .minimal), CGSize(width: 108, height: 44))
+        XCTAssertEqual(OverlayLayout.contentSize(for: .minimal), CGSize(width: 108, height: 44))
+        let size = OverlayLayout.size(for: .minimal)
+        XCTAssertEqual(size.width, 108 + OverlayLayout.glowBleed * 2)
+        XCTAssertEqual(size.height, 44 + OverlayLayout.glowBleed * 2)
     }
 
     func testLiveOverlayIsShorterThanTheOriginalPanel() {
+        let content = OverlayLayout.contentSize(for: .live)
         let size = OverlayLayout.size(for: .live)
 
-        XCTAssertEqual(size, CGSize(width: 240, height: 72))
-        XCTAssertLessThan(size.width, 360)
+        XCTAssertEqual(content, CGSize(width: 240, height: 72))
+        XCTAssertEqual(size.width, 240 + OverlayLayout.glowBleed * 2)
+        XCTAssertLessThan(content.width, 360)
     }
 }
 
@@ -56,7 +61,7 @@ final class OverlayLayoutTests: XCTestCase {
 final class OverlayPlacementTests: XCTestCase {
 
     private let visibleFrame = CGRect(x: 0, y: 0, width: 1_000, height: 700)
-    private let panelSize = CGSize(width: 108, height: 44)
+    private let panelSize = OverlayLayout.size(for: .minimal)
 
     func testPointOutsideScreenIsClampedBackIntoVisibleFrame() {
         let origin = OverlayPlacement.clampedOrigin(
@@ -65,7 +70,7 @@ final class OverlayPlacementTests: XCTestCase {
             visibleFrames: [visibleFrame]
         )
 
-        XCTAssertEqual(origin.x, 892)
+        XCTAssertEqual(origin.x, 1000 - OverlayLayout.size(for: .minimal).width)
         XCTAssertEqual(origin.y, 200)
     }
 

--- a/Tests/VocaMacTests/DictationOutputFormatterTests.swift
+++ b/Tests/VocaMacTests/DictationOutputFormatterTests.swift
@@ -1,0 +1,124 @@
+// DictationOutputFormatterTests.swift
+// VocaMac Tests
+//
+// Edge-case coverage for trailing space and sentence capitalization polish.
+
+import XCTest
+@testable import VocaMac
+
+final class DictationOutputFormatterTests: XCTestCase {
+
+    // MARK: - Capitalize
+
+    func testCapitalizeEmptyString() {
+        XCTAssertEqual(DictationOutputFormatter.capitalizeSentences(""), "")
+    }
+
+    func testCapitalizeFirstLetter() {
+        XCTAssertEqual(
+            DictationOutputFormatter.capitalizeSentences("hello world"),
+            "Hello world"
+        )
+    }
+
+    func testCapitalizeAfterSentencePunctuation() {
+        XCTAssertEqual(
+            DictationOutputFormatter.capitalizeSentences("hello world. goodbye world"),
+            "Hello world. Goodbye world"
+        )
+        XCTAssertEqual(
+            DictationOutputFormatter.capitalizeSentences("what? really! yes. ok"),
+            "What? Really! Yes. Ok"
+        )
+    }
+
+    func testCapitalizeIsIdempotent() {
+        let already = "Hello world. Goodbye"
+        XCTAssertEqual(DictationOutputFormatter.capitalizeSentences(already), already)
+    }
+
+    func testCapitalizePreservesURLsAndDecimals() {
+        XCTAssertEqual(
+            DictationOutputFormatter.capitalizeSentences("visit example.com for info"),
+            "Visit example.com for info"
+        )
+        XCTAssertEqual(
+            DictationOutputFormatter.capitalizeSentences("the value is 3.14 exactly"),
+            "The value is 3.14 exactly"
+        )
+    }
+
+    func testCapitalizeAfterNewlineWhitespace() {
+        XCTAssertEqual(
+            DictationOutputFormatter.capitalizeSentences("first line.\nsecond line"),
+            "First line.\nSecond line"
+        )
+    }
+
+    // MARK: - Trailing space
+
+    func testAppendTrailingSpaceEmpty() {
+        XCTAssertEqual(DictationOutputFormatter.appendTrailingSpace(""), "")
+    }
+
+    func testAppendTrailingSpaceAddsSpace() {
+        XCTAssertEqual(DictationOutputFormatter.appendTrailingSpace("Hello."), "Hello. ")
+    }
+
+    func testAppendTrailingSpaceSkipsExistingWhitespace() {
+        XCTAssertEqual(DictationOutputFormatter.appendTrailingSpace("Hello. "), "Hello. ")
+        XCTAssertEqual(DictationOutputFormatter.appendTrailingSpace("Hello.\t"), "Hello.\t")
+    }
+
+    func testAppendTrailingSpaceSkipsTrailingNewline() {
+        XCTAssertEqual(DictationOutputFormatter.appendTrailingSpace("Hello.\n"), "Hello.\n")
+        XCTAssertEqual(DictationOutputFormatter.appendTrailingSpace("para\n\n"), "para\n\n")
+    }
+
+    // MARK: - Apply
+
+    func testApplyBothFlags() {
+        XCTAssertEqual(
+            DictationOutputFormatter.apply(
+                "hello world. goodbye",
+                autoCapitalize: true,
+                appendTrailingSpace: true
+            ),
+            "Hello world. Goodbye "
+        )
+    }
+
+    func testApplyFlagsOffIsIdentity() {
+        let text = "hello world"
+        XCTAssertEqual(
+            DictationOutputFormatter.apply(
+                text,
+                autoCapitalize: false,
+                appendTrailingSpace: false
+            ),
+            text
+        )
+    }
+
+    func testApplyCapitalizeOnly() {
+        XCTAssertEqual(
+            DictationOutputFormatter.apply(
+                "hello. there",
+                autoCapitalize: true,
+                appendTrailingSpace: false
+            ),
+            "Hello. There"
+        )
+    }
+
+    func testApplyTrailingSpaceOnly() {
+        XCTAssertEqual(
+            DictationOutputFormatter.apply(
+                "hello",
+                autoCapitalize: false,
+                appendTrailingSpace: true
+            ),
+            "hello "
+        )
+    }
+}

--- a/Tests/VocaMacTests/Mocks/MockServices.swift
+++ b/Tests/VocaMacTests/Mocks/MockServices.swift
@@ -222,7 +222,6 @@ final class MockCursorOverlay: CursorOverlayManaging {
     var lastAudioLevel: Float?
     var lastStyle: OverlayStyle?
     var lastPosition: OverlayPosition?
-    var cancelHandler: (() -> Void)?
 
     func show(style: OverlayStyle, position: OverlayPosition) {
         showCallCount += 1
@@ -240,10 +239,6 @@ final class MockCursorOverlay: CursorOverlayManaging {
 
     func updateAudioLevel(_ level: Float) {
         lastAudioLevel = level
-    }
-
-    func setCancelHandler(_ handler: @escaping () -> Void) {
-        cancelHandler = handler
     }
 }
 

--- a/Tests/VocaMacTests/Mocks/MockServices.swift
+++ b/Tests/VocaMacTests/Mocks/MockServices.swift
@@ -433,6 +433,14 @@ final class MockWhisperService: SpeechTranscribing {
         loadedModelName = name ?? "mock-model"
         isModelLoaded = true
     }
+
+    var unloadCallCount = 0
+
+    func unloadModel() async {
+        unloadCallCount += 1
+        loadedModelName = nil
+        isModelLoaded = false
+    }
 }
 
 // MARK: - MockTextInjector

--- a/Tests/VocaMacTests/ModelKeepAliveTests.swift
+++ b/Tests/VocaMacTests/ModelKeepAliveTests.swift
@@ -1,0 +1,89 @@
+// ModelKeepAliveTests.swift
+// VocaMac Tests
+
+import XCTest
+@testable import VocaMac
+
+@MainActor
+final class ModelKeepAliveTests: XCTestCase {
+
+    func testClampIdleTimeout() {
+        XCTAssertEqual(ModelKeepAlive.clampIdleTimeout(10), 60)
+        XCTAssertEqual(ModelKeepAlive.clampIdleTimeout(300), 300)
+        XCTAssertEqual(ModelKeepAlive.clampIdleTimeout(99999), 3600)
+        XCTAssertEqual(ModelKeepAlive.clampIdleTimeout(.nan), 300)
+    }
+
+    func testBumpArmsAndFireUnloadsWhenSafe() {
+        var unloadCount = 0
+        var enabled = true
+        var safe = true
+
+        let keepAlive = ModelKeepAlive(
+            getConfig: { (enabled, 120) },
+            onIdleUnload: { unloadCount += 1 },
+            isSafeToUnload: { safe },
+            useTimer: false
+        )
+        keepAlive.start()
+        keepAlive.bump()
+        XCTAssertTrue(keepAlive.isArmed)
+
+        XCTAssertTrue(keepAlive.fireIfDue())
+        XCTAssertEqual(unloadCount, 1)
+        XCTAssertFalse(keepAlive.isArmed)
+    }
+
+    func testFireSkippedWhenUnsafe() {
+        var unloadCount = 0
+        let keepAlive = ModelKeepAlive(
+            getConfig: { (true, 120) },
+            onIdleUnload: { unloadCount += 1 },
+            isSafeToUnload: { false },
+            useTimer: false
+        )
+        keepAlive.start()
+        keepAlive.bump()
+        XCTAssertFalse(keepAlive.fireIfDue())
+        XCTAssertEqual(unloadCount, 0)
+        XCTAssertFalse(keepAlive.isArmed)
+    }
+
+    func testDisabledCancelsArm() {
+        var enabled = true
+        let keepAlive = ModelKeepAlive(
+            getConfig: { (enabled, 120) },
+            useTimer: false
+        )
+        keepAlive.start()
+        keepAlive.bump()
+        XCTAssertTrue(keepAlive.isArmed)
+
+        enabled = false
+        keepAlive.bump()
+        XCTAssertFalse(keepAlive.isArmed)
+        XCTAssertFalse(keepAlive.fireIfDue())
+    }
+
+    func testCancelDisarms() {
+        let keepAlive = ModelKeepAlive(
+            getConfig: { (true, 120) },
+            useTimer: false
+        )
+        keepAlive.start()
+        keepAlive.bump()
+        keepAlive.cancel()
+        XCTAssertFalse(keepAlive.isArmed)
+        XCTAssertFalse(keepAlive.fireIfDue())
+    }
+
+    func testFireRequiresStart() {
+        let keepAlive = ModelKeepAlive(
+            getConfig: { (true, 120) },
+            useTimer: false
+        )
+        keepAlive.bump()
+        XCTAssertFalse(keepAlive.isArmed)
+        XCTAssertFalse(keepAlive.fireIfDue())
+    }
+}

--- a/Tests/VocaMacTests/SettingsSearchIndexTests.swift
+++ b/Tests/VocaMacTests/SettingsSearchIndexTests.swift
@@ -41,4 +41,10 @@ final class SettingsSearchIndexTests: XCTestCase {
         XCTAssertGreaterThan(counts[.performance] ?? 0, 0)
         XCTAssertNil(counts[.about])
     }
+
+    func testResourceQueryHitsAdvanced() {
+        let matches = SettingsSearchIndex.matches(query: "resource")
+        XCTAssertTrue(matches.contains { $0.page == .advanced })
+        XCTAssertEqual(SettingsSearchIndex.firstMatchingPage(query: "resource"), .advanced)
+    }
 }

--- a/Tests/VocaMacTests/SettingsSearchIndexTests.swift
+++ b/Tests/VocaMacTests/SettingsSearchIndexTests.swift
@@ -1,0 +1,44 @@
+// SettingsSearchIndexTests.swift
+// VocaMac Tests
+
+import XCTest
+@testable import VocaMac
+
+final class SettingsSearchIndexTests: XCTestCase {
+
+    func testEmptyQueryReturnsAllEntries() {
+        let matches = SettingsSearchIndex.matches(query: "")
+        XCTAssertEqual(matches.count, SettingsSearchIndex.entries.count)
+        XCTAssertTrue(SettingsSearchIndex.matchCounts(query: "   ").isEmpty)
+        XCTAssertNil(SettingsSearchIndex.firstMatchingPage(query: ""))
+    }
+
+    func testPauseQueryHitsPerformance() {
+        let matches = SettingsSearchIndex.matches(query: "pause")
+        XCTAssertFalse(matches.isEmpty)
+        XCTAssertTrue(matches.contains { $0.page == .performance })
+        XCTAssertEqual(SettingsSearchIndex.firstMatchingPage(query: "pause"), .performance)
+    }
+
+    func testIdleQueryHitsKeepAlive() {
+        let matches = SettingsSearchIndex.matches(query: "idle")
+        XCTAssertTrue(matches.contains { $0.id == "idle-unload" })
+    }
+
+    func testTrailingQueryHitsDictation() {
+        let matches = SettingsSearchIndex.matches(query: "trailing")
+        XCTAssertTrue(matches.contains { $0.page == .dictation })
+        XCTAssertEqual(SettingsSearchIndex.firstMatchingPage(query: "trailing"), .dictation)
+    }
+
+    func testUnknownQueryIsEmpty() {
+        XCTAssertTrue(SettingsSearchIndex.matches(query: "zzznomatch999").isEmpty)
+        XCTAssertNil(SettingsSearchIndex.firstMatchingPage(query: "zzznomatch999"))
+    }
+
+    func testMatchCountsBadgePerformance() {
+        let counts = SettingsSearchIndex.matchCounts(query: "unload")
+        XCTAssertGreaterThan(counts[.performance] ?? 0, 0)
+        XCTAssertNil(counts[.about])
+    }
+}

--- a/Tests/VocaMacTests/StatsShareCardTests.swift
+++ b/Tests/VocaMacTests/StatsShareCardTests.swift
@@ -1,0 +1,25 @@
+// StatsShareCardTests.swift
+// VocaMac Tests
+
+import XCTest
+@testable import VocaMac
+
+final class StatsShareCardTests: XCTestCase {
+
+    func testSnapshotFromUserStats() {
+        var stats = UserStats()
+        stats.totalWords = 1200
+        stats.totalTranscriptions = 40
+        stats.totalAudioDurationSeconds = 3600
+        stats.averageWPM = 95
+        stats.currentStreak = 3
+        stats.bestStreak = 12
+
+        let snapshot = StatsShareSnapshot.from(stats)
+        XCTAssertEqual(snapshot.totalWords, 1200)
+        XCTAssertEqual(snapshot.totalTranscriptions, 40)
+        XCTAssertEqual(snapshot.averageWPM, 95)
+        XCTAssertEqual(snapshot.currentStreak, 3)
+        XCTAssertEqual(snapshot.bestStreak, 12)
+    }
+}

--- a/Tests/VocaMacTests/StatsShareCardTests.swift
+++ b/Tests/VocaMacTests/StatsShareCardTests.swift
@@ -10,15 +10,14 @@ final class StatsShareCardTests: XCTestCase {
         var stats = UserStats()
         stats.totalWords = 1200
         stats.totalTranscriptions = 40
-        stats.totalAudioDurationSeconds = 3600
-        stats.averageWPM = 95
+        stats.totalAudioDurationSeconds = 600 // 20 WPM from 1200 words / 10 minutes
         stats.currentStreak = 3
         stats.bestStreak = 12
 
         let snapshot = StatsShareSnapshot.from(stats)
         XCTAssertEqual(snapshot.totalWords, 1200)
         XCTAssertEqual(snapshot.totalTranscriptions, 40)
-        XCTAssertEqual(snapshot.averageWPM, 95)
+        XCTAssertEqual(snapshot.averageWPM, 120.0, accuracy: 0.01)
         XCTAssertEqual(snapshot.currentStreak, 3)
         XCTAssertEqual(snapshot.bestStreak, 12)
     }

--- a/Tests/VocaMacTests/TranscriptionLanguageTests.swift
+++ b/Tests/VocaMacTests/TranscriptionLanguageTests.swift
@@ -1,0 +1,35 @@
+// TranscriptionLanguageTests.swift
+// VocaMac Tests
+
+import XCTest
+@testable import VocaMac
+
+final class TranscriptionLanguageTests: XCTestCase {
+
+    func testCatalogIncludesAutoAndHungarian() {
+        XCTAssertTrue(TranscriptionLanguage.catalog.contains { $0.code == "auto" })
+        XCTAssertTrue(TranscriptionLanguage.catalog.contains { $0.code == "hu" })
+        XCTAssertTrue(TranscriptionLanguage.catalog.contains { $0.code == "vi" })
+        XCTAssertGreaterThanOrEqual(TranscriptionLanguage.catalog.count, 30)
+    }
+
+    func testCodesAreUnique() {
+        let codes = TranscriptionLanguage.catalog.map(\.code)
+        XCTAssertEqual(codes.count, Set(codes).count)
+    }
+
+    func testFilterByNameAndCode() {
+        let byName = TranscriptionLanguage.filtered(search: "hungar")
+        XCTAssertEqual(byName.map(\.code), ["hu"])
+
+        let byCode = TranscriptionLanguage.filtered(search: "ja")
+        XCTAssertTrue(byCode.contains { $0.code == "ja" })
+    }
+
+    func testSelectableExcludesAutoAndIsSorted() {
+        let selectable = TranscriptionLanguage.selectable
+        XCTAssertFalse(selectable.contains { $0.code == "auto" })
+        let names = selectable.map(\.displayName)
+        XCTAssertEqual(names, names.sorted { $0.localizedCaseInsensitiveCompare($1) == .orderedAscending })
+    }
+}

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -333,6 +333,10 @@ CGEventSource(stateID: .hidSystemState)
 
 **Required Permission:** Accessibility (same as HotKeyManager)
 
+**Related helpers:**
+- `DictationOutputFormatter` — trailing space + sentence capitalization before inject
+- `AutoPauseMonitor` / `ModelKeepAlive` / `SleepWakeMonitor` — power controls that unload via `TranscriptionRouter.unloadModel()`
+
 **Edge Cases:**
 - If clipboard contains non-text content (images, files), save and restore the full pasteboard items
 - Add configurable delay between paste simulation events for slower apps

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -514,36 +514,40 @@ swift build -c release
 
 ## 8. Cross-Platform Strategy
 
-### 8.1 Architecture for Future Portability
+VocaMac is part of [VocaHQ](https://github.com/VocaHQ): offline voice dictation on each OS, with feature parity over time. Sister apps: [VocaLinux](https://github.com/VocaHQ/vocalinux) (stable), VocaWin (coming soon), VocaPhone (in development).
 
-While VocaMac is a native macOS app, the architecture is designed to facilitate a future Windows port (VocaWin):
+The living Mac ↔ Linux gap list and phased port plan live in [`docs/VOCAHQ_PARITY.md`](VOCAHQ_PARITY.md).
+
+### 8.1 Shared jobs, native code
 
 ```
 Shared Concepts:
-  └── Whisper models        ← Same model family across platforms
-  └── UX patterns           ← Same user interaction design
+  └── Speech model families   ← Whisper-class (+ platform specialists)
+  └── UX patterns             ← Hotkey → speak → inject; searchable settings IA
+  └── Power controls          ← Auto-pause apps; idle model unload
+  └── Output polish           ← Trailing space; capitalization rules
 
 Platform-Specific:
-  ┌──────────────────────┬──────────────────────┐
-  │      macOS            │      Windows         │
-  ├──────────────────────┼──────────────────────┤
-  │ Swift + SwiftUI      │ C++/C# + WinUI 3    │
-  │ AVAudioEngine        │ WASAPI / NAudio      │
-  │ CGEventTap           │ SetWindowsHookEx     │
-  │ NSPasteboard + CGEvt │ Clipboard + SendInput│
-  │ Metal acceleration   │ CUDA / DirectML      │
-  │ MenuBarExtra         │ System Tray (NotifyIcon) │
-  └──────────────────────┴──────────────────────┘
+  ┌──────────────────────┬──────────────────────┬──────────────────────┐
+  │      macOS            │      Linux            │      Windows         │
+  ├──────────────────────┼──────────────────────┼──────────────────────┤
+  │ Swift + SwiftUI      │ Python + GTK         │ (VocaWin TBD)        │
+  │ AVAudioEngine        │ PortAudio            │ WASAPI / NAudio      │
+  │ CGEventTap           │ evdev / pynput       │ SetWindowsHookEx     │
+  │ AX + NSPasteboard    │ IBus / ydotool / …   │ Clipboard + SendInput│
+  │ CoreML / Metal / ANE │ Vulkan / CUDA        │ CUDA / DirectML      │
+  │ MenuBarExtra         │ AppIndicator tray    │ NotifyIcon           │
+  └──────────────────────┴──────────────────────┴──────────────────────┘
 ```
 
-### 8.2 What Can Be Shared
+### 8.2 What can be shared
 
-- **Whisper models** - Same OpenAI Whisper model family on all platforms
-- **Model files** - Each platform uses its optimal format (CoreML on macOS, GGML on Linux/Windows)
-- **Model catalog** - Same model variants and metadata
-- **UX patterns** - Same user flows and interaction design
+- User jobs and settings topic names (Dictation, Speech Model, Audio, Performance, …)
+- Model catalog *ideas* (size tiers, language honesty); each OS keeps its optimal format
+- Preference semantics (auto-pause app list, idle timeout, trailing space)
+- Privacy bar: local engines, no account wall
 
-### 8.3 What Must Be Platform-Specific
+### 8.3 What must stay platform-specific
 
 - UI framework and rendering
 - Audio capture API
@@ -551,7 +555,7 @@ Platform-Specific:
 - Text injection method
 - Permission handling
 - App lifecycle and distribution
-
+- GPU / NPU acceleration APIs
 ---
 
 ## 9. Error Handling Strategy

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -334,8 +334,8 @@ CGEventSource(stateID: .hidSystemState)
 **Required Permission:** Accessibility (same as HotKeyManager)
 
 **Related helpers:**
-- `DictationOutputFormatter` — trailing space + sentence capitalization before inject
-- `AutoPauseMonitor` / `ModelKeepAlive` / `SleepWakeMonitor` — power controls that unload via `TranscriptionRouter.unloadModel()`
+- `DictationOutputFormatter`: trailing space and sentence capitalization before inject
+- `AutoPauseMonitor` / `ModelKeepAlive` / `SleepWakeMonitor`: power controls that unload via `TranscriptionRouter.unloadModel()`
 
 **Edge Cases:**
 - If clipboard contains non-text content (images, files), save and restore the full pasteboard items

--- a/docs/DATA_MODEL.md
+++ b/docs/DATA_MODEL.md
@@ -298,6 +298,17 @@ struct UserSettings {
     var selectedModelSize: ModelSize = .tiny
     var selectedLanguage: String = "auto"       // "auto" or ISO 639-1 code
 
+    // Output polish
+    var appendTrailingSpace: Bool = true        // Space after each completed utterance
+    var autoCapitalize: Bool = true             // Capitalize sentence starts
+
+    // Performance / power
+    var autoPauseEnabled: Bool = false
+    var autoPauseApps: [AutoPauseAppEntry] = [] // JSON in UserDefaults
+    var autoPausePollIntervalSeconds: Double = 5
+    var modelKeepAliveEnabled: Bool = false
+    var modelKeepAliveIdleTimeoutSeconds: Double = 300
+
     // App Behavior
     var launchAtLogin: Bool = false
     var preserveClipboard: Bool = true          // Restore clipboard after text injection
@@ -311,6 +322,12 @@ vocamac.activationMode     = "pushToTalk"
 vocamac.hotKeyCode         = 61
 vocamac.doubleTapThreshold = 0.4
 vocamac.silenceThreshold   = 0.01
+vocamac.appendTrailingSpace = true
+vocamac.autoCapitalize = true
+vocamac.autoPause.enabled = false
+vocamac.autoPause.apps = "[]"
+vocamac.modelKeepAlive.enabled = false
+vocamac.modelKeepAlive.idleTimeoutSeconds = 300
 ...
 ```
 

--- a/docs/VOCAHQ_PARITY.md
+++ b/docs/VOCAHQ_PARITY.md
@@ -33,22 +33,22 @@ Status as of this document. Update cells when follow-up PRs land.
 | Category | Capability | VocaLinux v0.15 | VocaMac | Target |
 |----------|------------|-----------------|---------|--------|
 | Core loop | Push-to-talk / toggle, silence stop, inject | Yes | Yes | Keep |
-| Settings IA | Topic pages in a **left sidebar** | Yes | Horizontal tabs | Port UX |
-| Settings IA | Live **settings search** | Yes | No | Port UX |
-| Settings IA | Persistent status / mic / test footer | Yes | No | Port UX |
-| Output | Trailing space after utterance | Yes | No | Port |
-| Output | Auto-capitalize after sentence ends | Yes (esp. VOSK path) | No | Port where useful |
+| Settings IA | Topic pages in a **left sidebar** | Yes | Yes (`NavigationSplitView`) | Keep |
+| Settings IA | Live **settings search** | Yes | Yes | Keep |
+| Settings IA | Persistent status / mic / test footer | Yes | Yes | Keep |
+| Output | Trailing space after utterance | Yes | Yes | Keep |
+| Output | Auto-capitalize after sentence ends | Yes (esp. VOSK path) | Yes | Keep |
 | Output | Voice commands | Yes (engine-gated) | No | Later / optional |
 | Output | Custom vocabulary | No | Yes (Whisper) | Keep; feed Linux later |
 | Output | Translation | No | Yes (Whisper) | Keep |
-| Power | Auto-pause while listed apps run | Yes | No | Port |
-| Power | Idle model unload (keep-alive) | Yes | No | Port |
-| Power | Sleep/wake recovery | Yes (logind) | Partial (audio route) | Strengthen |
+| Power | Auto-pause while listed apps run | Yes | Yes | Keep |
+| Power | Idle model unload (keep-alive) | Yes | Yes (opt-in) | Keep |
+| Power | Sleep/wake recovery | Yes (logind) | Yes (`NSWorkspace`) | Keep |
 | Models | Multi-engine catalog | 3 + remote | 4 on-device | Keep Mac lead |
-| Models | Language catalog depth | ~33 + auto | ~17 + auto | Expand |
-| Updates | Stable / nightly channel picker | Yes | Nightly via separate cask/DMG | Align UX |
-| Diagnostics | In-app log viewer | Yes | Copy/export only | Improve |
-| Stats | Usage stats / streaks | Thin | Rich Stats tab | Keep; feed Linux later |
+| Models | Language catalog depth | ~33 + auto | ~36 + auto (searchable) | Keep |
+| Updates | Stable / nightly channel picker | Yes | Nightly via separate cask/DMG | Align UX (follow-up) |
+| Diagnostics | In-app log viewer | Yes | Copy/export only | Improve (follow-up) |
+| Stats | Usage stats / streaks | Thin | Rich Stats sidebar page | Keep; feed Linux later |
 | UX | Cursor mic overlay | No | Yes | Keep |
 | UX | Onboarding wizard | Basic first-run | Full multi-step | Keep |
 
@@ -142,24 +142,24 @@ Voice commands stay **out of phase 1**. Port later as an optional, engine-aware 
 
 ---
 
-## 6. Phased delivery (separate PRs)
+## 6. Phased delivery
 
-Ship one concern per PR. Do not bundle the settings shell with model lifecycle.
+Originally planned as separate PRs. Phases **1–3** plus the language-catalog half of Phase 4 shipped together in the stacked implementation PR on top of this plan (user requested a single follow-up). Remaining Phase 4 (update channel UX, richer log viewer) and Phase 5 stay deferred.
 
-### Phase 1: Output polish
+### Phase 1: Output polish — **done**
 
 - Trailing space + auto-capitalize preferences and injection hook
 - Tests for edge cases (empty text, already capitalized, CJK, trailing punctuation)
-- Settings toggles under Dictation/Output (can live in General until the sidebar lands)
+- Settings toggles under Dictation/Output
 
-### Phase 2: Performance / power
+### Phase 2: Performance / power — **done**
 
 - `AutoPauseMonitor` + preferences + Settings UI
 - `ModelKeepAlive` idle unload + preferences
 - Sleep/wake hardening
 - Tests with injected process snapshots / fake clocks
 
-### Phase 3: Settings shell
+### Phase 3: Settings shell — **done**
 
 - Sidebar navigation + searchable index
 - Sidebar footer: status, level, Test Dictation, Close
@@ -168,9 +168,9 @@ Ship one concern per PR. Do not bundle the settings shell with model lifecycle.
 
 ### Phase 4: Catalog and updates
 
-- Expand language list toward the VocaLinux catalog; searchable language picker
-- Update channel selector (stable vs nightly) wired to the right GitHub release endpoints
-- Optional: richer log viewer in Advanced
+- Expand language list toward the VocaLinux catalog; searchable language picker — **done**
+- Update channel selector (stable vs nightly) wired to the right GitHub release endpoints — **follow-up**
+- Optional: richer log viewer in Advanced — **follow-up**
 
 ### Phase 5: Bidirectional / org
 

--- a/docs/VOCAHQ_PARITY.md
+++ b/docs/VOCAHQ_PARITY.md
@@ -4,10 +4,10 @@ Living plan for bringing VocaMac in line with the Voca family product bar, start
 
 **Org principle** ([VocaHQ/PRODUCT.md](https://github.com/VocaHQ/vocahq/blob/main/PRODUCT.md)): feature parity over time across platforms. Same jobs, native code. Not a shared UI toolkit, not identical screenshots.
 
-**Sources reviewed for this draft:**
+**Sources reviewed:**
 
 - VocaLinux `main` (v0.15 line): searchable sidebar settings (#601, #618), auto-pause + idle unload (#592), dictation polish (#554, #608), language catalog (#616)
-- VocaMac `main`: tabbed settings, four-engine `TranscriptionRouter`, cursor overlay, stats, AX injection
+- VocaMac: four-engine `TranscriptionRouter`, cursor overlay, stats, AX injection, plus the parity work shipped in PR #207
 - VocaHQ product principles and status labels
 
 ---
@@ -28,14 +28,14 @@ Platform adapters stay native: `NSWorkspace` instead of `psutil`, `NSWorkspace` 
 
 ## 2. Snapshot matrix
 
-Status as of this document. Update cells when follow-up PRs land.
+Status as of the #207 parity ship. Update cells when follow-up PRs land.
 
 | Category | Capability | VocaLinux v0.15 | VocaMac | Target |
 |----------|------------|-----------------|---------|--------|
 | Core loop | Push-to-talk / toggle, silence stop, inject | Yes | Yes | Keep |
-| Settings IA | Topic pages in a **left sidebar** | Yes | Yes (`NavigationSplitView`) | Keep |
-| Settings IA | Live **settings search** | Yes | Yes | Keep |
-| Settings IA | Persistent status / mic / test footer | Yes | Yes | Keep |
+| Settings IA | Topic pages in a **left sidebar** | Yes | Yes (custom sidebar + detail) | Keep |
+| Settings IA | Live **settings search** | Yes | Yes (sidebar search field) | Keep |
+| Settings IA | Persistent status / mic / test footer | Yes | Yes (Test Dictation; no inject) | Keep |
 | Output | Trailing space after utterance | Yes | Yes | Keep |
 | Output | Auto-capitalize after sentence ends | Yes (esp. VOSK path) | Yes | Keep |
 | Output | Voice commands | Yes (engine-gated) | No | Later / optional |
@@ -48,151 +48,127 @@ Status as of this document. Update cells when follow-up PRs land.
 | Models | Language catalog depth | ~33 + auto | ~36 + auto (searchable) | Keep |
 | Updates | Stable / nightly channel picker | Yes | Nightly via separate cask/DMG | Align UX (follow-up) |
 | Diagnostics | In-app log viewer | Yes | Copy/export only | Improve (follow-up) |
-| Stats | Usage stats / streaks | Thin | Rich Stats sidebar page | Keep; feed Linux later |
+| Stats | Usage stats / streaks | Thin | Rich Stats sidebar page (+ Share) | Keep; feed Linux later |
 | UX | Cursor mic overlay | No | Yes | Keep |
-| UX | Onboarding wizard | Basic first-run | Full multi-step | Keep |
+| UX | Onboarding wizard | Basic first-run | Full multi-step (About entry) | Keep |
 
 ---
 
-## 3. Unified settings IA (target)
-
-Mirror VocaLinux topic names where they map cleanly. Keep Mac-only content under the right topic.
+## 3. Settings IA (shipped)
 
 ```
-Dictation       Hotkey, mode, silence/VAD, output formatting, voice commands (later)
-Speech Model    Engine/model picker, downloads, language catalog, translation/vocab
-Audio           Device, mic test, sound effects
-Performance     Auto-pause apps, idle unload, resource readout
-Application     Launch at login, cursor overlay, clipboard preserve, notifications
-Advanced        Engine knobs (gated), debug tools
-About           Version, update channel, links, setup wizard
-[Sidebar footer] Status, level meter, Test Dictation, Close
+Dictation       Hotkey, mode, output formatting (trailing space, auto-capitalize)
+Speech Model    Engine/model picker, downloads, language, translation/vocab (engine-gated)
+Audio           Device, silence/VAD, sound effects
+Performance     Model status, auto-pause apps, idle unload
+Application     Launch at login, recording overlay, clipboard preserve
+Stats           Usage totals, streaks, Share card
+Advanced        System info, resource pills, permissions, debug logs
+About           Version, updates, links, setup wizard
+[Sidebar]       Search at top; status + Test Dictation footer (results only, no inject)
 ```
 
-**macOS shell:** SwiftUI `NavigationSplitView` (or equivalent sidebar list + detail) + `.searchable`. Do not paste GTK layout into SwiftUI.
+**macOS shell:** Custom sidebar + detail layout (not `NavigationSplitView`, which fought Tahoe toolbar chrome). Sidebar search field matches System Settings placement. One top-right sidebar toggle.
 
-**Search contract** (match Linux behavior):
+**Search contract:**
 
 1. Index each control by title, subtitle, and optional keywords
-2. Filter rows in place; badge match counts on sidebar pages
+2. Filter sidebar pages by match; badge counts when searching
 3. Jump to first page with matches; empty state when none
-4. Esc clears search; restore previous page
+4. Clearing search restores the previous page
 
-Current tab → target page mapping:
+Former tab → page mapping:
 
-| Today | Target page |
-|-------|-------------|
-| General (hotkey, language, translation, vocab, behavior) | Split across Dictation / Speech Model / Application |
-| Models | Speech Model (+ resource bits → Performance) |
-| Stats | Application or its own sidebar entry (keep Mac lead) |
+| Was | Now |
+|-----|-----|
+| General | Split across Dictation / Speech Model / Application |
+| Models | Speech Model (system/resource bits → Advanced) |
+| Stats | Stats (own sidebar item) |
 | Audio | Audio |
 | Debug | Advanced |
 | About | About |
 
 ---
 
-## 4. Power management (port of #592)
+## 4. Power management (shipped; port of #592)
 
 ### 4.1 Auto-pause for apps
 
-**Linux:** poll process basenames; unload model while any listed name runs; reload when none remain.
-
 **Mac adapter:**
 
-- Watch `NSWorkspace.shared.runningApplications` (and/or `NSWorkspace` launch/terminate notifications)
-- Match on bundle ID and/or executable basename (user-facing list should prefer app names + bundle IDs)
-- On pause: stop recording if active, call existing unload paths on `TranscriptionRouter` / engine services, set an `isAutoPaused` gate so hotkeys do not start capture
-- On resume: lazy reload on next dictation (same as Linux), or warm-reload if already preferred
+- Poll `NSWorkspace.shared.runningApplications` (~5s)
+- Match on bundle ID **or** executable basename
+- On pause: stop recording if active, unload via `TranscriptionRouter`, set `isAutoPaused`
+- On resume: warm-reload selected model
+- UI surfaces which app triggered pause (Performance + menu bar)
 
-**Settings:** Performance page. Toggle + editable list + "Choose Running App…" picker.
+**Settings:** Performance page. Toggle + list + "Choose Running App…"
 
-**Defaults:** off; empty app list; poll / refresh interval ~5s (reuse the existing ProcessMonitor cadence mindset; do not add a second high-frequency timer).
+**Defaults:** off; empty app list.
 
-### 4.2 Idle model unload ("keep-alive")
+### 4.2 Idle model unload
 
-**Linux:** after N seconds idle (default 300, options 1-30 min), unload model; next dictation reloads.
-
-**Mac adapter:**
-
-- Arm timer when `AppStatus` returns to `.idle` after a transcription
-- Cancel while recording/processing or while auto-paused
-- Call the same unload APIs used on engine switch
-- Surface cold-start latency honestly in UI copy
-
-**Note:** `AudioEngine` already releases the AVAudioEngine after 3s idle for Bluetooth HFP. Idle *model* unload is separate and optional.
+- Arm when status returns to idle; cancel while recording/processing/auto-paused
+- Opt-in; default timeout 300s (1–30 min options)
+- Next dictation reloads; Performance/menu bar show unload reason and approx RSS drop
 
 ### 4.3 Sleep / wake
 
-Subscribe to `NSWorkspace.willSleepNotification` / `didWakeNotification` (and/or screen sleep). On wake: refresh audio devices and hotkey tap health; bump keep-alive. Skip model reload if still auto-paused.
+`NSWorkspace.willSleepNotification` / `didWakeNotification`: cancel keep-alive on sleep; on wake refresh hotkey health and bump keep-alive (skip reload if still auto-paused).
 
 ---
 
-## 5. Dictation polish (port of #554 / #608)
+## 5. Dictation polish (shipped; port of #554 / #608)
 
-Apply in one place before `TextInjector.inject`:
+Applied in `DictationOutputFormatter` before `TextInjector.inject` (hotkey path). Settings Test Dictation shows results in the footer only and does **not** inject.
 
 | Preference | Default | Behavior |
 |------------|---------|----------|
-| `appendTrailingSpace` | `true` | Append a trailing space after a completed utterance so the next PTT/toggle session does not glue onto the previous sentence |
-| `autoCapitalize` | `true` | Capitalize start of session and after `.` `!` `?` when the engine did not already |
+| `appendTrailingSpace` | `true` | Space after each utterance |
+| `autoCapitalize` | `true` | Capitalize start and after `.` `!` `?` when needed |
 
-Whisper / Apple Speech often emit capitalization already; keep the pass idempotent (do not double-upcase). Marketing copy that already claims this behavior should match the implementation once shipped.
-
-Voice commands stay **out of phase 1**. Port later as an optional, engine-aware post-processor, not as a default for WhisperKit.
+Voice commands remain out of scope for now.
 
 ---
 
 ## 6. Phased delivery
 
-Originally planned as separate PRs. Phases 1-3 plus the language-catalog half of Phase 4 shipped together in the stacked implementation PR on top of this plan (user requested a single follow-up). Remaining Phase 4 (update channel UX, richer log viewer) and Phase 5 stay deferred.
+Phases 1–3 and the language half of Phase 4 shipped in PR #207. Remaining Phase 4 and Phase 5 stay deferred.
 
 ### Phase 1: Output polish (done)
 
-- Trailing space + auto-capitalize preferences and injection hook
-- Tests for edge cases (empty text, already capitalized, CJK, trailing punctuation)
-- Settings toggles under Dictation/Output
-
 ### Phase 2: Performance / power (done)
-
-- `AutoPauseMonitor` + preferences + Settings UI
-- `ModelKeepAlive` idle unload + preferences
-- Sleep/wake hardening
-- Tests with injected process snapshots / fake clocks
 
 ### Phase 3: Settings shell (done)
 
-- Sidebar navigation + searchable index
-- Sidebar footer: status, level, Test Dictation, Close
-- Rehome existing controls into the target IA
-- Preserve Stats and Mac-only controls
-
 ### Phase 4: Catalog and updates
 
-- Expand language list toward the VocaLinux catalog; searchable language picker (done)
-- Update channel selector (stable vs nightly) wired to the right GitHub release endpoints (follow-up)
-- Optional: richer log viewer in Advanced (follow-up)
+- Expand language list; searchable picker (done)
+- Update channel selector stable vs nightly (follow-up)
+- Richer log viewer in Advanced (follow-up)
 
 ### Phase 5: Bidirectional / org
 
 - Feed Mac wins back to Linux where useful: stats, custom vocabulary, translation UX, multi-engine honesty
-- Keep the matrix in this file (and eventually a short matrix on vocahq.com) updated
-- VocaWin / VocaPhone consume the same taxonomy when they grow past marketing
+- Keep this matrix (and eventually vocahq.com) updated
+- VocaWin / VocaPhone reuse the same taxonomy when they grow past marketing
 
 ---
 
-## 7. Suggested Swift touch points
+## 7. Swift touch points (implemented)
 
 | Work | Where |
 |------|--------|
-| Preferences | `AppState` `@AppStorage` keys (`vocamac.appendTrailingSpace`, `vocamac.autoCapitalize`, `vocamac.autoPause.*`, `vocamac.modelKeepAlive.*`) |
-| Text polish | Small helper used from `AppState` before `TextInjector` |
-| Auto-pause | New `AutoPauseMonitor` service; wire from `AppState` / app lifecycle |
-| Idle unload | New `ModelKeepAlive` helper calling `TranscriptionRouter` unload APIs |
-| Settings shell | Refactor `SettingsView.swift` off `TabView`; keep tab bodies as page views |
-| Search index | Lightweight struct listing title/subtitle/keywords → page id (no new dependency) |
-| Tests | `Tests/VocaMacTests/` mirrors Linux: pure matching + timeout logic without UI |
+| Preferences | `AppState` / `PreferenceKey` (`vocamac.appendTrailingSpace`, `vocamac.autoCapitalize`, `vocamac.autoPause.*`, `vocamac.modelKeepAlive.*`) |
+| Text polish | `DictationOutputFormatter` |
+| Auto-pause | `AutoPauseMonitor` |
+| Idle unload | `ModelKeepAlive` |
+| Sleep/wake | `SleepWakeMonitor` |
+| Settings shell | `SettingsView` (custom sidebar + detail) |
+| Search index | `SettingsSearchIndex` |
+| Tests | `Tests/VocaMacTests/` (matching, formatter, keep-alive, search, languages, …) |
 
-Reuse unload already present on Whisper / Parakeet / Apple Speech / Sherpa services. Do not invent a second model lifecycle path.
+Unload reuses existing engine teardown via `TranscriptionRouter.unloadModel()`.
 
 ---
 
@@ -211,20 +187,18 @@ Reuse unload already present on Whisper / Parakeet / Apple Speech / Sherpa servi
 
 A reviewer can open Settings and:
 
-1. Navigate by left sidebar topics (not only top tabs)
-2. Search "pause" or "idle" and land on Performance controls
-3. See live recognition status and run Test Dictation without leaving Settings
-4. Enable auto-pause, pick a running app, confirm the model unloads while it runs and reloads after
-5. Enable idle unload, wait past the timeout (or advance a test clock), confirm unload + next-dictation reload
-6. Dictate twice in a row with trailing-space on and get a clean space between utterances
+1. Navigate by left sidebar topics
+2. Search "pause" or "idle" and land on Performance
+3. See status and run Test Dictation in the footer (results appear there; no inject)
+4. Enable auto-pause, pick a running app, confirm unload while it runs and reload after
+5. Enable idle unload, wait past the timeout, confirm unload + next-dictation reload
+6. Dictate twice with trailing space on and get a clean space between utterances
 
 ---
 
-## 10. Open questions
+## 10. Decisions (resolved in #207)
 
-1. **Stats placement:** keep a dedicated sidebar item vs fold into Application?
-2. **Auto-pause matching:** bundle ID only, or also process name for CLI tools / games?
-3. **Idle unload default:** stay opt-in (Linux default) or recommend-on for large models?
-4. **Voice commands:** skip until a Whisper-friendly design exists, or ship a small English command set behind a toggle?
-
-Resolve these in the phase PRs; do not block Phase 1 on them.
+1. **Stats placement:** dedicated sidebar item (keep Mac lead).
+2. **Auto-pause matching:** bundle ID **or** process name.
+3. **Idle unload default:** opt-in, default off (match Linux).
+4. **Voice commands:** skip for now; revisit with a Whisper-friendly design.

--- a/docs/VOCAHQ_PARITY.md
+++ b/docs/VOCAHQ_PARITY.md
@@ -144,22 +144,22 @@ Voice commands stay **out of phase 1**. Port later as an optional, engine-aware 
 
 ## 6. Phased delivery
 
-Originally planned as separate PRs. Phases **1–3** plus the language-catalog half of Phase 4 shipped together in the stacked implementation PR on top of this plan (user requested a single follow-up). Remaining Phase 4 (update channel UX, richer log viewer) and Phase 5 stay deferred.
+Originally planned as separate PRs. Phases 1-3 plus the language-catalog half of Phase 4 shipped together in the stacked implementation PR on top of this plan (user requested a single follow-up). Remaining Phase 4 (update channel UX, richer log viewer) and Phase 5 stay deferred.
 
-### Phase 1: Output polish — **done**
+### Phase 1: Output polish (done)
 
 - Trailing space + auto-capitalize preferences and injection hook
 - Tests for edge cases (empty text, already capitalized, CJK, trailing punctuation)
 - Settings toggles under Dictation/Output
 
-### Phase 2: Performance / power — **done**
+### Phase 2: Performance / power (done)
 
 - `AutoPauseMonitor` + preferences + Settings UI
 - `ModelKeepAlive` idle unload + preferences
 - Sleep/wake hardening
 - Tests with injected process snapshots / fake clocks
 
-### Phase 3: Settings shell — **done**
+### Phase 3: Settings shell (done)
 
 - Sidebar navigation + searchable index
 - Sidebar footer: status, level, Test Dictation, Close
@@ -168,9 +168,9 @@ Originally planned as separate PRs. Phases **1–3** plus the language-catalog h
 
 ### Phase 4: Catalog and updates
 
-- Expand language list toward the VocaLinux catalog; searchable language picker — **done**
-- Update channel selector (stable vs nightly) wired to the right GitHub release endpoints — **follow-up**
-- Optional: richer log viewer in Advanced — **follow-up**
+- Expand language list toward the VocaLinux catalog; searchable language picker (done)
+- Update channel selector (stable vs nightly) wired to the right GitHub release endpoints (follow-up)
+- Optional: richer log viewer in Advanced (follow-up)
 
 ### Phase 5: Bidirectional / org
 

--- a/docs/VOCAHQ_PARITY.md
+++ b/docs/VOCAHQ_PARITY.md
@@ -1,0 +1,230 @@
+# VocaHQ feature parity (VocaMac)
+
+Living plan for bringing VocaMac in line with the Voca family product bar, starting from VocaLinux v0.15.
+
+**Org principle** ([VocaHQ/PRODUCT.md](https://github.com/VocaHQ/vocahq/blob/main/PRODUCT.md)): feature parity over time across platforms. Same jobs, native code. Not a shared UI toolkit, not identical screenshots.
+
+**Sources reviewed for this draft:**
+
+- VocaLinux `main` (v0.15 line): searchable sidebar settings (#601, #618), auto-pause + idle unload (#592), dictation polish (#554, #608), language catalog (#616)
+- VocaMac `main`: tabbed settings, four-engine `TranscriptionRouter`, cursor overlay, stats, AX injection
+- VocaHQ product principles and status labels
+
+---
+
+## 1. What "parity" means here
+
+| Means | Does not mean |
+|-------|---------------|
+| Same user jobs: hotkey → speak → text at cursor | Shared GTK/SwiftUI widgets |
+| Same settings topics and searchability | Pixel-identical layouts |
+| Same power controls (pause for apps, unload when idle) | Porting `psutil` / logind / Vulkan pickers |
+| Honest per-engine language and model labels | One engine stack on every OS |
+| Shared vocabulary for features in docs and marketing | Shipping Linux-only packaging or IBus |
+
+Platform adapters stay native: `NSWorkspace` instead of `psutil`, `NSWorkspace` sleep/wake instead of logind, Metal/CoreML instead of Vulkan.
+
+---
+
+## 2. Snapshot matrix
+
+Status as of this document. Update cells when follow-up PRs land.
+
+| Category | Capability | VocaLinux v0.15 | VocaMac | Target |
+|----------|------------|-----------------|---------|--------|
+| Core loop | Push-to-talk / toggle, silence stop, inject | Yes | Yes | Keep |
+| Settings IA | Topic pages in a **left sidebar** | Yes | Horizontal tabs | Port UX |
+| Settings IA | Live **settings search** | Yes | No | Port UX |
+| Settings IA | Persistent status / mic / test footer | Yes | No | Port UX |
+| Output | Trailing space after utterance | Yes | No | Port |
+| Output | Auto-capitalize after sentence ends | Yes (esp. VOSK path) | No | Port where useful |
+| Output | Voice commands | Yes (engine-gated) | No | Later / optional |
+| Output | Custom vocabulary | No | Yes (Whisper) | Keep; feed Linux later |
+| Output | Translation | No | Yes (Whisper) | Keep |
+| Power | Auto-pause while listed apps run | Yes | No | Port |
+| Power | Idle model unload (keep-alive) | Yes | No | Port |
+| Power | Sleep/wake recovery | Yes (logind) | Partial (audio route) | Strengthen |
+| Models | Multi-engine catalog | 3 + remote | 4 on-device | Keep Mac lead |
+| Models | Language catalog depth | ~33 + auto | ~17 + auto | Expand |
+| Updates | Stable / nightly channel picker | Yes | Nightly via separate cask/DMG | Align UX |
+| Diagnostics | In-app log viewer | Yes | Copy/export only | Improve |
+| Stats | Usage stats / streaks | Thin | Rich Stats tab | Keep; feed Linux later |
+| UX | Cursor mic overlay | No | Yes | Keep |
+| UX | Onboarding wizard | Basic first-run | Full multi-step | Keep |
+
+---
+
+## 3. Unified settings IA (target)
+
+Mirror VocaLinux topic names where they map cleanly. Keep Mac-only content under the right topic.
+
+```
+Dictation       Hotkey, mode, silence/VAD, output formatting, voice commands (later)
+Speech Model    Engine/model picker, downloads, language catalog, translation/vocab
+Audio           Device, mic test, sound effects
+Performance     Auto-pause apps, idle unload, resource readout
+Application     Launch at login, cursor overlay, clipboard preserve, notifications
+Advanced        Engine knobs (gated), debug tools
+About           Version, update channel, links, setup wizard
+[Sidebar footer] Status, level meter, Test Dictation, Close
+```
+
+**macOS shell:** SwiftUI `NavigationSplitView` (or equivalent sidebar list + detail) + `.searchable`. Do not paste GTK layout into SwiftUI.
+
+**Search contract** (match Linux behavior):
+
+1. Index each control by title, subtitle, and optional keywords
+2. Filter rows in place; badge match counts on sidebar pages
+3. Jump to first page with matches; empty state when none
+4. Esc clears search; restore previous page
+
+Current tab → target page mapping:
+
+| Today | Target page |
+|-------|-------------|
+| General (hotkey, language, translation, vocab, behavior) | Split across Dictation / Speech Model / Application |
+| Models | Speech Model (+ resource bits → Performance) |
+| Stats | Application or its own sidebar entry (keep Mac lead) |
+| Audio | Audio |
+| Debug | Advanced |
+| About | About |
+
+---
+
+## 4. Power management (port of #592)
+
+### 4.1 Auto-pause for apps
+
+**Linux:** poll process basenames; unload model while any listed name runs; reload when none remain.
+
+**Mac adapter:**
+
+- Watch `NSWorkspace.shared.runningApplications` (and/or `NSWorkspace` launch/terminate notifications)
+- Match on bundle ID and/or executable basename (user-facing list should prefer app names + bundle IDs)
+- On pause: stop recording if active, call existing unload paths on `TranscriptionRouter` / engine services, set an `isAutoPaused` gate so hotkeys do not start capture
+- On resume: lazy reload on next dictation (same as Linux), or warm-reload if already preferred
+
+**Settings:** Performance page. Toggle + editable list + "Choose Running App…" picker.
+
+**Defaults:** off; empty app list; poll / refresh interval ~5s (reuse the existing ProcessMonitor cadence mindset; do not add a second high-frequency timer).
+
+### 4.2 Idle model unload ("keep-alive")
+
+**Linux:** after N seconds idle (default 300, options 1-30 min), unload model; next dictation reloads.
+
+**Mac adapter:**
+
+- Arm timer when `AppStatus` returns to `.idle` after a transcription
+- Cancel while recording/processing or while auto-paused
+- Call the same unload APIs used on engine switch
+- Surface cold-start latency honestly in UI copy
+
+**Note:** `AudioEngine` already releases the AVAudioEngine after 3s idle for Bluetooth HFP. Idle *model* unload is separate and optional.
+
+### 4.3 Sleep / wake
+
+Subscribe to `NSWorkspace.willSleepNotification` / `didWakeNotification` (and/or screen sleep). On wake: refresh audio devices and hotkey tap health; bump keep-alive. Skip model reload if still auto-paused.
+
+---
+
+## 5. Dictation polish (port of #554 / #608)
+
+Apply in one place before `TextInjector.inject`:
+
+| Preference | Default | Behavior |
+|------------|---------|----------|
+| `appendTrailingSpace` | `true` | Append a trailing space after a completed utterance so the next PTT/toggle session does not glue onto the previous sentence |
+| `autoCapitalize` | `true` | Capitalize start of session and after `.` `!` `?` when the engine did not already |
+
+Whisper / Apple Speech often emit capitalization already; keep the pass idempotent (do not double-upcase). Marketing copy that already claims this behavior should match the implementation once shipped.
+
+Voice commands stay **out of phase 1**. Port later as an optional, engine-aware post-processor, not as a default for WhisperKit.
+
+---
+
+## 6. Phased delivery (separate PRs)
+
+Ship one concern per PR. Do not bundle the settings shell with model lifecycle.
+
+### Phase 1: Output polish
+
+- Trailing space + auto-capitalize preferences and injection hook
+- Tests for edge cases (empty text, already capitalized, CJK, trailing punctuation)
+- Settings toggles under Dictation/Output (can live in General until the sidebar lands)
+
+### Phase 2: Performance / power
+
+- `AutoPauseMonitor` + preferences + Settings UI
+- `ModelKeepAlive` idle unload + preferences
+- Sleep/wake hardening
+- Tests with injected process snapshots / fake clocks
+
+### Phase 3: Settings shell
+
+- Sidebar navigation + searchable index
+- Sidebar footer: status, level, Test Dictation, Close
+- Rehome existing controls into the target IA
+- Preserve Stats and Mac-only controls
+
+### Phase 4: Catalog and updates
+
+- Expand language list toward the VocaLinux catalog; searchable language picker
+- Update channel selector (stable vs nightly) wired to the right GitHub release endpoints
+- Optional: richer log viewer in Advanced
+
+### Phase 5: Bidirectional / org
+
+- Feed Mac wins back to Linux where useful: stats, custom vocabulary, translation UX, multi-engine honesty
+- Keep the matrix in this file (and eventually a short matrix on vocahq.com) updated
+- VocaWin / VocaPhone consume the same taxonomy when they grow past marketing
+
+---
+
+## 7. Suggested Swift touch points
+
+| Work | Where |
+|------|--------|
+| Preferences | `AppState` `@AppStorage` keys (`vocamac.appendTrailingSpace`, `vocamac.autoCapitalize`, `vocamac.autoPause.*`, `vocamac.modelKeepAlive.*`) |
+| Text polish | Small helper used from `AppState` before `TextInjector` |
+| Auto-pause | New `AutoPauseMonitor` service; wire from `AppState` / app lifecycle |
+| Idle unload | New `ModelKeepAlive` helper calling `TranscriptionRouter` unload APIs |
+| Settings shell | Refactor `SettingsView.swift` off `TabView`; keep tab bodies as page views |
+| Search index | Lightweight struct listing title/subtitle/keywords → page id (no new dependency) |
+| Tests | `Tests/VocaMacTests/` mirrors Linux: pure matching + timeout logic without UI |
+
+Reuse unload already present on Whisper / Parakeet / Apple Speech / Sherpa services. Do not invent a second model lifecycle path.
+
+---
+
+## 8. Explicit non-goals (do not port)
+
+- IBus / ydotool / wtype / xdotool injection stacks
+- Vulkan device picker
+- VOSK as a Mac engine
+- Flatpak / AppImage / AUR packaging
+- systemd-logind D-Bus suspend API
+- Remote OpenAI-compatible API engine (revisit only if VocaGateway needs a Mac client)
+
+---
+
+## 9. Acceptance bar for "settings parity"
+
+A reviewer can open Settings and:
+
+1. Navigate by left sidebar topics (not only top tabs)
+2. Search "pause" or "idle" and land on Performance controls
+3. See live recognition status and run Test Dictation without leaving Settings
+4. Enable auto-pause, pick a running app, confirm the model unloads while it runs and reloads after
+5. Enable idle unload, wait past the timeout (or advance a test clock), confirm unload + next-dictation reload
+6. Dictate twice in a row with trailing-space on and get a clean space between utterances
+
+---
+
+## 10. Open questions
+
+1. **Stats placement:** keep a dedicated sidebar item vs fold into Application?
+2. **Auto-pause matching:** bundle ID only, or also process name for CLI tools / games?
+3. **Idle unload default:** stay opt-in (Linux default) or recommend-on for large models?
+4. **Voice commands:** skip until a Whisper-friendly design exists, or ship a small English command set behind a toggle?
+
+Resolve these in the phase PRs; do not block Phase 1 on them.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Ports the main VocaLinux v0.15 gaps onto VocaMac, then polishes the settings shell and recording overlay after Tahoe testing. Includes the docs parity plan that used to live in #206.

### Dictation and power
- Trailing space and auto-capitalize before inject (defaults on)
- Auto-pause for listed apps (match by bundle ID or process name); unloads the model and blocks hotkeys while they run
- Optional idle model unload (default off) with sleep/wake recovery via `NSWorkspace`
- Shared `SpeechTranscribing.unloadModel()` path on `TranscriptionRouter`
- Performance settings show loaded/unloaded state, estimated model RAM, and approx RSS drop after unload
- Menu bar explains auto-pause (including which app) and idle unload so "no model loaded" is not a mystery

### Settings shell
- Sidebar + detail layout with search at the top of the sidebar (System Settings style)
- One top-right sidebar toggle (custom layout; no duplicate/jumping system toggles)
- Footer Test Dictation: status, level meter, results in place; does not inject text
- Speech Model focuses on catalog + language; translation/vocab only when the engine supports them
- System info and live resource pills live under Advanced
- Stats Share copies a dark branded card image to the clipboard
- Setup Wizard stays under About (removed from the menu bar popover)
- Expanded searchable language catalog (~36 + auto)
- Recording overlay controls stay under Application

### Recording overlay and menu bar
- Overlay follows light/dark appearance, with stronger contrast and a brand-teal glow while recording
- Waveform is more sensitive to quiet speech; slide-in from top or bottom based on position
- Cancel button removed; brand mark instead of a red status dot; clicks pass through
- Hot mic uses brand teal in the menu bar; processing uses yellow (not purple)

### Docs
- `docs/VOCAHQ_PARITY.md` matrix and phased delivery notes updated
- Preference keys documented in `DATA_MODEL.md`

## Test plan

- [x] Unit tests (formatter, auto-pause, keep-alive, search index, languages, overlay sizes, share snapshot, inject vs test-dictation)
- [x] CI green on `macos-15`
- [x] Signed/notarized `/build` DMGs exercised on Tahoe during review
- [x] Final smoke after merge: two PTT sessions with trailing space; auto-pause with a listed app; idle unload; Test Dictation footer only; sidebar toggle stays top-right; overlay colors in light and dark; menu bar teal while recording

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2a077a95-b726-4353-aaae-00be646f3b87?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2a077a95-b726-4353-aaae-00be646f3b87&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

