### PR TITLE
docs: fix VocaHQ family links in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -550,9 +550,11 @@ VocaMac is the macOS member of the Voca family:
 
 | Platform | Project | Status |
 |----------|---------|--------|
-|  Linux | [VocaLinux](https://github.com/jatinkrmalik/vocalinux) | ✅ Available |
+|  Linux | [VocaLinux](https://github.com/VocaHQ/vocalinux) | ✅ Available |
 |  macOS | [VocaMac](https://github.com/VocaHQ/vocamac) | 🚀 Beta |
 | 🪟 Windows | [VocaWin](https://vocawin.com) | 📋 Planned |
+| 📱 Phone | [VocaPhone](https://vocaphone.vocahq.com) | Android beta / iOS source build |
+| 🔌 Gateway | [VocaGateway](https://github.com/VocaHQ/vocagateway) | Early |
 
 Each platform uses native technologies for the best possible integration, while sharing the same UX patterns and Whisper model family.
 
@@ -561,7 +563,7 @@ Each platform uses native technologies for the best possible integration, while 
 ## 🤝 Related Projects
 
 - [WhisperKit](https://github.com/argmaxinc/WhisperKit) - Swift native on-device speech recognition
-- [VocaLinux](https://github.com/jatinkrmalik/vocalinux) - Voice-to-text for Linux
+- [VocaLinux](https://github.com/VocaHQ/vocalinux) - Voice-to-text for Linux
 - [OpenAI Whisper](https://github.com/openai/whisper) - Original Whisper model
 
 ---


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

README still sent Linux (and the Related Projects list) to `jatinkrmalik/vocalinux`. The Cross-Platform family table was also missing VocaPhone and VocaGateway, which PRODUCT.md and vocahq.com already list.

## Changes

- Point VocaLinux at `VocaHQ/vocalinux` in Cross-Platform and Related Projects
- Add Phone (VocaPhone) and Gateway (VocaGateway) rows to the Cross-Platform table
- Keep old-tap migration notes for `jatinkrmalik/vocamac`
- Leave macOS 14+ and Beta labels alone

## Files touched

- `README.md`

## Out of scope

`web/` and the docs visitors hit already route the family through VocaHQ / vocahq.com. No leftover personal product-repo URLs there. Status label product calls (Stable vs Beta, macOS floor) stay for a separate PR.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fd3d2713-7cdc-4e0a-9e76-a7c58bc1ad89?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fd3d2713-7cdc-4e0a-9e76-a7c58bc1ad89&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

