### PR TITLE
chore: prepare VocaMac 0.9.0

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -8,8 +8,8 @@
 # 3. Code signs — Developer ID if CODE_SIGN_IDENTITY is set, ad-hoc otherwise
 #
 # Environment variables:
-#   APP_VERSION         — Version string to embed in Info.plist. Defaults to 0.8.0.
-#                         Set by CI for nightly builds (e.g., 0.8.0-nightly.20260512+abc1234).
+#   APP_VERSION         — Version string to embed in Info.plist. Defaults to 0.9.0.
+#                         Set by CI for nightly builds (e.g., 0.9.0-nightly.20260512+abc1234).
 #   CODE_SIGN_IDENTITY  — Signing identity to use. Defaults to auto-detect
 #                         Developer ID Application in the login keychain.
 #                         Set to "-" to force ad-hoc signing.
@@ -29,7 +29,7 @@ BUNDLE_ID="com.vocamac.app"
 APP_NAME="VocaMac"
 APP_DIR="${APP_NAME}.app"
 ENTITLEMENTS="VocaMac.entitlements"
-APP_VERSION="${APP_VERSION:-0.8.0}"
+APP_VERSION="${APP_VERSION:-0.9.0}"
 
 # Resolve signing identity:
 # 1. Use CODE_SIGN_IDENTITY env var if set


### PR DESCRIPTION
## Summary

Prepares the v0.9.0 minor release. This release adds text snippets and selectable dictation tones, hardens microphone startup and device switching, and refreshes the About, community, and installer experience.

### Changes since v0.8.0

| PR | Type | Summary |
|---|---|---|
| #224 | docs/web | Publish the v0.8.0 product facts on vocamac.com |
| #225 | docs | Describe the shipped multi-engine transcription support |
| #226 | docs/web | Use consistent public document titles |
| #227 | feat | Add ten selectable start and stop dictation tone pairs, plus Off |
| #228 | fix/web | Keep headings sans-serif on Windows Chrome |
| #229 | ui/web | Restore the hero teal and VocaHQ heading scale |
| #231 | docs/web | Point Discord and X links at the VocaHQ community |
| #232 | chore | Welcome new issues and pull requests through the shared workflow |
| #235 | docs | Refresh contributor guidance and worktree requirements |
| #233 | fix | Repair microphone startup, route switching, cancellation, and live device refresh |
| #150 | feat | Add custom text snippets for dictation output |
| #230 | feat | Rebuild About around this Mac, the VocaHQ family, and support links |
| #239 | fix/ui | Polish About and correct the VocaHQ Retina DMG installer |

Compare: https://github.com/VocaHQ/vocamac/compare/v0.8.0...171cac44c9420ca377c4033353f16afa8581bb05

### Version surface

- `scripts/build.sh`: default app version and nightly example move from `0.8.0` to `0.9.0`.
- `web/data/product.toml` intentionally remains on the verified `v0.8.0` release until the new assets exist. It will move to `v0.9.0` after publication and be verified against the live DMG.
- Release notes are drafted out of tree at `/tmp/RELEASE_NOTES_v0.9.0.md` and will become the GitHub Release description.

### Validation

- [x] Rebased onto merged PR #239 at `68b48c6`
- [x] `swift test`: 435 tests passed, 1 Accessibility-dependent test skipped, 0 failures
- [x] `swift build -c release`: optimized arm64 build completed successfully
- [x] `git diff --check`
- [x] PR #239 signed/notarized DMG manually approved, including corrected Finder installer layout
- [ ] Fresh `/build` signed and notarized v0.9.0 DMG tested before merge

### Release plan after approval

1. Squash merge this PR after the v0.9.0 test DMG is approved.
2. Tag the exact merged commit as `v0.9.0` and push the tag.
3. Verify the release workflow tests, signs, notarizes, and uploads the DMG, ZIP, and checksums.
4. Replace the generated draft body with the finalized product notes and publish it.
5. Verify the public release assets, checksums, website deployment, in-app update surface, and Homebrew cask.
6. Update the website's stable release metadata to the verified `v0.9.0` artifact.
