### PR TITLE
Restore hero teal and HQ heading scale on vocamac.com

### DIFF
--- a/web/static/style.css
+++ b/web/static/style.css
@@ -19,6 +19,7 @@
   --line-dark: #9ea59f;
   --line-control: #5c7d71;
   --brand: #0f6b57;
+  --teal: var(--brand);
   --brand-dark: #0b493d;
   --brand-soft: #cfe9dc;
   --brand-softer: #e5f2eb;
@@ -117,7 +118,7 @@ h1, h2, h3, h4 {
   font-family: var(--display);
   font-weight: 760;
   line-height: 1.08;
-  letter-spacing: -0.04em;
+  letter-spacing: -0.065em;
 }
 
 /* em does not keep the heading stack when the user-agent italic face is
@@ -144,7 +145,10 @@ p { margin: 0; }
 
 .section-title {
   max-width: 20ch;
-  font-size: clamp(2.1rem, 4.6vw, 3.3rem);
+  font-size: clamp(2.2rem, 6vw, 4.7rem);
+  font-weight: 760;
+  letter-spacing: -0.065em;
+  line-height: 1.06;
 }
 
 .section-lede {
@@ -361,13 +365,14 @@ a:hover > .btn-arrow-back { transform: translateX(-3px); }
 
 .hero h1 {
   max-width: 15ch;
-  font-size: clamp(3.2rem, 7vw, 5.6rem);
+  font-size: clamp(3.7rem, 10vw, 7.4rem);
   font-weight: 780;
-  letter-spacing: -0.065em;
-  line-height: 1.02;
+  letter-spacing: -0.075em;
+  line-height: 0.92;
 }
 
 .hero h1 em {
+  color: var(--teal);
   font-family: var(--display);
   font-style: normal;
 }

--- a/web/tests/site.test.mjs
+++ b/web/tests/site.test.mjs
@@ -121,10 +121,19 @@ test("keeps Windows Chrome headlines on a real sans stack", () => {
 
   assert.match(css, /h1,\s*h2,\s*h3,\s*h4\s*\{[^}]*font-family:\s*var\(--display\)/);
   assert.match(css, /h1,\s*h2,\s*h3,\s*h4\s*\{[^}]*font-weight:\s*760/);
+  assert.match(css, /h1,\s*h2,\s*h3,\s*h4\s*\{[^}]*letter-spacing:\s*-0?\.065em/);
   assert.match(css, /h1 em,\s*h2 em,\s*h3 em,\s*h4 em\s*\{[^}]*font-family:\s*var\(--display\)/);
+  assert.match(css, /\.hero h1 em\s*\{[^}]*color:\s*var\(--teal\)/);
   assert.match(css, /\.hero h1 em\s*\{[^}]*font-family:\s*var\(--display\)/);
   assert.match(css, /\.hero h1 em\s*\{[^}]*font-style:\s*normal/);
+  assert.match(css, /\.hero h1\s*\{[^}]*font-size:\s*clamp\(3\.7rem,\s*10vw,\s*7\.4rem\)/);
   assert.match(css, /\.hero h1\s*\{[^}]*font-weight:\s*780/);
+  assert.match(css, /\.hero h1\s*\{[^}]*letter-spacing:\s*-0?\.075em/);
+  assert.match(css, /\.hero h1\s*\{[^}]*line-height:\s*0?\.92/);
+  assert.match(css, /\.section-title\s*\{[^}]*font-size:\s*clamp\(2\.2rem,\s*6vw,\s*4\.7rem\)/);
+  assert.match(css, /\.section-title\s*\{[^}]*font-weight:\s*760/);
+  assert.match(css, /\.section-title\s*\{[^}]*letter-spacing:\s*-0?\.065em/);
+  assert.match(css, /\.section-title\s*\{[^}]*line-height:\s*1\.06/);
   assert.match(index, /<h1 id="hero-title">Say it once\.<br><em>Your Mac types\.<\/em><\/h1>/);
 });
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
#228 closed the Windows serif hole. The homepage still reads unfinished next to vocahq.com. "Your Mac types." is ink, and the H1 and H2 clamps sit below HQ.

`.hero h1 em` is teal again (`var(--teal)`). It still uses the display stack and `font-style: normal`.

Hero H1 uses the HQ numbers: `clamp(3.7rem, 10vw, 7.4rem)`, weight 780, tracking `-0.075em`, line-height 0.92. Section titles use `clamp(2.2rem, 6vw, 4.7rem)`, weight 760, tracking `-0.065em`, line-height 1.06. Generic heading tracking is `-0.065em`. Body stays 16px / 1rem.

`--display` is the same stack from #228. vocamac does not have `.section-intro`, `.gateway-copy`, or `.principles-heading`, so those HQ em rules are not copied.

The Windows-sans test still covers the stack. It now also checks teal plus the new clamps. Website CI is green. App job skipped because this is CSS only.

Tone picker is untouched. Version stays 0.8.0.

![Desktop hero with teal Your Mac types and HQ heading scale](https://cursor.com/artifacts/c/art-b4fc0253-887d-43a3-a5b4-e48d15907758)
![Mobile hero with teal accent and 3.7rem clamp](https://cursor.com/artifacts/c/art-2e334c2a-a92b-4a44-a637-177279891b92)
![How it works section title at HQ H2 scale](https://cursor.com/artifacts/c/art-e5e1a4bf-8012-4b1a-a177-7762696eab96)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-69b24d7b-bb12-430a-85fd-178eca4c46d6?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-69b24d7b-bb12-430a-85fd-178eca4c46d6&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

