### PR TITLE
Use a colon in public document titles

### DIFF
--- a/web/content/_index.md
+++ b/web/content/_index.md
@@ -1,5 +1,5 @@
 ---
-title: "VocaMac — native voice typing for macOS"
+title: "VocaMac: native voice typing for macOS"
 description: "Native voice typing for macOS. Hold a hotkey, speak, and text appears at your cursor — transcribed by a Whisper model running on your own Mac. Free and open source."
 keywords: "voice to text macOS, on-device dictation, speech to text mac, whisperkit, coreml speech recognition, push to talk mac, open source dictation, privacy voice typing, apple silicon voice recognition"
 ---

--- a/web/hugo.toml
+++ b/web/hugo.toml
@@ -1,6 +1,6 @@
 baseURL = "https://vocamac.com/"
 locale = "en-us"
-title = "VocaMac — native voice typing for macOS"
+title = "VocaMac: native voice typing for macOS"
 
 [params]
   description = "Native voice typing for macOS. Hold a hotkey, speak, and text appears at your cursor — transcribed by a Whisper model running on your own Mac. Free and open source."

--- a/web/layouts/partials/head.html
+++ b/web/layouts/partials/head.html
@@ -1,5 +1,5 @@
 {{- $p := hugo.Data.product -}}
-{{- $title := cond .IsHome "VocaMac — native voice typing for macOS, transcribed on your Mac" (printf "%s | VocaMac" .Title) -}}
+{{- $title := cond .IsHome "VocaMac: native voice typing for macOS" (printf "%s | VocaMac" .Title) -}}
 {{- $description := cond (ne .Params.description nil) .Params.description site.Params.description -}}
 {{- /* absURL, not a hardcoded domain string: a literal "https://vocamac.com/..."
    can't follow a --baseURL override, so a Netlify preview build kept
@@ -29,7 +29,7 @@
     <meta property="og:image:type" content="image/png">
     <meta property="og:image:width" content="1200">
     <meta property="og:image:height" content="630">
-    <meta property="og:image:alt" content="VocaMac — native voice typing for macOS">
+    <meta property="og:image:alt" content="VocaMac: native voice typing for macOS">
     <meta property="og:site_name" content="VocaMac">
     <meta property="og:locale" content="en_US">
 
@@ -38,7 +38,7 @@
     <meta name="twitter:title" content="{{ $title }}">
     <meta name="twitter:description" content="{{ $description }}">
     <meta name="twitter:image" content="{{ $ogImage }}">
-    <meta name="twitter:image:alt" content="VocaMac — native voice typing for macOS">
+    <meta name="twitter:image:alt" content="VocaMac: native voice typing for macOS">
     <meta name="twitter:creator" content="{{ site.Params.twitterHandle }}">
 
     <link rel="stylesheet" href="/style.css">

--- a/web/static/og-image.svg
+++ b/web/static/og-image.svg
@@ -1,5 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="1200" height="630" viewBox="0 0 1200 630" role="img" aria-labelledby="og-title og-desc">
-  <title id="og-title">VocaMac — native voice typing for macOS</title>
+  <title id="og-title">VocaMac: native voice typing for macOS</title>
   <desc id="og-desc">A warm paper card. On the left, the VocaMac lockup, the headline "Say it once. Your Mac types.", and the macOS 14+, Apple Silicon, v0.8.0 beta and AGPL-3.0 proof line. On the right, the menu-bar recording preview with an audio meter and a transcript landing at the cursor.</desc>
 
   <!-- Defs first: a forward reference to the dot pattern is what turned the

--- a/web/tests/site.test.mjs
+++ b/web/tests/site.test.mjs
@@ -36,7 +36,7 @@ function pngDimensions(buffer) {
 }
 
 test("renders a complete VocaMac homepage", () => {
-  assert.match(index, /<title>VocaMac — native voice typing for macOS, transcribed on your Mac<\/title>/);
+  assert.match(index, /<title>VocaMac: native voice typing for macOS<\/title>/);
   assert.equal((index.match(/<h1\b/g) ?? []).length, 1);
   assert.match(index, /<main id="main">/);
   assert.match(index, /class="skip-link" href="#main"/);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Public site titles still used an em dash. Linux already uses a colon, so the Mac site now matches.

The home document title is:

VocaMac: native voice typing for macOS

Same string for the browser tab, Open Graph, Twitter, hugo.toml, homepage front matter, and og image alt.

Body copy and Makefile comments are unchanged. macOS floor and product status are unchanged.

Validation: `cd web && npm run check` (9 tests passed).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-84be8cd0-adb4-41ff-8ef8-6e65d2e057d2?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-84be8cd0-adb4-41ff-8ef8-6e65d2e057d2&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

