### PR TITLE
Keep vocamac.com headlines sans-serif on Windows Chrome

### DIFF
--- a/web/content/features/github-release-updates.md
+++ b/web/content/features/github-release-updates.md
@@ -15,7 +15,7 @@ If you installed VocaMac via Homebrew (`brew install --cask vocamac`), updates a
 The check is lightweight and rate-limit friendly:
 
 - automatic check on launch (at most once every 24 hours)
-- manual **Check for Updates...** button in **Settings -> About**
+- manual **Check for Updates...** button in **Settings / About**
 - no extra account, login, or update service required
 
 ## Update Flow (DMG Installs)

--- a/web/static/style.css
+++ b/web/static/style.css
@@ -30,7 +30,10 @@
   --veil-14: rgba(207, 233, 220, 0.14);
   --veil-30: rgba(207, 233, 220, 0.3);
   --veil-45: rgba(207, 233, 220, 0.45);
-  --display: "Avenir Next", "SF Pro Display", "Helvetica Neue", ui-sans-serif, system-ui, sans-serif;
+  /* HQ display stack, plus Windows faces. SF Pro Display is gone: Windows
+     does not ship it, and a hole in Helvetica Neue italic used to dump
+     headings into Times New Roman. Segoe UI and Arial close that hole. */
+  --display: "Avenir Next", "Helvetica Neue", ui-sans-serif, system-ui, "Segoe UI", Arial, sans-serif;
   --body: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
   --mono: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Monaco, Consolas, monospace;
   --shell: min(1180px, calc(100% - 2rem));
@@ -57,7 +60,7 @@ body {
   color: var(--ink);
   background: var(--paper) url("/brand/paper-dots.svg") repeat;
   font-family: var(--body);
-  font-size: 1.0625rem;
+  font-size: 1rem;
   line-height: 1.65;
   text-rendering: optimizeLegibility;
   -webkit-font-smoothing: antialiased;
@@ -111,9 +114,15 @@ button, a { -webkit-tap-highlight-color: transparent; }
 h1, h2, h3, h4 {
   margin: 0;
   font-family: var(--display);
-  font-weight: 600;
+  font-weight: 760;
   line-height: 1.08;
-  letter-spacing: -0.025em;
+  letter-spacing: -0.04em;
+}
+
+/* em does not keep the heading stack when the user-agent italic face is
+   missing. Repeat the Windows-safe list so Chrome cannot fall to Times. */
+h1 em, h2 em, h3 em, h4 em {
+  font-family: var(--display);
 }
 
 p { margin: 0; }
@@ -351,7 +360,15 @@ a:hover > .btn-arrow-back { transform: translateX(-3px); }
 
 .hero h1 {
   max-width: 15ch;
-  font-size: clamp(2.6rem, 5.6vw, 4.4rem);
+  font-size: clamp(3.2rem, 7vw, 5.6rem);
+  font-weight: 780;
+  letter-spacing: -0.065em;
+  line-height: 1.02;
+}
+
+.hero h1 em {
+  font-family: var(--display);
+  font-style: normal;
 }
 
 .hero-lede {
@@ -1376,7 +1393,7 @@ details.source-install summary {
 
 .back-link:hover { text-decoration: underline; text-underline-offset: 0.18em; }
 
-.page-hero h1 { max-width: 22ch; font-size: clamp(2.1rem, 4.6vw, 3.2rem); }
+.page-hero h1 { max-width: 22ch; font-size: clamp(2.4rem, 5vw, 3.6rem); }
 .page-hero p { max-width: 60ch; margin-top: 1rem; color: var(--muted); }
 
 /* Article + sticky contents. The measure used to sit alone against a third of

--- a/web/static/style.css
+++ b/web/static/style.css
@@ -30,9 +30,10 @@
   --veil-14: rgba(207, 233, 220, 0.14);
   --veil-30: rgba(207, 233, 220, 0.3);
   --veil-45: rgba(207, 233, 220, 0.45);
-  /* HQ display stack, plus Windows faces. SF Pro Display is gone: Windows
-     does not ship it, and a hole in Helvetica Neue italic used to dump
-     headings into Times New Roman. Segoe UI and Arial close that hole. */
+  /* HQ display stack, plus Windows faces. The old Apple display name is
+     gone: Windows does not ship it, and a hole in Helvetica Neue italic
+     used to dump headings into Times New Roman. Segoe UI and Arial close
+     that hole. */
   --display: "Avenir Next", "Helvetica Neue", ui-sans-serif, system-ui, "Segoe UI", Arial, sans-serif;
   --body: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
   --mono: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Monaco, Consolas, monospace;

--- a/web/tests/site.test.mjs
+++ b/web/tests/site.test.mjs
@@ -109,6 +109,25 @@ test("keeps the visual and privacy boundaries flat", () => {
   assert.doesNotMatch(script, /api\.github\.com|fetch\(/i);
 });
 
+test("keeps Windows Chrome headlines on a real sans stack", () => {
+  assert.match(
+    css,
+    /--display:\s*"Avenir Next",\s*"Helvetica Neue",\s*ui-sans-serif,\s*system-ui,\s*"Segoe UI",\s*Arial,\s*sans-serif/,
+  );
+  assert.doesNotMatch(css, /SF Pro Display/);
+  assert.doesNotMatch(css, /@font-face/);
+  assert.doesNotMatch(css, /fonts\.google/);
+  assert.doesNotMatch(index, /fonts\.google|fonts\.gstatic|typekit|use\.typekit/i);
+
+  assert.match(css, /h1,\s*h2,\s*h3,\s*h4\s*\{[^}]*font-family:\s*var\(--display\)/);
+  assert.match(css, /h1,\s*h2,\s*h3,\s*h4\s*\{[^}]*font-weight:\s*760/);
+  assert.match(css, /h1 em,\s*h2 em,\s*h3 em,\s*h4 em\s*\{[^}]*font-family:\s*var\(--display\)/);
+  assert.match(css, /\.hero h1 em\s*\{[^}]*font-family:\s*var\(--display\)/);
+  assert.match(css, /\.hero h1 em\s*\{[^}]*font-style:\s*normal/);
+  assert.match(css, /\.hero h1\s*\{[^}]*font-weight:\s*780/);
+  assert.match(index, /<h1 id="hero-title">Say it once\.<br><em>Your Mac types\.<\/em><\/h1>/);
+});
+
 test("keeps content available without javascript", () => {
   assert.match(index, /<details[^>]+open/);
   assert.match(index, /<summary>Does my voice leave my Mac\?<\/summary>/);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Windows Chrome was showing the homepage headline in Times New Roman. The display stack named Avenir Next and SF Pro Display, which Windows does not have. Chrome then hit Helvetica Neue italic (often a broken local face) and fell to a serif.

`--display` now matches HQ: `Avenir Next`, `Helvetica Neue`, `ui-sans-serif`, `system-ui`. Segoe UI and Arial sit on the end so Windows has a real sans. SF Pro Display is gone. Headings and heading `em` set that stack themselves. The hero line "Your Mac types." no longer uses the user-agent italic face.

Display weight is 760, 780 on the hero H1, with tighter tracking and a larger H1. Body is 16px. No `@font-face` and no Google Fonts. Status stays Beta. No version bump. Tone picker is untouched.

The GitHub Release Updates page said `Settings -> About`. Latest html-validate rejects the raw `>`. That line is now `Settings / About` so the website job can stay green.

HQ reference: https://vocahq.com/styles.css?v=4 and the typography tokens in https://github.com/VocaHQ/vocahq/blob/main/web/DESIGN.md. `brand/README.md` §8 and `docs/website-design-standard.md` are not on vocahq `main`; DESIGN.md is what that repo publishes.

Local checks: `cd web && npm run check` (10 tests), stylelint, html-validate.

This is a new CSS PR, not #227.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4997b60f-e09c-45ff-841b-57b8ca9b8ca3?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4997b60f-e09c-45ff-841b-57b8ca9b8ca3&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

