### PR TITLE
docs(web): list nightly engines and models on the homepage

### DIFF
--- a/web/data/product.toml
+++ b/web/data/product.toml
@@ -5,7 +5,9 @@
 # Version/artifact figures were verified against the tagged v0.7.2 release.
 # Re-verify this file before publishing a website change.
 #
-# Verified: 2026-08-16 against v0.7.2 and PRODUCT.md.
+# Verified: 2026-08-17 against v0.7.2 (stable) and main @ 1b409b6 (nightly
+# models, from Sources/VocaMac/Models/WhisperModel.swift and
+# SherpaModelCatalog.swift).
 
 [stable]
 version = "0.7.2"
@@ -108,6 +110,72 @@ size = "3.1 GB"
 ram = "10 GB"
 quality = "Best"
 note = "Highest accuracy. Wants a 16 GB Mac and patience."
+
+# Additional engines and models shipped only in nightly builds from main
+# (Sources/VocaMac/Models/WhisperModel.swift ModelSize + SherpaModelCatalog.swift),
+# not in the v0.7.2 release above. size/note follow README.md's Models section.
+[[nightlyModels]]
+id = "parakeet-v3"
+name = "Parakeet v3"
+engine = "Parakeet"
+size = "0.7 GB"
+note = "Fastest engine. 25 European languages + Japanese, auto-detected."
+
+[[nightlyModels]]
+id = "parakeet-v2"
+name = "Parakeet v2"
+engine = "Parakeet"
+size = "1.2 GB"
+note = "Fastest engine. English only, highest recall."
+
+[[nightlyModels]]
+id = "parakeet-110m"
+name = "Parakeet 110M"
+engine = "Parakeet"
+size = "0.2 GB"
+note = "English only, smaller download and faster first load."
+
+[[nightlyModels]]
+id = "apple-speech"
+name = "Apple Speech"
+engine = "Apple Speech"
+size = "Managed by macOS"
+note = "macOS 26+ system engine (SpeechAnalyzer). Roughly 30 locales."
+
+[[nightlyModels]]
+id = "moonshine-v2-tiny"
+name = "Moonshine v2 Tiny"
+engine = "sherpa-onnx"
+size = "60 MB"
+note = "CPU-only. Very low-RAM Macs, English."
+
+[[nightlyModels]]
+id = "moonshine-v2-base"
+name = "Moonshine v2 Base"
+engine = "sherpa-onnx"
+size = "190 MB"
+note = "CPU-only. Low-RAM Macs, English."
+
+[[nightlyModels]]
+id = "sense-voice"
+name = "SenseVoice"
+engine = "sherpa-onnx"
+size = "240 MB"
+note = "CPU-only. Chinese, Japanese, Korean, Cantonese, English."
+
+[[nightlyModels]]
+id = "gigaam-v3"
+name = "GigaAM v3"
+engine = "sherpa-onnx"
+size = "270 MB"
+note = "CPU-only. Russian, with punctuation."
+
+[[nightlyModels]]
+id = "canary-180m-flash"
+name = "Canary 180M Flash"
+engine = "sherpa-onnx"
+size = "320 MB"
+note = "CPU-only. English, Spanish, German, French."
 
 [links]
 repo = "https://github.com/VocaHQ/vocamac"

--- a/web/layouts/index.html
+++ b/web/layouts/index.html
@@ -103,26 +103,50 @@
                 </div>
                 <div class="note note-nightly">
                     <h3>Nightly is a separate lane</h3>
-                    <p>The current shipping release is {{ $p.stable.tag }} ({{ $p.stable.status }}). New engine work may appear in nightly builds before it reaches a tagged release; check the release notes before choosing that path.</p>
+                    <p>The current shipping release is {{ $p.stable.tag }} ({{ $p.stable.status }}). Nightly builds from <code>main</code> add the engines and models in the second table before they reach a tagged release.</p>
+                    <div class="code-block" data-copy>
+                        <pre><code><span class="prompt">$ </span>{{ $p.nightly.cask }}</code></pre>
+                    </div>
+                    <p class="install-detail">Check the <a href="{{ $p.nightly.url }}">nightly release notes</a> before installing.</p>
                 </div>
             </div>
-            <div class="table-scroll">
-                <table class="model-table">
-                    <caption>WhisperKit models available in {{ $p.stable.tag }}</caption>
-                    <thead>
-                        <tr><th scope="col">Model</th><th scope="col">Download</th><th scope="col">RAM</th><th scope="col">Character</th></tr>
-                    </thead>
-                    <tbody>
-                        {{ range $p.models }}
-                        <tr>
-                            <th scope="row">{{ .name }}</th>
-                            <td>{{ .size }}</td>
-                            <td>{{ .ram }}</td>
-                            <td class="model-note">{{ .note }}</td>
-                        </tr>
-                        {{ end }}
-                    </tbody>
-                </table>
+            <div>
+                <div class="table-scroll">
+                    <table class="model-table">
+                        <caption>WhisperKit models available in {{ $p.stable.tag }}</caption>
+                        <thead>
+                            <tr><th scope="col">Model</th><th scope="col">Download</th><th scope="col">RAM</th><th scope="col">Character</th></tr>
+                        </thead>
+                        <tbody>
+                            {{ range $p.models }}
+                            <tr>
+                                <th scope="row">{{ .name }}</th>
+                                <td>{{ .size }}</td>
+                                <td>{{ .ram }}</td>
+                                <td class="model-note">{{ .note }}</td>
+                            </tr>
+                            {{ end }}
+                        </tbody>
+                    </table>
+                </div>
+                <div class="table-scroll table-scroll-nightly">
+                    <table class="model-table">
+                        <caption>Additional engines and models in nightly builds</caption>
+                        <thead>
+                            <tr><th scope="col">Model</th><th scope="col">Engine</th><th scope="col">Download</th><th scope="col">Note</th></tr>
+                        </thead>
+                        <tbody>
+                            {{ range $p.nightlyModels }}
+                            <tr>
+                                <th scope="row">{{ .name }}</th>
+                                <td>{{ .engine }}</td>
+                                <td>{{ .size }}</td>
+                                <td class="model-note">{{ .note }}</td>
+                            </tr>
+                            {{ end }}
+                        </tbody>
+                    </table>
+                </div>
             </div>
         </div>
     </div>
@@ -298,7 +322,7 @@
             <details><summary>Which Macs can run VocaMac?</summary><p>The current release supports {{ $p.requirements.os }} on {{ $p.requirements.arch }}. Intel Macs are not supported by the released arm64 build.</p></details>
             <details><summary>Why does VocaMac need permissions?</summary><p>Microphone access captures speech. Accessibility and Input Monitoring let the menu-bar app hear its configured shortcut and insert the resulting text into the app where you are working. Secure fields and individual apps can still restrict insertion.</p></details>
             <details><summary>Which model should I choose?</summary><p>Start with Small on an 8 GB Mac, then choose a compact Large or Distil variant when accuracy matters and your Mac has the headroom. Tiny and Base are useful when a smaller download or lower memory use matters more.</p></details>
-            <details><summary>What is available beyond Whisper?</summary><p>Additional engine work is currently shipped in nightly/source channels rather than the {{ $p.stable.tag }} release. Check the current release notes before installing a nightly build.</p></details>
+            <details><summary>What is available beyond Whisper?</summary><p>Nightly builds add three more engines: Parakeet (NVIDIA TDT models on the Apple Neural Engine, the fastest option), Apple Speech (the macOS 26+ system engine), and sherpa-onnx (CPU-only specialized models: Moonshine, SenseVoice, GigaAM v3, and Canary 180M Flash). These ship in nightly/source channels rather than the {{ $p.stable.tag }} release — see the nightly table above and check release notes before installing.</p></details>
         </div>
     </div>
 </section>

--- a/web/static/style.css
+++ b/web/static/style.css
@@ -722,6 +722,8 @@ a:hover > .btn-arrow-back { transform: translateX(-3px); }
   border-radius: var(--radius-md);
 }
 
+.table-scroll + .table-scroll { margin-top: 1.25rem; }
+
 .model-table {
   width: 100%;
   border-collapse: collapse;

--- a/web/tests/site.test.mjs
+++ b/web/tests/site.test.mjs
@@ -62,7 +62,10 @@ test("keeps the PRODUCT.md product boundary explicit", () => {
   assert.match(index, /WhisperKit/);
   assert.match(index, /model downloads/i);
   assert.match(index, /Beta/);
-  assert.match(index, /Additional engine work is currently shipped in nightly\/source channels/i);
+  assert.match(index, /Nightly builds add three more engines/i);
+  assert.match(index, /ship in nightly\/source channels/i);
+  assert.match(index, /Parakeet/);
+  assert.match(index, /sherpa-onnx/);
   assert.doesNotMatch(index, /Stable release/i);
   assert.doesNotMatch(index, /macOS 13/);
   assert.doesNotMatch(index, /Zero Network Calls/i);


### PR DESCRIPTION
## Summary
- The nightly note on the homepage only said "additional engine work" with no specifics, while `Sources/VocaMac/Models/WhisperModel.swift` and `SherpaModelCatalog.swift` (and `README.md`) already document real, current engines/models: Parakeet v3/v2/110M, Apple Speech, and the sherpa-onnx models (Moonshine Tiny/Base, SenseVoice, GigaAM v3, Canary 180M Flash).
- Add a `[[nightlyModels]]` table to `web/data/product.toml`, sourced from the code and cross-checked against README's model table.
- Render a second table on the homepage's Models section for these nightly-only engines, alongside the existing stable WhisperKit table.
- Surface the `brew install --cask vocamac-nightly` command, which existed in `product.toml` but was never actually rendered anywhere on the site, plus a link to the nightly release notes.
- Sharpen the "What is available beyond Whisper?" FAQ answer to name the engines instead of a vague placeholder.

## Test plan
- [x] `npm run check` in `web/` (Hugo build + all 9 site tests) passes
- [ ] Visual check of the new nightly table / note-nightly box on a real browser (not verified locally due to a Playwright/Chromium version mismatch in this environment)