### PR TITLE
feat: add tray microphone switcher

### DIFF
--- a/Sources/VocaMac/Models/AppState.swift
+++ b/Sources/VocaMac/Models/AppState.swift
@@ -170,6 +170,13 @@ final class AppState: ObservableObject {
         Double(maxRecordingDuration) + 5.0
     }
 
+    /// Persist the microphone VocaMac should use for future recordings.
+    /// Passing nil restores the system-default input behavior.
+    func selectAudioDevice(_ device: AudioDevice?) {
+        selectedAudioDeviceID = device?.id ?? ""
+        selectedAudioDeviceName = device?.name ?? ""
+    }
+
     // MARK: - Services
 
     let audioEngine: AudioRecording

--- a/Sources/VocaMac/Views/MenuBarView.swift
+++ b/Sources/VocaMac/Views/MenuBarView.swift
@@ -93,6 +93,7 @@ struct MenuBarView: View {
     @ObservedObject var settingsManager: SettingsWindowManager
     @ObservedObject var updateWindowManager: UpdateWindowManager
     @StateObject private var processMonitor = ProcessMonitor()
+    @State private var audioDevices: [AudioDevice] = []
 
     var body: some View {
         VStack(alignment: .leading, spacing: 14) {
@@ -108,6 +109,11 @@ struct MenuBarView: View {
 
             // Status & Recording
             statusSection
+
+            Divider()
+
+            // Microphone selection
+            microphoneSection
 
             // Last Transcription
             if let transcription = appState.lastTranscription {
@@ -286,6 +292,133 @@ struct MenuBarView: View {
                 }
                 .buttonStyle(.plain)
             }
+        }
+    }
+
+    // MARK: - Microphone
+
+    /// Provides a quick microphone switcher without requiring the Settings window.
+    /// The selected device is persisted by AppState and takes effect on the next
+    /// recording; it does not change macOS's global input-device selection.
+    private var microphoneSection: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            HStack {
+                Label("Microphone", systemImage: "mic.fill")
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+
+                Spacer()
+
+                Button {
+                    refreshAudioDevices()
+                } label: {
+                    Image(systemName: "arrow.clockwise")
+                        .font(.caption)
+                }
+                .buttonStyle(.plain)
+                .foregroundStyle(.secondary)
+                .help("Refresh microphones")
+            }
+
+            Menu {
+                Button {
+                    appState.selectAudioDevice(nil)
+                } label: {
+                    microphoneMenuItem("System Default", isSelected: appState.selectedAudioDeviceID.isEmpty)
+                }
+
+                if selectedAudioDeviceIsUnavailable {
+                    Divider()
+                    Text(selectedAudioDeviceDisplayName)
+                }
+
+                if !audioDevices.isEmpty {
+                    Divider()
+                }
+
+                ForEach(audioDevices) { device in
+                    Button {
+                        appState.selectAudioDevice(device)
+                    } label: {
+                        microphoneMenuItem(device.name, isSelected: appState.selectedAudioDeviceID == device.id)
+                    }
+                }
+
+                if audioDevices.isEmpty {
+                    Text("No audio input devices found")
+                }
+            } label: {
+                HStack(spacing: 8) {
+                    Image(systemName: "mic.circle.fill")
+                        .foregroundStyle(Color(nsColor: BrandAssets.brandGreen))
+
+                    Text(selectedAudioDeviceDisplayName)
+                        .lineLimit(1)
+
+                    Spacer()
+
+                    Image(systemName: "chevron.up.chevron.down")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+                .font(.body)
+                .padding(.horizontal, 10)
+                .padding(.vertical, 8)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .background(Color.secondary.opacity(0.1), in: RoundedRectangle(cornerRadius: 8, style: .continuous))
+            }
+            .menuStyle(.borderlessButton)
+            .disabled(appState.isRecording)
+
+            Text(appState.isRecording
+                 ? "Stop recording before changing the input."
+                 : "Applies to the next recording. Does not change macOS's system default.")
+                .font(.caption2)
+                .foregroundStyle(.secondary)
+        }
+        .onAppear {
+            refreshAudioDevices()
+        }
+    }
+
+    /// Renders a checkmarked microphone option inside the tray menu.
+    @ViewBuilder
+    private func microphoneMenuItem(_ name: String, isSelected: Bool) -> some View {
+        HStack {
+            Text(name)
+            Spacer()
+            if isSelected {
+                Image(systemName: "checkmark")
+            }
+        }
+    }
+
+    private var selectedAudioDevice: AudioDevice? {
+        guard !appState.selectedAudioDeviceID.isEmpty else { return nil }
+        return audioDevices.first { $0.id == appState.selectedAudioDeviceID }
+    }
+
+    private var selectedAudioDeviceIsUnavailable: Bool {
+        !appState.selectedAudioDeviceID.isEmpty && selectedAudioDevice == nil
+    }
+
+    private var selectedAudioDeviceDisplayName: String {
+        if appState.selectedAudioDeviceID.isEmpty {
+            return "System Default"
+        }
+        if let selectedAudioDevice {
+            return selectedAudioDevice.name
+        }
+        let storedName = appState.selectedAudioDeviceName.isEmpty
+            ? "Selected microphone"
+            : appState.selectedAudioDeviceName
+        return "\(storedName) (Unavailable)"
+    }
+
+    private func refreshAudioDevices() {
+        audioDevices = AudioEngine.availableInputDevices()
+        if let selectedAudioDevice {
+            appState.selectedAudioDeviceName = selectedAudioDevice.name
         }
     }
 

--- a/Sources/VocaMac/Views/SettingsView.swift
+++ b/Sources/VocaMac/Views/SettingsView.swift
@@ -1246,12 +1246,12 @@ struct AudioSettingsTab: View {
 
     private func syncSelectedAudioDeviceName() {
         guard !appState.selectedAudioDeviceID.isEmpty else {
-            appState.selectedAudioDeviceName = ""
+            appState.selectAudioDevice(nil)
             return
         }
 
         if let selectedAudioDevice {
-            appState.selectedAudioDeviceName = selectedAudioDevice.name
+            appState.selectAudioDevice(selectedAudioDevice)
         }
     }
 

--- a/Tests/VocaMacTests/AppStateRecordingTests.swift
+++ b/Tests/VocaMacTests/AppStateRecordingTests.swift
@@ -288,6 +288,27 @@ final class AppStateRecordingTests: XCTestCase {
                       "No device name should be persisted for system default")
     }
 
+    func testSelectingAudioDevicePersistsIDAndName() {
+        let (appState, _) = AppState.makeTestState()
+        let device = AudioDevice(
+            id: "test-microphone-uid",
+            name: "USB Microphone",
+            isDefault: false,
+            sampleRate: 48_000,
+            channelCount: 1
+        )
+
+        appState.selectAudioDevice(device)
+
+        XCTAssertEqual(appState.selectedAudioDeviceID, device.id)
+        XCTAssertEqual(appState.selectedAudioDeviceName, device.name)
+
+        appState.selectAudioDevice(nil)
+
+        XCTAssertEqual(appState.selectedAudioDeviceID, "")
+        XCTAssertEqual(appState.selectedAudioDeviceName, "")
+    }
+
     func testActivationModeDefault() {
         let (appState, _) = AppState.makeTestState()
 


### PR DESCRIPTION
## Problem
Users had to open Settings to change the microphone used for dictation from VocaMac.

## Demo
<img width="383" height="432" alt="Screenshot 2026-08-13 at 2 24 32 AM" src="https://github.com/user-attachments/assets/efee623a-61aa-402b-92f9-4a8022aa61b4" />
<img width="378" height="297" alt="Screenshot 2026-08-13 at 2 24 40 AM" src="https://github.com/user-attachments/assets/de0702bc-eda6-4a99-a2d8-39752c7bad8f" />


## Summary
- Add a microphone picker directly to the menu-bar popover.
- Support System Default, available devices, refresh, and unavailable-device status.
- Persist tray selections through AppState and keep Settings synchronized.
- Add regression coverage for selection persistence.

## Verification
- `swift test` — 359 tests passed, 3 skipped
- `make build` — succeeded with local ad-hoc signing
- `git diff --check` — passed