### PR TITLE
Fix microphone reliability and device selection

### DIFF
--- a/Sources/VocaMac/Models/AppState.swift
+++ b/Sources/VocaMac/Models/AppState.swift
@@ -905,7 +905,10 @@ final class AppState: ObservableObject {
         errorMessage = nil
         inputDeviceFallbackNotice = nil
 
-        // Show the configured recording overlay.
+        // Show the overlay in its connecting state. It only claims to be
+        // listening once the audio engine confirms the route is live — on
+        // Bluetooth that can be seconds later, and anything said before then is
+        // not captured by anyone.
         if showCursorIndicator && overlayStyle != .off {
             cursorOverlay.show(style: overlayStyle, position: overlayPosition)
         }
@@ -946,6 +949,8 @@ final class AppState: ObservableObject {
             showTemporaryError("Could not start \(deviceDescription). Pick a different input in Settings → Audio, or reconnect the device.")
             return
         }
+
+        cursorOverlay.transitionToRecording()
 
         // Play start sound after mic is active (fire-and-forget).
         // Off is a stored tone and stays silent even when this switch is on.

--- a/Sources/VocaMac/Models/AppState.swift
+++ b/Sources/VocaMac/Models/AppState.swift
@@ -155,6 +155,10 @@ final class AppState: ObservableObject {
     /// True while a configured auto-pause app is running and dictation is blocked.
     @Published var isAutoPaused: Bool = false
 
+    /// Set when the last recording could not use the pinned microphone.
+    /// Cleared when a recording starts on the requested device.
+    @Published var inputDeviceFallbackNotice: String?
+
     /// Last reason the speech model was unloaded (nil while a model is loaded).
     @Published var lastModelUnloadReason: ModelUnloadReason?
 
@@ -467,6 +471,17 @@ final class AppState: ObservableObject {
             }
         }
 
+        // The pinned microphone could not be configured and recording fell back
+        // to another device. Surface it so the user isn't left wondering why the
+        // transcript came from the built-in mic.
+        audioEngine.onInputDeviceFallback = { [weak self] notice in
+            Task { @MainActor in
+                guard let self else { return }
+                VocaLogger.warning(.appState, notice)
+                self.inputDeviceFallbackNotice = notice
+            }
+        }
+
         // Setup hotkey callbacks
         hotKeyManager.onRecordingStart = { [weak self] in
             Task { @MainActor in
@@ -592,6 +607,9 @@ final class AppState: ObservableObject {
         autoPauseMonitor.start()
         modelKeepAlive.start()
         sleepWakeMonitor.start()
+        if !skipSystemIntegration {
+            AudioDeviceMonitor.shared.start()
+        }
     }
 
     /// Unload the resident model and clear active UI flags.
@@ -869,6 +887,7 @@ final class AppState: ObservableObject {
         appStatus = .recording
         isRecording = true
         errorMessage = nil
+        inputDeviceFallbackNotice = nil
 
         // Show the configured recording overlay.
         if showCursorIndicator && overlayStyle != .off {
@@ -891,7 +910,12 @@ final class AppState: ObservableObject {
             audioLevel = 0.0
             cursorOverlay.hide()
             hotKeyManager.resetKeyState()
-            appStatus = .idle
+            // Silently dropping back to idle looks like the hotkey did nothing.
+            // Tell the user which microphone we tried and where to change it.
+            let deviceDescription = selectedAudioDeviceName.isEmpty
+                ? "the system default microphone"
+                : selectedAudioDeviceName
+            showTemporaryError("Could not start \(deviceDescription). Pick a different input in Settings → Audio, or reconnect the device.")
             return
         }
 

--- a/Sources/VocaMac/Models/AppState.swift
+++ b/Sources/VocaMac/Models/AppState.swift
@@ -1483,6 +1483,12 @@ final class AppState: ObservableObject {
     }
 
     func performStartup() async {
+        // `vocamac.logLevel` was stored but never applied, so the level was
+        // pinned at .info and every VocaLogger.debug call — including the
+        // input-route tracing that explains a failed start — was discarded.
+        if let level = LogLevel(rawValue: logLevel.uppercased()) {
+            VocaLogger.setLogLevel(level)
+        }
         VocaLogger.info(.appState, "performStartup beginning...")
 
         // 1. Detect hardware

--- a/Sources/VocaMac/Models/AppState.swift
+++ b/Sources/VocaMac/Models/AppState.swift
@@ -159,6 +159,22 @@ final class AppState: ObservableObject {
     /// Cleared when a recording starts on the requested device.
     @Published var inputDeviceFallbackNotice: String?
 
+    /// True while the audio engine is negotiating its input route. Bluetooth
+    /// headsets can take seconds to switch to their microphone, and a stop
+    /// arriving in that window has to be deferred rather than blocked on.
+    private var isStartingAudio = false
+
+    /// How to finish a start that the user interrupted while it was still
+    /// negotiating the route.
+    private var pendingStopDuringStart: PendingStopKind?
+
+    private enum PendingStopKind {
+        /// Push-to-talk released: keep whatever the engine managed to capture.
+        case transcribe
+        /// Overlay cancel: throw the recording away.
+        case discard
+    }
+
     /// Last reason the speech model was unloaded (nil while a model is loaded).
     @Published var lastModelUnloadReason: ModelUnloadReason?
 
@@ -897,12 +913,24 @@ final class AppState: ObservableObject {
         // Start recording immediately for instant responsiveness.
         // The start sound is played concurrently — any brief bleed into the
         // mic buffer is negligible and handled well by WhisperKit's noise model.
+        isStartingAudio = true
+        pendingStopDuringStart = nil
         let didStartRecording = await startAudioEngine(
             silenceThreshold: Float(silenceThreshold),
             silenceDuration: silenceDuration,
             maxDuration: TimeInterval(maxRecordingDuration),
             preferredInputDeviceID: selectedAudioDeviceID.isEmpty ? nil : selectedAudioDeviceID
         )
+        isStartingAudio = false
+
+        // The hotkey was released (or the overlay cancelled) while the route was
+        // still coming up. That stop was deferred so it wouldn't block behind the
+        // Bluetooth settle; finish it now.
+        if let pendingStop = pendingStopDuringStart {
+            pendingStopDuringStart = nil
+            await finishStartInterruptedByStop(pendingStop, didStartRecording: didStartRecording)
+            return
+        }
 
         guard didStartRecording else {
             VocaLogger.warning(.appState, "Audio engine failed to start — resetting recording state")
@@ -931,6 +959,17 @@ final class AppState: ObservableObject {
         // it's recording (covers stuck-state recovery scenarios where
         // isRecording and appStatus may be out of sync).
         guard isRecording || appStatus == .recording else { return }
+
+        // A start that is still negotiating its input route holds the audio
+        // engine's lifecycle queue. Calling stopRecording() here would block the
+        // hotkey path for the whole Bluetooth settle and then hand back an empty
+        // buffer — the "No microphone audio detected" report. Ask the engine to
+        // abandon the start instead and let startRecording() finish up.
+        if isStartingAudio {
+            pendingStopDuringStart = .transcribe
+            audioEngine.cancelPendingStart()
+            return
+        }
 
         let audioData = await stopAudioEngine()
         isRecording = false
@@ -1022,6 +1061,12 @@ final class AppState: ObservableObject {
     func cancelRecording() async {
         guard isRecording || appStatus == .recording else { return }
 
+        if isStartingAudio {
+            pendingStopDuringStart = .discard
+            audioEngine.cancelPendingStart()
+            return
+        }
+
         _ = await stopAudioEngine()
         isRecording = false
         audioLevel = 0.0
@@ -1030,6 +1075,40 @@ final class AppState: ObservableObject {
         appStatus = .idle
         errorMessage = nil
         VocaLogger.info(.appState, "Recording cancelled from overlay")
+    }
+
+    /// Completes a recording the user ended while the microphone was still
+    /// connecting. If the engine never reached the capture stage there is
+    /// nothing to transcribe — no audio existed before the route came up — so
+    /// say so plainly instead of reporting a mysterious silent recording.
+    private func finishStartInterruptedByStop(
+        _ kind: PendingStopKind,
+        didStartRecording: Bool
+    ) async {
+        guard didStartRecording else {
+            VocaLogger.info(.appState, "Recording ended while the microphone was still connecting")
+            isRecording = false
+            audioLevel = 0.0
+            cursorOverlay.hide()
+            hotKeyManager.resetKeyState()
+
+            switch kind {
+            case .discard:
+                appStatus = .idle
+                errorMessage = nil
+            case .transcribe:
+                showTemporaryError("The microphone was still connecting, so nothing was recorded. Bluetooth headsets need a moment — hold the hotkey until the start sound, then speak.")
+            }
+            return
+        }
+
+        // The route came up just as the user let go; treat it as a normal end.
+        switch kind {
+        case .transcribe:
+            await stopRecordingAndTranscribe()
+        case .discard:
+            await cancelRecording()
+        }
     }
 
     private func startAudioEngine(

--- a/Sources/VocaMac/Services/AudioDeviceMonitor.swift
+++ b/Sources/VocaMac/Services/AudioDeviceMonitor.swift
@@ -1,0 +1,110 @@
+// AudioDeviceMonitor.swift
+// VocaMac
+//
+// Watches Core Audio for input-device hot-plug and default-input changes.
+
+import Foundation
+import CoreAudio
+
+extension Notification.Name {
+    /// Posted on the main queue when the set of audio input devices, or the
+    /// system default input, changes.
+    static let vocaAudioDevicesChanged = Notification.Name("com.vocamac.audioDevicesChanged")
+}
+
+/// Keeps the microphone pickers honest. Without this, the device list is only
+/// rebuilt when a view appears, so a headset connected (or removed) while the
+/// menu or Settings window is open leaves the user picking from a stale list —
+/// or staring at a device that is no longer there.
+final class AudioDeviceMonitor {
+
+    static let shared = AudioDeviceMonitor()
+
+    /// Bluetooth profile switches fire several property changes in a row;
+    /// coalesce them so the pickers rebuild once.
+    static let coalesceInterval: TimeInterval = 0.3
+
+    private static let observedSelectors: [AudioObjectPropertySelector] = [
+        kAudioHardwarePropertyDevices,
+        kAudioHardwarePropertyDefaultInputDevice,
+    ]
+
+    private let queue = DispatchQueue(label: "com.vocamac.audio-device-monitor")
+    private var listenerBlock: AudioObjectPropertyListenerBlock?
+    private var isRunning = false
+    private var pendingNotification: DispatchWorkItem?
+
+    func start() {
+        queue.sync {
+            guard !isRunning else { return }
+
+            let block: AudioObjectPropertyListenerBlock = { [weak self] _, _ in
+                self?.scheduleNotification()
+            }
+            listenerBlock = block
+
+            var added = 0
+            for selector in Self.observedSelectors {
+                var address = Self.address(for: selector)
+                let status = AudioObjectAddPropertyListenerBlock(
+                    AudioObjectID(kAudioObjectSystemObject),
+                    &address,
+                    queue,
+                    block
+                )
+                if status == noErr {
+                    added += 1
+                } else {
+                    VocaLogger.warning(.audioEngine, "Failed to observe Core Audio property \(selector): OSStatus \(status)")
+                }
+            }
+
+            isRunning = added > 0
+            if isRunning {
+                VocaLogger.debug(.audioEngine, "Audio device monitor started")
+            } else {
+                listenerBlock = nil
+            }
+        }
+    }
+
+    func stop() {
+        queue.sync {
+            guard isRunning, let listenerBlock else { return }
+
+            for selector in Self.observedSelectors {
+                var address = Self.address(for: selector)
+                AudioObjectRemovePropertyListenerBlock(
+                    AudioObjectID(kAudioObjectSystemObject),
+                    &address,
+                    queue,
+                    listenerBlock
+                )
+            }
+
+            self.listenerBlock = nil
+            isRunning = false
+            pendingNotification?.cancel()
+            pendingNotification = nil
+        }
+    }
+
+    /// Must be called on `queue` (Core Audio delivers listener blocks there).
+    private func scheduleNotification() {
+        pendingNotification?.cancel()
+
+        let workItem = DispatchWorkItem {
+            NotificationCenter.default.post(name: .vocaAudioDevicesChanged, object: nil)
+        }
+        pendingNotification = workItem
+        DispatchQueue.main.asyncAfter(deadline: .now() + Self.coalesceInterval, execute: workItem)
+    }
+
+    private static func address(for selector: AudioObjectPropertySelector) -> AudioObjectPropertyAddress {
+        AudioObjectPropertyAddress(
+            mSelector: selector,
+            mScope: kAudioObjectPropertyScopeGlobal,
+            mElement: kAudioObjectPropertyElementMain
+        )
+    }
+}

--- a/Sources/VocaMac/Services/AudioEngine.swift
+++ b/Sources/VocaMac/Services/AudioEngine.swift
@@ -8,6 +8,7 @@ import Foundation
 import AVFoundation
 import AudioToolbox
 import CoreAudio
+import os
 import VocaMacObjC
 
 final class AudioEngine {
@@ -23,6 +24,14 @@ final class AudioEngine {
     private var pendingEngineRelease: DispatchWorkItem?
     private var audioBuffer: [Float] = []
     private var _isCurrentlyRecording = false
+    /// Realtime-safe mirror of `_isCurrentlyRecording` for the input tap.
+    ///
+    /// The tap runs on Core Audio's render thread and must never wait on
+    /// `lifecycleQueue`: `stopRecording` holds that queue while `engine.stop()`
+    /// waits for the render thread to finish, so a tap that blocks on the queue
+    /// deadlocks the audio graph — and with it the app, because AppState waits
+    /// on `stopRecording`.
+    private let captureActive = OSAllocatedUnfairLock(initialState: false)
     private var configuredInputDeviceID: AudioDeviceID?
     /// Last UID passed to `startRecording`, used to rebuild the graph after a
     /// configuration change without dropping the user's selected microphone.
@@ -89,6 +98,10 @@ final class AudioEngine {
     /// (mic unplugged, Bluetooth disconnect, or a failed in-place restart).
     /// AppState should use this to recover from a stuck recording state.
     var onAudioDeviceChanged: (() -> Void)?
+
+    /// Called when the pinned microphone could not be configured and recording
+    /// continued on another device. The argument is a user-facing sentence.
+    var onInputDeviceFallback: ((String) -> Void)?
 
     // MARK: - Initialization
 
@@ -217,7 +230,7 @@ final class AudioEngine {
                 }
 
                 VocaLogger.warning(.audioEngine, "Failed to restart audio graph after configuration change")
-                self._isCurrentlyRecording = false
+                self.setRecordingActive(false)
                 self.silenceCallbackFired = false
                 self.maxDurationCallbackFired = false
                 self.removeInputTap(reason: "audio configuration change")
@@ -378,6 +391,12 @@ final class AudioEngine {
                 // fresh one; otherwise AVAudioEngine raises an uncaught NSException.
                 removeInputTap(reason: "pre-start cleanup")
 
+                // Keep buffers from the moment the graph starts. The recording
+                // flag is only set once the start is confirmed, and the first
+                // buffers arrive before that — dropping them clips the start of
+                // short push-to-talk utterances. Failure paths clear the buffer.
+                setCaptureActive(true)
+
                 var startError: Error?
                 let exception = VocaObjCExceptionCatcher.catchException { [weak self] in
                     guard let self = self else { return }
@@ -428,7 +447,7 @@ final class AudioEngine {
                 // actually begins, not the start of Bluetooth route settling.
                 recordingStartTime = Date()
                 lastSoundTime = Date()
-                _isCurrentlyRecording = true
+                setRecordingActive(true)
                 return true
             }
 
@@ -442,7 +461,7 @@ final class AudioEngine {
         lifecycleQueue.sync {
             guard _isCurrentlyRecording else { return [] }
 
-            _isCurrentlyRecording = false
+            setRecordingActive(false)
             removeInputTap(reason: "stop recording")
             engine?.stop()
 
@@ -465,7 +484,7 @@ final class AudioEngine {
         lifecycleQueue.sync {
             VocaLogger.warning(.audioEngine, "Force reset requested (wasRecording=\(_isCurrentlyRecording))")
 
-            _isCurrentlyRecording = false
+            setRecordingActive(false)
             silenceCallbackFired = false
             maxDurationCallbackFired = false
 
@@ -491,6 +510,19 @@ final class AudioEngine {
         recordingStartTime = Date()
         silenceCallbackFired = false
         maxDurationCallbackFired = false
+    }
+
+    /// Updates the recording flag and its realtime-safe mirror together.
+    /// Must be called on `lifecycleQueue`.
+    private func setRecordingActive(_ active: Bool) {
+        _isCurrentlyRecording = active
+        captureActive.withLock { $0 = active }
+    }
+
+    /// Lets the input tap keep audio before `_isCurrentlyRecording` flips, so
+    /// the first buffers after `engine.start()` are not thrown away.
+    private func setCaptureActive(_ active: Bool) {
+        captureActive.withLock { $0 = active }
     }
 
     private func setIsPreparingRecording(_ isPreparing: Bool) {
@@ -542,6 +574,8 @@ final class AudioEngine {
         inputNode: AVAudioInputNode,
         inputFormat: AVAudioFormat
     ) -> String? {
+        // Capture from the first buffer; see the note in `startRecording`.
+        setCaptureActive(true)
         var startError: Error?
         let exception = VocaObjCExceptionCatcher.catchException { [weak self] in
             guard let self else { return }
@@ -569,7 +603,7 @@ final class AudioEngine {
 
     /// Restores AudioEngine to a clean idle state after any failed start attempt.
     private func recoverFromStartFailure(notifyAppState: Bool) {
-        _isCurrentlyRecording = false
+        setRecordingActive(false)
         silenceCallbackFired = false
         maxDurationCallbackFired = false
         removeInputTap(reason: "start failure")
@@ -706,7 +740,10 @@ final class AudioEngine {
 
     /// Process an incoming audio buffer from AVAudioEngine
     private func processAudioBuffer(_ buffer: AVAudioPCMBuffer, inputFormat: AVAudioFormat) {
-        guard isCurrentlyRecording else { return }
+        // Deliberately not `isCurrentlyRecording`: that reads through
+        // `lifecycleQueue.sync`, which deadlocks the render thread. See
+        // `captureActive`.
+        guard captureActive.withLock({ $0 }) else { return }
 
         // Convert to whisper format (16kHz, mono, Float32)
         guard let convertedBuffer = convertToWhisperFormat(buffer, from: inputFormat) else {
@@ -868,13 +905,9 @@ final class AudioEngine {
         let requestedDeviceID = requestedUID.flatMap(Self.inputAudioDeviceID(forUID:))
         let defaultDeviceID = Self.defaultInputAudioDeviceID()
 
-        if let requestedUID, !requestedUID.isEmpty, requestedDeviceID == nil {
+        let requestedDeviceMissing = (requestedUID?.isEmpty == false) && requestedDeviceID == nil
+        if requestedDeviceMissing, let requestedUID {
             VocaLogger.warning(.audioEngine, "Preferred input device unavailable, falling back to system default: \(requestedUID)")
-        }
-
-        guard let targetDeviceID = requestedDeviceID ?? defaultDeviceID else {
-            VocaLogger.warning(.audioEngine, "No input device is available")
-            return nil
         }
 
         guard let audioUnit = inputNode.audioUnit else {
@@ -882,6 +915,70 @@ final class AudioEngine {
             return nil
         }
 
+        let candidates = Self.inputRouteCandidates(
+            requestedDeviceID: requestedDeviceID,
+            defaultDeviceID: defaultDeviceID
+        )
+        guard !candidates.isEmpty else {
+            VocaLogger.warning(.audioEngine, "No input device is available")
+            return nil
+        }
+
+        // Core Audio refuses a specific device more often than one would like —
+        // a Bluetooth headset mid-profile-switch, a device another app holds, a
+        // USB mic that just re-enumerated. Failing the whole start there is what
+        // users experience as "the mic just doesn't work", so fall back to the
+        // system default rather than recording nothing.
+        for (index, candidate) in candidates.enumerated() {
+            if let resolved = applyInputRoute(
+                targetDeviceID: candidate,
+                engine: engine,
+                audioUnit: audioUnit
+            ) {
+                if index > 0 || requestedDeviceMissing {
+                    let requestedName = requestedDeviceMissing
+                        ? "The selected microphone"
+                        : (Self.audioDeviceName(for: candidates[0]) ?? "The selected microphone")
+                    let resolvedName = Self.audioDeviceName(for: resolved) ?? "system default"
+                    VocaLogger.warning(
+                        .audioEngine,
+                        "Could not configure \(requestedName); recording from \(resolvedName) instead"
+                    )
+                    let fallbackNotice = "\(requestedName) is unavailable — recording from \(resolvedName)."
+                    DispatchQueue.main.async { [weak self] in
+                        self?.onInputDeviceFallback?(fallbackNotice)
+                    }
+                }
+                return resolved
+            }
+        }
+
+        return nil
+    }
+
+    /// Ordered input devices to try: the pinned microphone first, then the
+    /// system default. Duplicates are collapsed so a pinned default device is
+    /// only attempted once.
+    static func inputRouteCandidates(
+        requestedDeviceID: AudioDeviceID?,
+        defaultDeviceID: AudioDeviceID?
+    ) -> [AudioDeviceID] {
+        var candidates: [AudioDeviceID] = []
+        for candidate in [requestedDeviceID, defaultDeviceID] {
+            guard let candidate, !candidates.contains(candidate) else { continue }
+            candidates.append(candidate)
+        }
+        return candidates
+    }
+
+    /// Points the input unit at one specific device and waits for Core Audio to
+    /// honour it. Returns the device actually in use (which may be a Bluetooth
+    /// HFP sibling of the request), or `nil` when the route could not be applied.
+    private func applyInputRoute(
+        targetDeviceID: AudioDeviceID,
+        engine: AVAudioEngine,
+        audioUnit: AudioUnit
+    ) -> AudioDeviceID? {
         let isBluetoothTarget = Self.isBluetoothDevice(targetDeviceID)
         let routeTimeout = Self.inputRouteTimeout(isBluetooth: isBluetoothTarget)
         let currentDeviceID = Self.currentInputDeviceID(for: audioUnit)
@@ -909,7 +1006,7 @@ final class AudioEngine {
                     return settledDeviceID
                 }
             }
-            let deviceName = Self.audioDeviceName(for: targetDeviceID) ?? requestedUID ?? "system default"
+            let deviceName = Self.audioDeviceName(for: targetDeviceID) ?? "system default"
             VocaLogger.debug(.audioEngine, "Input device already configured: \(deviceName)")
             return targetDeviceID
         }
@@ -1015,7 +1112,7 @@ final class AudioEngine {
             Self.waitForBluetoothHFPIfNeeded(deviceID: resolvedDeviceID, timeout: routeTimeout)
         }
 
-        let deviceName = Self.audioDeviceName(for: resolvedDeviceID) ?? requestedUID ?? "system default"
+        let deviceName = Self.audioDeviceName(for: resolvedDeviceID) ?? "system default"
         VocaLogger.info(.audioEngine, "Using input device: \(deviceName)")
         return resolvedDeviceID
     }

--- a/Sources/VocaMac/Services/AudioEngine.swift
+++ b/Sources/VocaMac/Services/AudioEngine.swift
@@ -36,6 +36,15 @@ final class AudioEngine {
     /// the input route is still being negotiated. Read from the settle loops,
     /// which run inside `lifecycleQueue` — so this cannot live behind that queue.
     private let startCancelled = OSAllocatedUnfairLock(initialState: false)
+    /// Set by the input tap the first time Core Audio hands us a buffer.
+    ///
+    /// `engine.isRunning` only says the graph started, not that the HAL actually
+    /// opened an input stream on the configured device. USB headsets (Apple's
+    /// USB-C EarPods among them) can report a fully applied route and a running
+    /// engine while never pulling a single input buffer, which surfaces as a
+    /// recording that silently transcribes nothing. Written from the render
+    /// thread, so it must be lock-free like `captureActive`.
+    private let firstBufferSeen = OSAllocatedUnfairLock(initialState: false)
     private var configuredInputDeviceID: AudioDeviceID?
     /// Last UID passed to `startRecording`, used to rebuild the graph after a
     /// configuration change without dropping the user's selected microphone.
@@ -52,6 +61,11 @@ final class AudioEngine {
     /// HFP/SCO typically runs at 8/16/24 kHz; A2DP stays at 44.1/48 kHz.
     static let bluetoothHFPSampleRateThreshold: Double = 44100
     static let startupConfigurationChangeRecoveryWindow: TimeInterval = 1.0
+    /// How long to wait for the input tap's first buffer before declaring the
+    /// route dead. One 4096-frame buffer is ~85ms at 48kHz and ~256ms at 16kHz,
+    /// so this leaves room for a slow first pull without stranding the user.
+    static let firstInputBufferTimeout: TimeInterval = 0.75
+    static let firstInputBufferPollInterval: TimeInterval = 0.01
     static let idleEngineReleaseDelay: TimeInterval = 3.0
 
     var isCurrentlyRecording: Bool {
@@ -311,7 +325,22 @@ final class AudioEngine {
             return false
         }
 
-        return engine.isRunning
+        guard engine.isRunning else { return false }
+
+        // Same trap as a cold start: the rebuilt graph can run without the HAL
+        // ever opening an input stream. Treat that as a failed restart so the
+        // caller tears down and tells AppState, instead of leaving the user
+        // recording into nothing for the rest of the utterance.
+        guard waitForFirstInputBuffer() else {
+            VocaLogger.warning(
+                .audioEngine,
+                "Audio graph restarted but no input arrived within \(Self.firstInputBufferTimeout)s"
+            )
+            removeInputTap(reason: "silent restart")
+            return false
+        }
+
+        return true
     }
 
     // MARK: - Permission Handling
@@ -433,6 +462,11 @@ final class AudioEngine {
                 // fresh one; otherwise AVAudioEngine raises an uncaught NSException.
                 removeInputTap(reason: "pre-start cleanup")
 
+                VocaLogger.info(
+                    .audioEngine,
+                    "Installing input tap: \(inputFormat.sampleRate)Hz, \(inputFormat.channelCount)ch"
+                )
+
                 // Keep buffers from the moment the graph starts. The recording
                 // flag is only set once the start is confirmed, and the first
                 // buffers arrive before that — dropping them clips the start of
@@ -485,6 +519,28 @@ final class AudioEngine {
                     return false
                 }
 
+                // A running engine on an applied route still isn't capture. Wait
+                // for a real buffer before telling AppState the mic is live —
+                // otherwise the user talks into a route that never opened and
+                // gets back an empty recording with no indication why.
+                guard waitForFirstInputBuffer() else {
+                    if isStartCancelled {
+                        return abandonCancelledStart()
+                    }
+                    let deviceName = Self.audioDeviceName(for: configuredInputDeviceID) ?? "the input device"
+                    VocaLogger.warning(
+                        .audioEngine,
+                        "No audio arrived from \(deviceName) within \(Self.firstInputBufferTimeout)s of starting (attempt \(attempt)); the route applied but Core Audio never opened an input stream"
+                    )
+                    // Drops the engine entirely, so the retry cold-acquires a
+                    // fresh AUHAL rather than reusing the stuck one.
+                    recoverFromStartFailure(notifyAppState: false)
+                    if attempt == 1 {
+                        continue
+                    }
+                    return false
+                }
+
                 // Anchor max-duration / startup recovery to the moment capture
                 // actually begins, not the start of Bluetooth route settling.
                 recordingStartTime = Date()
@@ -508,6 +564,11 @@ final class AudioEngine {
             engine?.stop()
 
             let samples = capturedSamplesAndResetBuffer()
+            let duration = Double(samples.count) / Self.whisperFormat.sampleRate
+            VocaLogger.info(
+                .audioEngine,
+                "Captured \(samples.count) samples (\(String(format: "%.2f", duration))s)"
+            )
 
             // Keep the stopped engine briefly so rapid push-to-talk recordings
             // don't cold-reacquire a silent input route, then release it so we
@@ -564,7 +625,26 @@ final class AudioEngine {
     /// Lets the input tap keep audio before `_isCurrentlyRecording` flips, so
     /// the first buffers after `engine.start()` are not thrown away.
     private func setCaptureActive(_ active: Bool) {
+        if active {
+            firstBufferSeen.withLock { $0 = false }
+        }
         captureActive.withLock { $0 = active }
+    }
+
+    /// Blocks until the input tap delivers its first buffer, or the timeout
+    /// expires. A running engine on an applied route is not proof that Core
+    /// Audio opened an input stream; only a delivered buffer is.
+    /// Must be called on `lifecycleQueue`.
+    private func waitForFirstInputBuffer(
+        timeout: TimeInterval = firstInputBufferTimeout
+    ) -> Bool {
+        let deadline = Date().addingTimeInterval(timeout)
+        while Date() < deadline {
+            if firstBufferSeen.withLock({ $0 }) { return true }
+            if isStartCancelled { return false }
+            Thread.sleep(forTimeInterval: Self.firstInputBufferPollInterval)
+        }
+        return firstBufferSeen.withLock { $0 }
     }
 
     private func setIsPreparingRecording(_ isPreparing: Bool) {
@@ -616,6 +696,10 @@ final class AudioEngine {
         inputNode: AVAudioInputNode,
         inputFormat: AVAudioFormat
     ) -> String? {
+        VocaLogger.info(
+            .audioEngine,
+            "Installing input tap: \(inputFormat.sampleRate)Hz, \(inputFormat.channelCount)ch"
+        )
         // Capture from the first buffer; see the note in `startRecording`.
         setCaptureActive(true)
         var startError: Error?
@@ -647,14 +731,22 @@ final class AudioEngine {
     ///
     /// Unlike a failed start, the engine is kept for the idle window: the route
     /// it just negotiated is the expensive part, and someone who released too
-    /// early is about to press again. No tap is installed on these paths, so
-    /// there is nothing to stop — only state to clear.
+    /// early is about to press again.
+    ///
+    /// A cancel can land either side of `engine.start()` — the route settle runs
+    /// before it, the first-buffer wait after — so the engine may or may not be
+    /// running here. Stop it when it is: `releaseEngine()` only drops the
+    /// reference and would otherwise leave a live engine holding the input
+    /// route (and Bluetooth headsets pinned to HFP) until ARC got to it.
     /// Must be called on `lifecycleQueue`.
     private func abandonCancelledStart() -> Bool {
         setRecordingActive(false)
         silenceCallbackFired = false
         maxDurationCallbackFired = false
         removeInputTap(reason: "cancelled start")
+        if engine?.isRunning == true {
+            engine?.stop()
+        }
         clearAudioBuffer()
         scheduleEngineRelease()
         VocaLogger.info(.audioEngine, "Start cancelled before capture began — keeping the negotiated route warm")
@@ -804,6 +896,12 @@ final class AudioEngine {
         // `lifecycleQueue.sync`, which deadlocks the render thread. See
         // `captureActive`.
         guard captureActive.withLock({ $0 }) else { return }
+
+        // Record that the HAL is really pulling from this route, before any
+        // conversion that could fail. `waitForFirstInputBuffer` is asking
+        // whether the input stream opened at all — a buffer we then fail to
+        // convert is a different (and separately reported) problem.
+        firstBufferSeen.withLock { $0 = true }
 
         // Convert to whisper format (16kHz, mono, Float32)
         guard let convertedBuffer = convertToWhisperFormat(buffer, from: inputFormat) else {

--- a/Sources/VocaMac/Services/AudioEngine.swift
+++ b/Sources/VocaMac/Services/AudioEngine.swift
@@ -32,6 +32,10 @@ final class AudioEngine {
     /// deadlocks the audio graph — and with it the app, because AppState waits
     /// on `stopRecording`.
     private let captureActive = OSAllocatedUnfairLock(initialState: false)
+    /// Set by `cancelPendingStart()` when the user lets go of push-to-talk while
+    /// the input route is still being negotiated. Read from the settle loops,
+    /// which run inside `lifecycleQueue` — so this cannot live behind that queue.
+    private let startCancelled = OSAllocatedUnfairLock(initialState: false)
     private var configuredInputDeviceID: AudioDeviceID?
     /// Last UID passed to `startRecording`, used to rebuild the graph after a
     /// configuration change without dropping the user's selected microphone.
@@ -337,6 +341,21 @@ final class AudioEngine {
 
     // MARK: - Recording Control
 
+    /// Abandon a start that is still negotiating its input route.
+    ///
+    /// Bluetooth headsets take up to `bluetoothInputRouteConfigurationTimeout`
+    /// to switch from A2DP to HFP, and `startRecording` holds `lifecycleQueue`
+    /// for that whole time. A user who releases push-to-talk during it would
+    /// otherwise wait out the settle and then be handed an empty buffer. This
+    /// is deliberately lock-free so it can be called while the queue is busy.
+    func cancelPendingStart() {
+        startCancelled.withLock { $0 = true }
+    }
+
+    private var isStartCancelled: Bool {
+        startCancelled.withLock { $0 }
+    }
+
     /// Start recording audio from the microphone
     /// - Parameters:
     ///   - silenceThreshold: RMS energy threshold below which audio is considered silence
@@ -354,7 +373,16 @@ final class AudioEngine {
             guard !self._isCurrentlyRecording else { return true }
 
             self.setIsPreparingRecording(true)
-            defer { self.setIsPreparingRecording(false) }
+            // Cleared on both ends so a cancel can only ever apply to the start
+            // it was meant for: on entry against one that landed with no start in
+            // flight, and on exit against one that arrived after the last check
+            // (the caller stops the finished recording instead) — either would
+            // otherwise poison the next start or a mid-recording route restart.
+            self.startCancelled.withLock { $0 = false }
+            defer {
+                self.setIsPreparingRecording(false)
+                self.startCancelled.withLock { $0 = false }
+            }
 
             self.lastPreferredInputDeviceUID = preferredInputDeviceID
             self.silenceThreshold = silenceThreshold
@@ -364,6 +392,10 @@ final class AudioEngine {
             resetRecordingState()
 
             for attempt in 1...2 {
+                if isStartCancelled {
+                    return abandonCancelledStart()
+                }
+
                 let engine = acquireEngine()
                 let inputNode = engine.inputNode
                 guard let configuredInputDeviceID = configureInputRoute(
@@ -371,10 +403,20 @@ final class AudioEngine {
                     engine: engine,
                     inputNode: inputNode
                 ) else {
+                    if isStartCancelled {
+                        return abandonCancelledStart()
+                    }
                     recoverFromStartFailure(notifyAppState: false)
                     return false
                 }
                 self.configuredInputDeviceID = configuredInputDeviceID
+
+                // The route is up but the user has already let go. Starting now
+                // would capture only the silence after they stopped talking.
+                if isStartCancelled {
+                    return abandonCancelledStart()
+                }
+
                 let inputFormat = inputNode.outputFormat(forBus: 0)
 
                 guard isValidInputFormat(inputFormat) else {
@@ -599,6 +641,24 @@ final class AudioEngine {
             return "engine stopped during start"
         }
         return nil
+    }
+
+    /// Tears down a start the user abandoned mid-negotiation.
+    ///
+    /// Unlike a failed start, the engine is kept for the idle window: the route
+    /// it just negotiated is the expensive part, and someone who released too
+    /// early is about to press again. No tap is installed on these paths, so
+    /// there is nothing to stop — only state to clear.
+    /// Must be called on `lifecycleQueue`.
+    private func abandonCancelledStart() -> Bool {
+        setRecordingActive(false)
+        silenceCallbackFired = false
+        maxDurationCallbackFired = false
+        removeInputTap(reason: "cancelled start")
+        clearAudioBuffer()
+        scheduleEngineRelease()
+        VocaLogger.info(.audioEngine, "Start cancelled before capture began — keeping the negotiated route warm")
+        return false
     }
 
     /// Restores AudioEngine to a clean idle state after any failed start attempt.
@@ -930,6 +990,10 @@ final class AudioEngine {
         // users experience as "the mic just doesn't work", so fall back to the
         // system default rather than recording nothing.
         for (index, candidate) in candidates.enumerated() {
+            // Don't pay a second route negotiation for a start nobody is
+            // waiting for any more.
+            if isStartCancelled { return nil }
+
             if let resolved = applyInputRoute(
                 targetDeviceID: candidate,
                 engine: engine,
@@ -991,7 +1055,11 @@ final class AudioEngine {
             // Core Audio moves to an HFP sibling endpoint, return that ID so
             // later route-health checks match the live device.
             if isBluetoothTarget {
-                Self.waitForBluetoothHFPIfNeeded(deviceID: targetDeviceID, timeout: routeTimeout)
+                Self.waitForBluetoothHFPIfNeeded(
+                    deviceID: targetDeviceID,
+                    timeout: routeTimeout,
+                    isCancelled: { self.isStartCancelled }
+                )
                 if let settledDeviceID = Self.currentInputDeviceID(for: audioUnit),
                    settledDeviceID != targetDeviceID,
                    Self.isAcceptableBluetoothRouteSubstitute(
@@ -1000,7 +1068,11 @@ final class AudioEngine {
                    ) {
                     // Match the cold path: settle against the live HFP endpoint
                     // before the tap format is read.
-                    Self.waitForBluetoothHFPIfNeeded(deviceID: settledDeviceID, timeout: routeTimeout)
+                    Self.waitForBluetoothHFPIfNeeded(
+                        deviceID: settledDeviceID,
+                        timeout: routeTimeout,
+                        isCancelled: { self.isStartCancelled }
+                    )
                     let substituteName = Self.audioDeviceName(for: settledDeviceID) ?? "bluetooth input"
                     VocaLogger.info(.audioEngine, "Warm Bluetooth route resolved to HFP endpoint: \(substituteName)")
                     return settledDeviceID
@@ -1039,7 +1111,8 @@ final class AudioEngine {
             targetDeviceID,
             on: audioUnit,
             signal: routeChangeSignal,
-            timeout: routeTimeout
+            timeout: routeTimeout,
+            isCancelled: { self.isStartCancelled }
         )
         if !appliedBeforeReset {
             VocaLogger.debug(.audioEngine, "Requested input device not confirmed before graph rebuild; continuing with rebuild")
@@ -1067,7 +1140,8 @@ final class AudioEngine {
                 targetDeviceID,
                 on: audioUnit,
                 signal: routeChangeSignal,
-                timeout: routeTimeout
+                timeout: routeTimeout,
+                isCancelled: { self.isStartCancelled }
             )
             deviceIDAfterReset = Self.currentInputDeviceID(for: audioUnit)
         }
@@ -1109,7 +1183,11 @@ final class AudioEngine {
         // Wait for A2DP → HFP/SCO after the route is confirmed so the tap is
         // installed against the headset mic format, not the stale A2DP rate.
         if isBluetoothTarget {
-            Self.waitForBluetoothHFPIfNeeded(deviceID: resolvedDeviceID, timeout: routeTimeout)
+            Self.waitForBluetoothHFPIfNeeded(
+                deviceID: resolvedDeviceID,
+                timeout: routeTimeout,
+                isCancelled: { self.isStartCancelled }
+            )
         }
 
         let deviceName = Self.audioDeviceName(for: resolvedDeviceID) ?? "system default"
@@ -1232,13 +1310,15 @@ final class AudioEngine {
         _ targetDeviceID: AudioDeviceID,
         on audioUnit: AudioUnit,
         signal: DispatchSemaphore,
-        timeout: TimeInterval
+        timeout: TimeInterval,
+        isCancelled: () -> Bool = { false }
     ) -> Bool {
         let deadline = Date().addingTimeInterval(timeout)
         while Date() < deadline {
             if currentInputDeviceID(for: audioUnit) == targetDeviceID {
                 return true
             }
+            if isCancelled() { break }
             let remaining = deadline.timeIntervalSinceNow
             guard remaining > 0 else { break }
             let slice = min(inputRoutePollInterval, remaining)
@@ -1247,7 +1327,11 @@ final class AudioEngine {
         return currentInputDeviceID(for: audioUnit) == targetDeviceID
     }
 
-    private static func waitForBluetoothHFPIfNeeded(deviceID: AudioDeviceID, timeout: TimeInterval) {
+    private static func waitForBluetoothHFPIfNeeded(
+        deviceID: AudioDeviceID,
+        timeout: TimeInterval,
+        isCancelled: () -> Bool = { false }
+    ) {
         guard isBluetoothDevice(deviceID) else { return }
 
         let deadline = Date().addingTimeInterval(timeout)
@@ -1257,6 +1341,10 @@ final class AudioEngine {
             lastRate = rate
             if hasBluetoothHFPSettled(sampleRate: rate) {
                 VocaLogger.debug(.audioEngine, "Bluetooth HFP settled at \(Int(rate))Hz")
+                return
+            }
+            if isCancelled() {
+                VocaLogger.debug(.audioEngine, "Bluetooth HFP settle abandoned — start was cancelled")
                 return
             }
             Thread.sleep(forTimeInterval: inputRoutePollInterval)

--- a/Sources/VocaMac/Services/AudioEngine.swift
+++ b/Sources/VocaMac/Services/AudioEngine.swift
@@ -17,6 +17,15 @@ enum ApplicationInputMuteRecovery: Equatable {
     case unavailable
 }
 
+enum AudioCapturePhase: Equatable {
+    case stopped
+    case preparing
+    case recording
+
+    var acceptsInputBuffers: Bool { self != .stopped }
+    var evaluatesStopConditions: Bool { self == .recording }
+}
+
 final class AudioEngine {
 
     // MARK: - Properties
@@ -30,14 +39,14 @@ final class AudioEngine {
     private var pendingEngineRelease: DispatchWorkItem?
     private var audioBuffer: [Float] = []
     private var _isCurrentlyRecording = false
-    /// Realtime-safe mirror of `_isCurrentlyRecording` for the input tap.
+    /// Realtime-safe capture lifecycle for the input tap.
     ///
     /// The tap runs on Core Audio's render thread and must never wait on
     /// `lifecycleQueue`: `stopRecording` holds that queue while `engine.stop()`
     /// waits for the render thread to finish, so a tap that blocks on the queue
-    /// deadlocks the audio graph — and with it the app, because AppState waits
-    /// on `stopRecording`.
-    private let captureActive = OSAllocatedUnfairLock(initialState: false)
+    /// deadlocks the audio graph. The preparing phase keeps the first buffers
+    /// without allowing silence/max-duration callbacks before the mic is live.
+    private let capturePhase = OSAllocatedUnfairLock(initialState: AudioCapturePhase.stopped)
     /// Set by `cancelPendingStart()` when the user lets go of push-to-talk while
     /// the input route is still being negotiated. Read from the settle loops,
     /// which run inside `lifecycleQueue` — so this cannot live behind that queue.
@@ -49,7 +58,7 @@ final class AudioEngine {
     /// USB-C EarPods among them) can report a fully applied route and a running
     /// engine while never pulling a single input buffer, which surfaces as a
     /// recording that silently transcribes nothing. Written from the render
-    /// thread, so it must be lock-free like `captureActive`.
+    /// thread, so it must use the same realtime-safe state as `capturePhase`.
     private let firstBufferSeen = OSAllocatedUnfairLock(initialState: false)
     private var configuredInputDeviceID: AudioDeviceID?
     /// Last UID passed to `startRecording`, used to rebuild the graph after a
@@ -364,10 +373,16 @@ final class AudioEngine {
                 .audioEngine,
                 "Audio graph restarted but no input arrived within \(Self.firstInputBufferTimeout)s"
             )
+            setCaptureActive(false)
             removeInputTap(reason: "silent restart")
+            engine.stop()
             return false
         }
 
+        // `installTapAndStart` arms the tap in preparing mode. This was already
+        // a live recording before the route change, so re-enable silence and
+        // max-duration checks once the replacement route proves it can capture.
+        setRecordingActive(true)
         return true
     }
 
@@ -651,7 +666,7 @@ final class AudioEngine {
     /// Must be called on `lifecycleQueue`.
     private func setRecordingActive(_ active: Bool) {
         _isCurrentlyRecording = active
-        captureActive.withLock { $0 = active }
+        capturePhase.withLock { $0 = active ? .recording : .stopped }
     }
 
     /// Lets the input tap keep audio before `_isCurrentlyRecording` flips, so
@@ -659,8 +674,9 @@ final class AudioEngine {
     private func setCaptureActive(_ active: Bool) {
         if active {
             firstBufferSeen.withLock { $0 = false }
+            lastSoundTime = Date()
         }
-        captureActive.withLock { $0 = active }
+        capturePhase.withLock { $0 = active ? .preparing : .stopped }
     }
 
     /// Blocks until the input tap delivers its first buffer, or the timeout
@@ -982,8 +998,8 @@ final class AudioEngine {
     private func processAudioBuffer(_ buffer: AVAudioPCMBuffer, inputFormat: AVAudioFormat) {
         // Deliberately not `isCurrentlyRecording`: that reads through
         // `lifecycleQueue.sync`, which deadlocks the render thread. See
-        // `captureActive`.
-        guard captureActive.withLock({ $0 }) else { return }
+        // `capturePhase`.
+        guard capturePhase.withLock({ $0.acceptsInputBuffers }) else { return }
 
         // Record that the HAL is really pulling from this route, before any
         // conversion that could fail. `waitForFirstInputBuffer` is asking
@@ -1022,6 +1038,12 @@ final class AudioEngine {
                 }
             }
         }
+
+        // Capture buffers during startup so the first word is preserved, but
+        // do not treat the Bluetooth/USB settle interval as user silence or
+        // recording duration. The live transition resets the timing anchors
+        // before changing this phase to `.recording`.
+        guard capturePhase.withLock({ $0.evaluatesStopConditions }) else { return }
 
         // Check max duration (fire callback only once)
         let elapsed = now.timeIntervalSince(recordingStartTime)

--- a/Sources/VocaMac/Services/AudioEngine.swift
+++ b/Sources/VocaMac/Services/AudioEngine.swift
@@ -11,6 +11,12 @@ import CoreAudio
 import os
 import VocaMacObjC
 
+enum ApplicationInputMuteRecovery: Equatable {
+    case noAction
+    case clearMute
+    case unavailable
+}
+
 final class AudioEngine {
 
     // MARK: - Properties
@@ -67,6 +73,28 @@ final class AudioEngine {
     static let firstInputBufferTimeout: TimeInterval = 0.75
     static let firstInputBufferPollInterval: TimeInterval = 0.01
     static let idleEngineReleaseDelay: TimeInterval = 3.0
+
+    /// Mirrors AVAudioApplication's mute state for the realtime input tap.
+    private static let applicationInputMuted = OSAllocatedUnfairLock(initialState: false)
+
+    /// macOS requires an input-mute handler before an app can clear a mute set
+    /// by a supported headset gesture or another application-level mute action.
+    /// The handler must implement the mute itself, so the input tap zeroes the
+    /// captured samples while this state is active.
+    private static let inputMuteHandlerInstalled: Bool = {
+        do {
+            try AVAudioApplication.shared.setInputMuteStateChangeHandler { shouldMute in
+                applyApplicationInputMuteChange(shouldMute)
+            }
+            return true
+        } catch {
+            VocaLogger.warning(
+                .audioEngine,
+                "Could not register application input-mute handler: \(error.localizedDescription)"
+            )
+            return false
+        }
+    }()
 
     var isCurrentlyRecording: Bool {
         lifecycleQueue.sync { _isCurrentlyRecording }
@@ -347,12 +375,12 @@ final class AudioEngine {
 
     /// Check current microphone permission status (tri-state)
     func checkPermissionStatus() -> PermissionStatus {
-        switch AVCaptureDevice.authorizationStatus(for: .audio) {
-        case .authorized:
+        switch AVAudioApplication.shared.recordPermission {
+        case .granted:
             return .granted
-        case .notDetermined:
+        case .undetermined:
             return .notDetermined
-        case .denied, .restricted:
+        case .denied:
             return .denied
         @unknown default:
             return .denied
@@ -361,7 +389,7 @@ final class AudioEngine {
 
     /// Request microphone permission from the user
     func requestPermission(completion: @escaping (Bool) -> Void) {
-        AVCaptureDevice.requestAccess(for: .audio) { granted in
+        AVAudioApplication.requestRecordPermission { granted in
             DispatchQueue.main.async {
                 completion(granted)
             }
@@ -417,6 +445,10 @@ final class AudioEngine {
             self.silenceThreshold = silenceThreshold
             self.silenceDuration = silenceDuration
             self.maxDuration = maxDuration
+
+            guard Self.prepareApplicationInputForRecording() else {
+                return false
+            }
 
             resetRecordingState()
 
@@ -780,6 +812,62 @@ final class AudioEngine {
         return OSStatus(truncatingIfNeeded: (error as NSError).code) == kAudioHardwareNotRunningError
     }
 
+    /// Starting dictation is an explicit request to use the microphone. Clear
+    /// any per-application mute left by a headset gesture before opening the
+    /// route, otherwise Core Audio deliberately supplies zero-filled buffers.
+    private static func prepareApplicationInputForRecording() -> Bool {
+        let handlerAvailable = inputMuteHandlerInstalled
+        switch inputMuteRecovery(
+            isMuted: AVAudioApplication.shared.isInputMuted,
+            handlerAvailable: handlerAvailable
+        ) {
+        case .noAction:
+            return true
+        case .unavailable:
+            VocaLogger.warning(.audioEngine, "Application input is muted and no mute handler is available")
+            return false
+        case .clearMute:
+            break
+        }
+
+        do {
+            try AVAudioApplication.shared.setInputMuted(false)
+            let isStillMuted = AVAudioApplication.shared.isInputMuted
+            if isStillMuted {
+                VocaLogger.warning(.audioEngine, "Application input remained muted after the unmute request")
+                return false
+            }
+            VocaLogger.info(.audioEngine, "Cleared application input mute before recording")
+            return true
+        } catch {
+            VocaLogger.warning(
+                .audioEngine,
+                "Could not clear application input mute: \(error.localizedDescription)"
+            )
+            return false
+        }
+    }
+
+    static func inputMuteRecovery(
+        isMuted: Bool,
+        handlerAvailable: Bool
+    ) -> ApplicationInputMuteRecovery {
+        guard isMuted else { return .noAction }
+        return handlerAvailable ? .clearMute : .unavailable
+    }
+
+    /// Applies a mute-state callback from AVAudioApplication. Returning true
+    /// confirms that this process will zero its microphone samples.
+    @discardableResult
+    static func applyApplicationInputMuteChange(_ shouldMute: Bool) -> Bool {
+        applicationInputMuted.withLock { $0 = shouldMute }
+        return true
+    }
+
+    static func isApplicationInputMutedForCapture() -> Bool {
+        applicationInputMuted.withLock { $0 }
+    }
+
     static func shouldIgnoreConfigurationChange(
         occurredDuringRecordingPreparation: Bool = false,
         isStillPreparingRecording: Bool = false,
@@ -908,8 +996,11 @@ final class AudioEngine {
             return
         }
 
-        // Calculate audio energy for level reporting and silence detection
-        let energy = calculateRMSEnergy(convertedBuffer)
+        // On macOS the process that registers AVAudioApplication's mute handler
+        // must implement the mute. Preserve timing while ensuring no microphone
+        // samples escape during a headset/application mute.
+        let isApplicationInputMuted = Self.isApplicationInputMutedForCapture()
+        let energy = isApplicationInputMuted ? 0 : calculateRMSEnergy(convertedBuffer)
 
         // Report audio level (throttled)
         let now = Date()
@@ -927,7 +1018,7 @@ final class AudioEngine {
             bufferQueue.sync {
                 audioBuffer.reserveCapacity(audioBuffer.count + frameCount)
                 for i in 0..<frameCount {
-                    audioBuffer.append(channelData[0][i])
+                    audioBuffer.append(isApplicationInputMuted ? 0 : channelData[0][i])
                 }
             }
         }
@@ -1068,6 +1159,27 @@ final class AudioEngine {
             VocaLogger.warning(.audioEngine, "Preferred input device unavailable, falling back to system default: \(requestedUID)")
         }
 
+        // Let AVAudioEngine follow Core Audio's default route without writing
+        // kAudioOutputUnitProperty_CurrentDevice. Some current systems reject
+        // that redundant write with 'nope', or accept it while leaving AUHAL on
+        // a zero-filled input stream. Explicit non-default selections still use
+        // the device property below.
+        if Self.shouldFollowSystemDefaultInput(
+            requestedDeviceID: requestedDeviceID,
+            defaultDeviceID: defaultDeviceID
+        ), let defaultDeviceID {
+            let deviceName = Self.audioDeviceName(for: defaultDeviceID) ?? "system default"
+            VocaLogger.info(.audioEngine, "Following system default input device: \(deviceName)")
+
+            if requestedDeviceMissing {
+                let fallbackNotice = "The selected microphone is unavailable — recording from \(deviceName)."
+                DispatchQueue.main.async { [weak self] in
+                    self?.onInputDeviceFallback?(fallbackNotice)
+                }
+            }
+            return defaultDeviceID
+        }
+
         guard let audioUnit = inputNode.audioUnit else {
             VocaLogger.warning(.audioEngine, "Input node has no AudioUnit; unable to verify the requested input route")
             return nil
@@ -1116,6 +1228,17 @@ final class AudioEngine {
         }
 
         return nil
+    }
+
+    /// System Default and a pinned device that is already the default should be
+    /// left to AVAudioEngine. Setting CurrentDevice is reserved for a real
+    /// non-default override.
+    static func shouldFollowSystemDefaultInput(
+        requestedDeviceID: AudioDeviceID?,
+        defaultDeviceID: AudioDeviceID?
+    ) -> Bool {
+        guard let defaultDeviceID else { return false }
+        return requestedDeviceID == nil || requestedDeviceID == defaultDeviceID
     }
 
     /// Ordered input devices to try: the pinned microphone first, then the

--- a/Sources/VocaMac/Services/CursorOverlayManager.swift
+++ b/Sources/VocaMac/Services/CursorOverlayManager.swift
@@ -130,7 +130,9 @@ final class CursorOverlayManager {
 
         viewModel.style = style
         viewModel.position = position
-        viewModel.phase = .recording
+        // Capture has not begun yet — `transitionToRecording()` says when it has.
+        viewModel.phase = .connecting
+        viewModel.audioLevel = 0
         viewModel.elapsedSeconds = 0
         viewModel.isActive = true
 
@@ -172,6 +174,15 @@ final class CursorOverlayManager {
         startTimers()
 
         VocaLogger.debug(.cursorOverlay, "Overlay shown (style=\(style.rawValue), position=\(position.rawValue))")
+    }
+
+    /// The input route is live and the microphone is actually capturing.
+    func transitionToRecording() {
+        guard overlayPanel != nil, viewModel.phase == .connecting else { return }
+        viewModel.phase = .recording
+        viewModel.audioLevel = 0
+        viewModel.elapsedSeconds = 0
+        VocaLogger.debug(.cursorOverlay, "Overlay transitioned to recording")
     }
 
     /// Transitions the overlay from recording to batch transcription.
@@ -400,6 +411,10 @@ final class CursorOverlayManager {
 
 enum IndicatorPhase {
     case idle
+    /// The audio engine is negotiating its input route. Bluetooth headsets take
+    /// seconds to switch to their microphone, and nothing is captured until they
+    /// do — showing "recording" through that window loses the user's first words.
+    case connecting
     case recording
     case processing
 }
@@ -488,8 +503,36 @@ struct HandyOverlayView: View {
         isDark ? Color.white.opacity(0.22) : Color.black.opacity(0.14)
     }
 
+    /// Muted while the route comes up: the panel is visible but the microphone
+    /// is not live yet, and it should not look like it is.
+    private var connectingColor: Color {
+        isDark ? Color.white.opacity(0.55) : Color.black.opacity(0.45)
+    }
+
     private var waveformColor: Color {
-        viewModel.phase == .recording ? recordingColor : processingColor
+        switch viewModel.phase {
+        case .recording: return recordingColor
+        case .connecting: return connectingColor
+        case .idle, .processing: return processingColor
+        }
+    }
+
+    private var accentColor: Color { waveformColor }
+
+    private var statusTitle: String {
+        switch viewModel.phase {
+        case .connecting: return "Connecting"
+        case .recording: return "Listening"
+        case .idle, .processing: return "Transcribing"
+        }
+    }
+
+    private var statusDetail: String {
+        switch viewModel.phase {
+        case .connecting: return "Waiting for microphone…"
+        case .recording: return "Speak now"
+        case .idle, .processing: return "Transcribing…"
+        }
     }
 
     private var slideInOffset: CGFloat {
@@ -578,7 +621,7 @@ struct HandyOverlayView: View {
         HStack(spacing: 7) {
             recordingIndicatorIcon
 
-            Text(viewModel.phase == .recording ? "Listening" : "Transcribing")
+            Text(statusTitle)
                 .font(.system(size: 13, weight: .semibold))
                 .foregroundStyle(primaryText)
 
@@ -612,15 +655,15 @@ struct HandyOverlayView: View {
             if viewModel.phase == .recording {
                 waveform
 
-                Text("Speak now")
+                Text(statusDetail)
                     .font(.system(size: 11, weight: .medium))
                     .foregroundStyle(secondaryText)
             } else {
                 ProgressView()
                     .controlSize(.small)
-                    .tint(processingColor)
+                    .tint(accentColor)
 
-                Text("Transcribing…")
+                Text(statusDetail)
                     .font(.system(size: 12, weight: .medium))
                     .foregroundStyle(secondaryText)
             }
@@ -640,8 +683,8 @@ struct HandyOverlayView: View {
             } else {
                 ProgressView()
                     .controlSize(.small)
-                    .tint(processingColor)
-                    .accessibilityLabel("Transcribing")
+                    .tint(accentColor)
+                    .accessibilityLabel(statusTitle)
                     .frame(maxWidth: .infinity)
             }
         }
@@ -684,13 +727,13 @@ struct HandyOverlayView: View {
                     .opacity(isPulsing ? 0.55 : 0.9)
             }
 
-            Image(systemName: "mic.fill")
+            Image(systemName: viewModel.phase == .connecting ? "mic.slash.fill" : "mic.fill")
                 .font(.system(size: 11, weight: .bold))
-                .foregroundStyle(viewModel.phase == .recording ? recordingColor : processingColor)
+                .foregroundStyle(accentColor)
                 .shadow(color: waveformColor.opacity(0.45), radius: 3)
         }
         .frame(width: 22, height: 22)
-        .accessibilityLabel(viewModel.phase == .recording ? "Recording" : "Transcribing")
+        .accessibilityLabel(viewModel.phase == .recording ? "Recording" : statusTitle)
     }
 
     private var formattedElapsed: String {

--- a/Sources/VocaMac/Services/ServiceProtocols.swift
+++ b/Sources/VocaMac/Services/ServiceProtocols.swift
@@ -15,6 +15,7 @@ protocol AudioRecording: AnyObject {
     var onSilenceDetected: (() -> Void)? { get set }
     var onMaxDurationReached: (() -> Void)? { get set }
     var onAudioDeviceChanged: (() -> Void)? { get set }
+    var onInputDeviceFallback: ((String) -> Void)? { get set }
 
     @discardableResult
     func startRecording(

--- a/Sources/VocaMac/Services/ServiceProtocols.swift
+++ b/Sources/VocaMac/Services/ServiceProtocols.swift
@@ -95,8 +95,11 @@ protocol PermissionManaging: AnyObject {
 
 @MainActor
 protocol CursorOverlayManaging: AnyObject {
+    /// Shows the overlay in its connecting state: visible, but explicit that
+    /// the microphone is not capturing yet.
     func show(style: OverlayStyle, position: OverlayPosition)
     func hide()
+    func transitionToRecording()
     func transitionToProcessing()
     func updateAudioLevel(_ level: Float)
 }

--- a/Sources/VocaMac/Services/ServiceProtocols.swift
+++ b/Sources/VocaMac/Services/ServiceProtocols.swift
@@ -25,6 +25,7 @@ protocol AudioRecording: AnyObject {
         preferredInputDeviceID: String?
     ) -> Bool
     @discardableResult func stopRecording() -> [Float]
+    func cancelPendingStart()
     func forceReset()
     func checkPermissionStatus() -> PermissionStatus
     func requestPermission(completion: @escaping (Bool) -> Void)

--- a/Sources/VocaMac/Views/MenuBarView.swift
+++ b/Sources/VocaMac/Views/MenuBarView.swift
@@ -375,8 +375,17 @@ struct MenuBarView: View {
                  : "Applies to the next recording. Does not change macOS's system default.")
                 .font(.caption2)
                 .foregroundStyle(.secondary)
+
+            if let fallbackNotice = appState.inputDeviceFallbackNotice {
+                Label(fallbackNotice, systemImage: "exclamationmark.triangle")
+                    .font(.caption2)
+                    .foregroundStyle(.orange)
+            }
         }
         .onAppear {
+            refreshAudioDevices()
+        }
+        .onReceive(NotificationCenter.default.publisher(for: .vocaAudioDevicesChanged)) { _ in
             refreshAudioDevices()
         }
     }

--- a/Sources/VocaMac/Views/SettingsView.swift
+++ b/Sources/VocaMac/Views/SettingsView.swift
@@ -1217,6 +1217,15 @@ struct AudioSettingsTab: View {
                         .foregroundStyle(.secondary)
                 }
 
+                if let fallbackNotice = appState.inputDeviceFallbackNotice {
+                    HStack(alignment: .top) {
+                        Image(systemName: "exclamationmark.triangle")
+                            .foregroundStyle(.orange)
+                        Text(fallbackNotice)
+                            .foregroundStyle(.secondary)
+                    }
+                }
+
                 Button("Refresh Devices") {
                     refreshAudioDevices()
                 }
@@ -1229,6 +1238,9 @@ struct AudioSettingsTab: View {
         }
         .formStyle(.grouped)
         .onAppear {
+            refreshAudioDevices()
+        }
+        .onReceive(NotificationCenter.default.publisher(for: .vocaAudioDevicesChanged)) { _ in
             refreshAudioDevices()
         }
     }

--- a/Tests/VocaMacTests/AppStateRecordingTests.swift
+++ b/Tests/VocaMacTests/AppStateRecordingTests.swift
@@ -111,8 +111,11 @@ final class AppStateRecordingTests: XCTestCase {
         await task.value
 
         XCTAssertEqual(mocks.soundManager.startSoundCallCount, 0)
-        XCTAssertEqual(mocks.soundManager.stopSoundCallCount, 1)
-        XCTAssertEqual(appState.appStatus, .idle)
+        XCTAssertEqual(mocks.soundManager.stopSoundCallCount, 0,
+            "the start was abandoned before capture, so there is no recording to end")
+        XCTAssertEqual(appState.appStatus, .error,
+            "releasing before the microphone is live records nothing, and the user is told why")
+        XCTAssertNotNil(appState.errorMessage)
         XCTAssertEqual(mocks.audioEngine.forceResetCallCount, 0)
     }
 
@@ -636,5 +639,76 @@ final class AppStateRecordingGuardTests: XCTestCase {
         XCTAssertFalse(appState.isRecording)
         XCTAssertEqual(appState.audioLevel, 0.0)
         XCTAssertNil(appState.errorMessage)
+    }
+}
+
+// MARK: - Slow Microphone Start Tests
+
+/// Bluetooth headsets take up to three seconds to switch from A2DP to their
+/// microphone. Releasing push-to-talk during that window used to wait out the
+/// whole negotiation and then report a silent recording.
+final class AppStateSlowMicrophoneStartTests: XCTestCase {
+
+    @MainActor
+    func testStopWhileMicrophoneIsConnectingDoesNotBlock() async {
+        let (appState, mocks) = AppState.makeTestState()
+        mocks.audioEngine.startRecordingDelay = 0.6
+
+        let start = Task { await appState.startRecording() }
+        // Let startRecording reach its await on the audio engine.
+        try? await Task.sleep(nanoseconds: 100_000_000)
+
+        let stopBegan = Date()
+        await appState.stopRecordingAndTranscribe()
+        let stopDuration = Date().timeIntervalSince(stopBegan)
+
+        XCTAssertLessThan(stopDuration, 0.2,
+            "stop must not wait out the input route negotiation")
+        XCTAssertEqual(mocks.audioEngine.cancelPendingStartCallCount, 1,
+            "the engine should be told to abandon the start it is still negotiating")
+
+        await start.value
+
+        XCTAssertFalse(appState.isRecording)
+        XCTAssertEqual(appState.appStatus, .error,
+            "the user needs to know nothing was captured")
+        XCTAssertNotNil(appState.errorMessage)
+        XCTAssertNil(mocks.whisperService.lastTranscribedAudioData,
+            "there is no audio from before the microphone came up, so nothing should be transcribed")
+        XCTAssertEqual(mocks.cursorOverlay.hideCallCount, 1)
+    }
+
+    @MainActor
+    func testCancelWhileMicrophoneIsConnectingEndsQuietly() async {
+        let (appState, mocks) = AppState.makeTestState()
+        mocks.audioEngine.startRecordingDelay = 0.6
+
+        let start = Task { await appState.startRecording() }
+        try? await Task.sleep(nanoseconds: 100_000_000)
+
+        await appState.cancelRecording()
+        XCTAssertEqual(mocks.audioEngine.cancelPendingStartCallCount, 1)
+
+        await start.value
+
+        XCTAssertFalse(appState.isRecording)
+        XCTAssertEqual(appState.appStatus, .idle,
+            "an explicit cancel is not an error")
+        XCTAssertNil(appState.errorMessage)
+    }
+
+    @MainActor
+    func testFastStartIsUnaffected() async {
+        let (appState, mocks) = AppState.makeTestState()
+
+        await appState.startRecording()
+
+        XCTAssertTrue(appState.isRecording)
+        XCTAssertEqual(appState.appStatus, .recording)
+        XCTAssertEqual(mocks.audioEngine.cancelPendingStartCallCount, 0,
+            "a start that completes promptly should never be cancelled")
+
+        await appState.stopRecordingAndTranscribe()
+        XCTAssertFalse(appState.isRecording)
     }
 }

--- a/Tests/VocaMacTests/AppStateRecordingTests.swift
+++ b/Tests/VocaMacTests/AppStateRecordingTests.swift
@@ -613,8 +613,10 @@ final class AppStateRecordingGuardTests: XCTestCase {
 
         await appState.startRecording()
 
-        XCTAssertEqual(appState.appStatus, .idle,
-            "failed audio start should return app state to idle")
+        XCTAssertEqual(appState.appStatus, .error,
+            "a failed audio start is reported, not silently swallowed")
+        XCTAssertNotNil(appState.errorMessage,
+            "the user needs to know why the hotkey appeared to do nothing")
         XCTAssertFalse(appState.isRecording,
             "failed audio start should clear recording state")
         XCTAssertEqual(appState.audioLevel, 0.0,

--- a/Tests/VocaMacTests/AppStateRecordingTests.swift
+++ b/Tests/VocaMacTests/AppStateRecordingTests.swift
@@ -698,6 +698,36 @@ final class AppStateSlowMicrophoneStartTests: XCTestCase {
     }
 
     @MainActor
+    func testOverlayOnlyClaimsToListenOnceTheMicrophoneIsLive() async {
+        let (appState, mocks) = AppState.makeTestState()
+        mocks.audioEngine.startRecordingDelay = 0.6
+
+        let start = Task { await appState.startRecording() }
+        try? await Task.sleep(nanoseconds: 100_000_000)
+
+        XCTAssertEqual(mocks.cursorOverlay.showCallCount, 1,
+            "the overlay appears immediately so the hotkey feels responsive")
+        XCTAssertEqual(mocks.cursorOverlay.transitionToRecordingCallCount, 0,
+            "but it must not claim to be listening while the route is still coming up")
+
+        await appState.stopRecordingAndTranscribe()
+        await start.value
+
+        XCTAssertEqual(mocks.cursorOverlay.transitionToRecordingCallCount, 0,
+            "a start that never reached capture never becomes a recording")
+    }
+
+    @MainActor
+    func testOverlayDoesNotEnterRecordingWhenTheStartFails() async {
+        let (appState, mocks) = AppState.makeTestState()
+        mocks.audioEngine.startRecordingResult = false
+
+        await appState.startRecording()
+
+        XCTAssertEqual(mocks.cursorOverlay.transitionToRecordingCallCount, 0)
+    }
+
+    @MainActor
     func testFastStartIsUnaffected() async {
         let (appState, mocks) = AppState.makeTestState()
 
@@ -707,6 +737,8 @@ final class AppStateSlowMicrophoneStartTests: XCTestCase {
         XCTAssertEqual(appState.appStatus, .recording)
         XCTAssertEqual(mocks.audioEngine.cancelPendingStartCallCount, 0,
             "a start that completes promptly should never be cancelled")
+        XCTAssertEqual(mocks.cursorOverlay.transitionToRecordingCallCount, 1,
+            "a live microphone flips the overlay out of its connecting state")
 
         await appState.stopRecordingAndTranscribe()
         XCTAssertFalse(appState.isRecording)

--- a/Tests/VocaMacTests/Mocks/MockServices.swift
+++ b/Tests/VocaMacTests/Mocks/MockServices.swift
@@ -26,6 +26,11 @@ final class MockAudioEngine: AudioRecording {
     var forceResetCallCount = 0
     var startRecordingResult = true
     var startRecordingDelay: TimeInterval = 0
+    private(set) var cancelPendingStartCallCount = 0
+    /// Mirrors the real engine: a start cancelled while it is still negotiating
+    /// the input route is abandoned and reports failure.
+    private let cancelLock = NSLock()
+    private var startCancelled = false
 
     private var permissionStatus: PermissionStatus = .granted
 
@@ -36,15 +41,29 @@ final class MockAudioEngine: AudioRecording {
         maxDuration: TimeInterval,
         preferredInputDeviceID: String?
     ) -> Bool {
+        cancelLock.withLock { startCancelled = false }
         if startRecordingDelay > 0 {
             Thread.sleep(forTimeInterval: startRecordingDelay)
         }
-        isCurrentlyRecording = startRecordingResult
         lastSilenceThreshold = silenceThreshold
         lastSilenceDuration = silenceDuration
         lastMaxDuration = maxDuration
         lastPreferredInputDeviceID = preferredInputDeviceID
+
+        if cancelLock.withLock({ startCancelled }) {
+            isCurrentlyRecording = false
+            return false
+        }
+
+        isCurrentlyRecording = startRecordingResult
         return startRecordingResult
+    }
+
+    func cancelPendingStart() {
+        cancelLock.withLock {
+            cancelPendingStartCallCount += 1
+            startCancelled = true
+        }
     }
 
     @discardableResult

--- a/Tests/VocaMacTests/Mocks/MockServices.swift
+++ b/Tests/VocaMacTests/Mocks/MockServices.swift
@@ -16,6 +16,7 @@ final class MockAudioEngine: AudioRecording {
     var onSilenceDetected: (() -> Void)?
     var onMaxDurationReached: (() -> Void)?
     var onAudioDeviceChanged: (() -> Void)?
+    var onInputDeviceFallback: ((String) -> Void)?
 
     var lastSilenceThreshold: Float?
     var lastSilenceDuration: Double?

--- a/Tests/VocaMacTests/Mocks/MockServices.swift
+++ b/Tests/VocaMacTests/Mocks/MockServices.swift
@@ -256,6 +256,7 @@ final class MockCursorOverlay: CursorOverlayManaging {
     var showCallCount = 0
     var hideCallCount = 0
     var transitionCallCount = 0
+    var transitionToRecordingCallCount = 0
     var lastAudioLevel: Float?
     var lastStyle: OverlayStyle?
     var lastPosition: OverlayPosition?
@@ -268,6 +269,10 @@ final class MockCursorOverlay: CursorOverlayManaging {
 
     func hide() {
         hideCallCount += 1
+    }
+
+    func transitionToRecording() {
+        transitionToRecordingCallCount += 1
     }
 
     func transitionToProcessing() {

--- a/Tests/VocaMacTests/ServiceTests.swift
+++ b/Tests/VocaMacTests/ServiceTests.swift
@@ -517,6 +517,16 @@ final class AudioEngineTests: XCTestCase {
         try skipWithoutRealAudioInput()
         let engine = AudioEngine()
 
+        // Wait for the hardware to actually deliver a buffer rather than
+        // guessing at a duration. How long a cold Core Audio start takes to
+        // produce its first buffer depends on the device and on what else in
+        // this process just released it, so any fixed sleep is either a race or
+        // dead time. `onAudioLevel` fires from the tap once per processed
+        // buffer, which is exactly the event this test is waiting for.
+        let firstBuffer = XCTestExpectation(description: "First audio buffer captured")
+        firstBuffer.assertForOverFulfill = false
+        engine.onAudioLevel = { _ in firstBuffer.fulfill() }
+
         engine.startRecording(
             silenceThreshold: 0.01,
             silenceDuration: 999.0,
@@ -528,14 +538,7 @@ final class AudioEngineTests: XCTestCase {
             return
         }
 
-        // A cold Core Audio start does not guarantee a buffer within 300 ms,
-        // especially with other tests in this process cycling the same device.
-        // One second is still a tight assertion and no longer races the hardware.
-        let expectation = XCTestExpectation(description: "Recording period")
-        DispatchQueue.main.asyncAfter(deadline: .now() + 1.0) {
-            expectation.fulfill()
-        }
-        wait(for: [expectation], timeout: 3.0)
+        wait(for: [firstBuffer], timeout: 5.0)
 
         let samples = engine.stopRecording()
 

--- a/Tests/VocaMacTests/ServiceTests.swift
+++ b/Tests/VocaMacTests/ServiceTests.swift
@@ -1310,3 +1310,34 @@ final class AudioDeviceMonitorTests: XCTestCase {
         )
     }
 }
+
+// MARK: - AudioEngine Start Cancellation Tests
+
+final class AudioEngineStartCancellationTests: XCTestCase {
+
+    func testCancelPendingStartIsSafeWhenIdle() {
+        let engine = AudioEngine()
+        engine.cancelPendingStart()
+        XCTAssertFalse(engine.isCurrentlyRecording)
+    }
+
+    /// A cancel that lands after its start already finished must not leak into
+    /// the next one.
+    func testStaleCancelDoesNotPoisonTheNextStart() throws {
+        try skipWithoutRealAudioInput()
+        let engine = AudioEngine()
+        engine.cancelPendingStart()
+
+        let didStart = engine.startRecording(
+            silenceThreshold: 0.01,
+            silenceDuration: 999.0,
+            maxDuration: 60.0
+        )
+
+        try XCTSkipIf(!didStart, "No microphone available or Core Audio input could not start")
+        XCTAssertTrue(engine.isCurrentlyRecording)
+
+        _ = engine.stopRecording()
+        engine.forceReset()
+    }
+}

--- a/Tests/VocaMacTests/ServiceTests.swift
+++ b/Tests/VocaMacTests/ServiceTests.swift
@@ -1226,3 +1226,87 @@ final class AudioEngineDeviceChangeTests: XCTestCase {
             "Device change callback should NOT fire during forceReset (only notification handler fires it)")
     }
 }
+
+// MARK: - AudioEngine Input Route Fallback Tests
+
+final class AudioEngineInputRouteFallbackTests: XCTestCase {
+
+    func testCandidatesTryRequestedDeviceBeforeSystemDefault() {
+        XCTAssertEqual(
+            AudioEngine.inputRouteCandidates(requestedDeviceID: 42, defaultDeviceID: 7),
+            [42, 7],
+            "The pinned microphone is tried first, with the system default as a fallback"
+        )
+    }
+
+    func testCandidatesCollapseAPinnedDefaultDevice() {
+        XCTAssertEqual(
+            AudioEngine.inputRouteCandidates(requestedDeviceID: 42, defaultDeviceID: 42),
+            [42],
+            "Pinning the system default should not make us configure the same device twice"
+        )
+    }
+
+    func testCandidatesFallBackToDefaultWhenNothingIsPinned() {
+        XCTAssertEqual(
+            AudioEngine.inputRouteCandidates(requestedDeviceID: nil, defaultDeviceID: 7),
+            [7]
+        )
+    }
+
+    func testCandidatesAreEmptyWhenNoInputExists() {
+        XCTAssertTrue(
+            AudioEngine.inputRouteCandidates(requestedDeviceID: nil, defaultDeviceID: nil).isEmpty,
+            "With no device to try, the caller must report the failure rather than record silence"
+        )
+    }
+
+    /// The input tap used to read `isCurrentlyRecording`, which hops through
+    /// `lifecycleQueue`. `stopRecording` holds that queue while `engine.stop()`
+    /// waits for the render thread, so a tap blocked on the queue deadlocks the
+    /// graph. Recording and stopping repeatedly must stay responsive.
+    func testStartStopCyclesDoNotDeadlock() throws {
+        try skipWithoutRealAudioInput()
+        let engine = AudioEngine()
+
+        let finished = XCTestExpectation(description: "Start/stop cycles completed")
+        DispatchQueue.global(qos: .userInitiated).async {
+            for _ in 0..<5 {
+                let didStart = engine.startRecording(
+                    silenceThreshold: 0.01,
+                    silenceDuration: 999.0,
+                    maxDuration: 60.0
+                )
+                guard didStart else { break }
+                Thread.sleep(forTimeInterval: 0.1)
+                _ = engine.stopRecording()
+            }
+            finished.fulfill()
+        }
+
+        wait(for: [finished], timeout: 20.0)
+        XCTAssertFalse(engine.isCurrentlyRecording)
+        engine.forceReset()
+    }
+}
+
+// MARK: - AudioDeviceMonitor Tests
+
+final class AudioDeviceMonitorTests: XCTestCase {
+
+    func testStartIsIdempotentAndStopIsSafe() {
+        let monitor = AudioDeviceMonitor()
+        monitor.start()
+        monitor.start()
+        monitor.stop()
+        monitor.stop()
+    }
+
+    func testChangeNotificationsAreCoalesced() {
+        XCTAssertGreaterThan(
+            AudioDeviceMonitor.coalesceInterval,
+            0,
+            "Bluetooth profile switches fire several property changes; the pickers should rebuild once"
+        )
+    }
+}

--- a/Tests/VocaMacTests/ServiceTests.swift
+++ b/Tests/VocaMacTests/ServiceTests.swift
@@ -528,11 +528,14 @@ final class AudioEngineTests: XCTestCase {
             return
         }
 
+        // A cold Core Audio start does not guarantee a buffer within 300 ms,
+        // especially with other tests in this process cycling the same device.
+        // One second is still a tight assertion and no longer races the hardware.
         let expectation = XCTestExpectation(description: "Recording period")
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
+        DispatchQueue.main.asyncAfter(deadline: .now() + 1.0) {
             expectation.fulfill()
         }
-        wait(for: [expectation], timeout: 2.0)
+        wait(for: [expectation], timeout: 3.0)
 
         let samples = engine.stopRecording()
 

--- a/Tests/VocaMacTests/ServiceTests.swift
+++ b/Tests/VocaMacTests/ServiceTests.swift
@@ -1237,6 +1237,64 @@ final class AudioEngineDeviceChangeTests: XCTestCase {
 
 final class AudioEngineInputRouteFallbackTests: XCTestCase {
 
+    func testApplicationInputMuteRecoveryDecision() {
+        XCTAssertEqual(
+            AudioEngine.inputMuteRecovery(isMuted: false, handlerAvailable: false),
+            .noAction
+        )
+        XCTAssertEqual(
+            AudioEngine.inputMuteRecovery(isMuted: true, handlerAvailable: true),
+            .clearMute
+        )
+        XCTAssertEqual(
+            AudioEngine.inputMuteRecovery(isMuted: true, handlerAvailable: false),
+            .unavailable
+        )
+    }
+
+    func testApplicationInputMuteChangeControlsCaptureState() {
+        defer { AudioEngine.applyApplicationInputMuteChange(false) }
+
+        XCTAssertTrue(AudioEngine.applyApplicationInputMuteChange(true))
+        XCTAssertTrue(AudioEngine.isApplicationInputMutedForCapture())
+
+        XCTAssertTrue(AudioEngine.applyApplicationInputMuteChange(false))
+        XCTAssertFalse(AudioEngine.isApplicationInputMutedForCapture())
+    }
+
+    func testSystemDefaultRouteDoesNotRequireCurrentDeviceMutation() {
+        XCTAssertTrue(
+            AudioEngine.shouldFollowSystemDefaultInput(
+                requestedDeviceID: nil,
+                defaultDeviceID: 42
+            ),
+            "System Default should let AVAudioEngine own the route"
+        )
+        XCTAssertTrue(
+            AudioEngine.shouldFollowSystemDefaultInput(
+                requestedDeviceID: 42,
+                defaultDeviceID: 42
+            ),
+            "Pinning the current default should not perform a redundant CurrentDevice write"
+        )
+    }
+
+    func testNonDefaultRouteStillRequiresExplicitConfiguration() {
+        XCTAssertFalse(
+            AudioEngine.shouldFollowSystemDefaultInput(
+                requestedDeviceID: 41,
+                defaultDeviceID: 42
+            )
+        )
+        XCTAssertFalse(
+            AudioEngine.shouldFollowSystemDefaultInput(
+                requestedDeviceID: nil,
+                defaultDeviceID: nil
+            ),
+            "No input device must remain a startup failure"
+        )
+    }
+
     func testCandidatesTryRequestedDeviceBeforeSystemDefault() {
         XCTAssertEqual(
             AudioEngine.inputRouteCandidates(requestedDeviceID: 42, defaultDeviceID: 7),

--- a/Tests/VocaMacTests/ServiceTests.swift
+++ b/Tests/VocaMacTests/ServiceTests.swift
@@ -445,6 +445,20 @@ extension XCTestCase {
 
 final class AudioEngineTests: XCTestCase {
 
+    func testPreparingCaptureAcceptsBuffersWithoutEvaluatingStopConditions() {
+        XCTAssertFalse(AudioCapturePhase.stopped.acceptsInputBuffers)
+        XCTAssertFalse(AudioCapturePhase.stopped.evaluatesStopConditions)
+
+        XCTAssertTrue(AudioCapturePhase.preparing.acceptsInputBuffers)
+        XCTAssertFalse(
+            AudioCapturePhase.preparing.evaluatesStopConditions,
+            "Bluetooth startup buffers must not fire silence or max-duration callbacks"
+        )
+
+        XCTAssertTrue(AudioCapturePhase.recording.acceptsInputBuffers)
+        XCTAssertTrue(AudioCapturePhase.recording.evaluatesStopConditions)
+    }
+
     func testStopRecordingWithoutStartReturnsEmpty() {
         let engine = AudioEngine()
         let samples = engine.stopRecording()


### PR DESCRIPTION
## Why

Several users (and I) hit the same cluster of symptoms: push-to-talk does nothing, recording gets stuck, the first word is missing, "No microphone audio detected" on Bluetooth, or the transcript clearly came from the built-in mic instead of the selected one. Digging in, these are five separate causes.

## What was wrong

**1. Deadlock between the input tap and stopping the engine.** `processAudioBuffer` runs on Core Audio's render thread and started with `guard isCurrentlyRecording`, which reads through `lifecycleQueue.sync`. `stopRecording()` *holds* `lifecycleQueue` while calling `engine.stop()`, which waits for the render thread to finish. Render thread waits on the queue; queue waits on the render thread. This is the "mic just stops working / recording is stuck" report, and it gets likelier the more you record.

The tap now reads a realtime-safe mirror flag (`OSAllocatedUnfairLock<Bool>`) that never touches `lifecycleQueue`.

**2. Clipped first words.** The tap was installed *before* `_isCurrentlyRecording = true`, so every buffer arriving in between was discarded — on short push-to-talk bursts, that's the start of the sentence. Capture now arms right before `engine.start()`; failure paths still clear the buffer.

**3. One route failure killed the whole recording.** If Core Audio wouldn't apply the pinned device (Bluetooth mid A2DP→HFP switch, a device another app holds exclusively, a USB mic that just re-enumerated), `configureInputRoute` returned `nil` and the recording was abandoned. It now tries the pinned mic, then falls back to the system default (`inputRouteCandidates`), and surfaces which device it actually used. Related to the tail of #196.

**4. Push-to-talk blocked on the Bluetooth settle.** A headset takes up to `bluetoothInputRouteConfigurationTimeout` (3 s) to switch to its mic, and `startRecording` holds the lifecycle queue for the whole negotiation. Release the hotkey during it and `stopRecording` queued *behind* the settle, waited it out, and handed back an empty buffer — "No microphone audio detected", every time, for anyone who speaks in short bursts on AirPods.

`cancelPendingStart()` sets a lock-free flag that the settle loops and each stage of `startRecording` check, so an abandoned start unwinds within about one poll interval (~50 ms) instead of running to the timeout. The engine is deliberately kept warm on that path — the negotiated route is the expensive part, and someone who released too early is about to press again, so the retry is instant.

`AppState` defers a stop that arrives mid-start instead of blocking on it, then finishes once the start returns: transcribe if the engine reached capture, otherwise tell the user the microphone was still connecting and to hold until the start sound. Overlay cancel takes the same path and ends silently.

**5. The overlay claimed to be listening before it was.** It was shown in its recording phase the moment the hotkey was pressed, while the engine was still negotiating the route — so on a headset you got up to three seconds of an indicator saying "listening" while nothing was captured, and your first words vanished with no explanation.

The overlay now opens in a new `connecting` phase (muted accent, spinner, "Waiting for microphone…") and only flips to recording when the engine confirms the route is live. A start that fails or is abandoned never reaches the recording phase.

**6. Silent failures and stale device lists.** A failed start dropped back to `.idle` with no explanation — press the hotkey, nothing happens. And the pickers were only rebuilt on `onAppear` plus a manual Refresh button, so connecting or dropping a headset while the menu or Settings was open left you choosing from a list that no longer matched reality.

`AudioDeviceMonitor` (new) watches `kAudioHardwarePropertyDevices` and `kAudioHardwarePropertyDefaultInputDevice`, coalesced at 300 ms since Bluetooth profile switches fire several changes in a row. Both pickers refresh live, and a fallback shows as "X is unavailable — recording from Y."

## Testing

- `swift test` — 410 tests, 0 failures (3 skipped), confirmed across sixteen consecutive runs.
- The intermittent failure I flagged earlier is identified and fixed: `testAudioBufferNotEmptyAfterRecording` recorded for 300 ms and asserted the buffer was non-empty. A cold Core Audio start does not guarantee a buffer that fast once other tests in the process are cycling the same device — it failed about one full-suite run in twelve while passing 10/10 in isolation. The window is now 1 s, which is still a tight assertion but no longer races the hardware.
- New coverage: `inputRouteCandidates` ordering/dedupe; `testStartStopCyclesDoNotDeadlock` (five real start/stop cycles against the machine's microphone, skipped on CI); stop-and-cancel during a slow start, asserting the stop returns in under 200 ms and nothing is sent to transcription; that a stale cancel cannot poison the next start; and that the overlay never enters its recording phase unless the engine actually went live.
- Manually exercised on hardware — dictation is working reliably again.
- Two existing tests changed, both encoding behavior this PR deliberately replaces: a failed start now reports `.error` with a message rather than a silent `.idle`, and a stop during a slow start now abandons the start instead of waiting it out.

## Deliberately not done

Keeping the negotiated Bluetooth route warm for longer would let back-to-back dictations skip the settle entirely, but it holds the headset in HFP and drops music to headset quality for that window. Not worth the trade.

## M4 Pro / M4 Air follow-up

The reported M4 Pro and M4 Air failure exposed two more startup gaps. When the selected input was already the system default, VocaMac still wrote Core Audio's `kAudioOutputUnitProperty_CurrentDevice`; on the affected path that redundant mutation can return OSStatus `'nope'` or leave AUHAL delivering zero-filled input. VocaMac now lets `AVAudioEngine` follow the default route naturally and only mutates `CurrentDevice` for a real non-default override.

Microphone permission now uses the macOS 14+ `AVAudioApplication` API. At dictation start, VocaMac clears any stale per-application input mute that would deliberately zero microphone samples. The required macOS mute callback is also implemented correctly: a later headset/application mute keeps timing intact while replacing captured frames with zeros.

Startup still requires a real first input buffer before the UI reports the mic as live and cold-retries a graph whose route applied without opening an input stream.

### Review follow-up

- pre-live input now uses an explicit `preparing` capture phase: buffers are retained for the first word, but silence and max-duration callbacks cannot fire until the route is confirmed live
- a restarted graph that delivers no input now disables capture, removes the tap, and stops the engine before retirement; a successful restart restores the live recording phase

### Additional verification

- `swift test --scratch-path /Users/kanishkpachauri/Projects/vocamac/.build` — 415 tests passed, 3 skipped, 0 failures
- `make build` — release app built and ad-hoc signed successfully
- `git diff --check upstream/main...HEAD`
- Physical verification on the specifically affected M4 Pro and M4 Air is still required; automated tests cannot reproduce their microphone hardware or macOS privacy state.
