### PR TITLE
docs: add Discord and VocaHQ README shields

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@
 [![GitHub Issues](https://img.shields.io/github/issues/VocaHQ/vocamac)](https://github.com/VocaHQ/vocamac/issues)
 [![GitHub Stars](https://img.shields.io/github/stars/VocaHQ/vocamac?style=social)](https://github.com/VocaHQ/vocamac/stargazers)
 [![Twitter Follow](https://img.shields.io/twitter/follow/jatinkrmalik?style=social)](https://x.com/intent/user?screen_name=jatinkrmalik)
+[![Discord](https://img.shields.io/discord/1538633755877580810?logo=discord&logoColor=white&label=Discord)](https://discord.gg/UMJduhcqn)
+[![VocaHQ](https://img.shields.io/badge/VocaHQ-vocahq.com-1a7f4e)](https://vocahq.com)
 
 </div>
 


### PR DESCRIPTION
Adds two badges next to the existing README shields.

- Discord: live shields.io badge for guild 1538633755877580810. The badge links to https://discord.gg/UMJduhcqn so people can join. Online count shows once Server Widget is enabled on the Discord server.
- VocaHQ: links to https://vocahq.com for the rest of the product family.

README only.