### PR TITLE
Point Discord and X community links at VocaHQ

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,8 +23,8 @@
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](https://github.com/VocaHQ/vocamac/pulls)
 [![GitHub Issues](https://img.shields.io/github/issues/VocaHQ/vocamac)](https://github.com/VocaHQ/vocamac/issues)
 [![GitHub Stars](https://img.shields.io/github/stars/VocaHQ/vocamac?style=social)](https://github.com/VocaHQ/vocamac/stargazers)
-[![Twitter Follow](https://img.shields.io/twitter/follow/jatinkrmalik?style=social)](https://x.com/intent/user?screen_name=jatinkrmalik)
-[![Discord](https://img.shields.io/discord/1538633755877580810?logo=discord&logoColor=white&label=Discord)](https://discord.gg/UMJduhcqn)
+[![Twitter Follow](https://img.shields.io/twitter/follow/vocahq?style=social)](https://x.com/vocahq)
+[![Discord](https://img.shields.io/discord/1538633755877580810?logo=discord&logoColor=white&label=Discord)](https://discord.gg/t6muquAJbm)
 [![VocaHQ](https://img.shields.io/badge/VocaHQ-vocahq.com-1a7f4e)](https://vocahq.com)
 
 </div>
@@ -614,5 +614,8 @@ AGPL-3.0 License - see [LICENSE](LICENSE) for details.
 <div align="center">
   
 Made with ❤️ for the macOS community!
+
+Join [Discord](https://discord.gg/t6muquAJbm) to talk with us, or follow
+[@vocahq](https://x.com/vocahq) on X.
 
 </div>

--- a/web/hugo.toml
+++ b/web/hugo.toml
@@ -5,7 +5,7 @@ title = "VocaMac: native voice typing for macOS"
 [params]
   description = "Native voice typing for macOS. Hold a hotkey, speak, and text appears at your cursor — transcribed by a Whisper model running on your own Mac. Free and open source."
   author = "Jatin Kumar Malik"
-  twitterHandle = "@jatinkrmalik"
+  twitterHandle = "@vocahq"
   githubRepo = "https://github.com/VocaHQ/vocamac"
   ogImagePath = "og-image.png"
 

--- a/web/layouts/partials/footer.html
+++ b/web/layouts/partials/footer.html
@@ -35,6 +35,8 @@
                 <ul>
                     <li><a href="{{ $p.links.repo }}">Source on GitHub</a></li>
                     <li><a href="{{ $p.links.issues }}">Issues</a></li>
+                    <li><a href="https://discord.gg/t6muquAJbm">Discord</a></li>
+                    <li><a href="https://x.com/vocahq">X @vocahq</a></li>
                     <li><a href="{{ $p.links.license }}">{{ $p.license.id }} licence</a></li>
                     <li><a href="{{ $p.links.vocahq }}">Part of the Voca family</a></li>
                 </ul>


### PR DESCRIPTION
## Why

We are standing up a shared VocaHQ community so contributors and testers can talk to us without waiting on GitHub issues. The old Discord invite is stale.

## What changed

- Discord invite is now https://discord.gg/t6muquAJbm
- X / Twitter follow shields and public follow links now point at [@vocahq](https://x.com/vocahq) instead of @jatinkrmalik
- Discord is also in contributing/support docs and site footers where people look for help

Personal GitHub credits, old Homebrew tap names, and maintainer emails are unchanged.

## Review

Please approve and merge if the invite and @vocahq handle look right.

Touched: README badges, vocamac.com footer, twitter:creator handle.