### PR TITLE
chore(web): publish v0.9.0 release metadata

### DIFF
--- a/web/data/product.toml
+++ b/web/data/product.toml
@@ -2,22 +2,22 @@
 #
 # Status and OS floor follow VocaHQ/vocahq PRODUCT.md (verified 2026-08-14):
 # Beta, macOS 14+ Apple Silicon, Homebrew or DMG, AGPL-3.0.
-# Version/artifact figures were verified against the tagged v0.8.0 release.
+# Version/artifact figures were verified against the tagged v0.9.0 release.
 # Re-verify this file before publishing a website change.
 #
-# Verified: 2026-08-18 against v0.8.0 and its tagged release assets.
+# Verified: 2026-08-24 against v0.9.0 and its tagged release assets.
 
 [stable]
-version = "0.8.0"
-tag = "v0.8.0"
+version = "0.9.0"
+tag = "v0.9.0"
 status = "Beta"
-released = "2026-08-18"
-releaseURL = "https://github.com/VocaHQ/vocamac/releases/tag/v0.8.0"
+released = "2026-08-24"
+releaseURL = "https://github.com/VocaHQ/vocamac/releases/tag/v0.9.0"
 releasesURL = "https://github.com/VocaHQ/vocamac/releases"
 latestURL = "https://github.com/VocaHQ/vocamac/releases/latest"
-dmg = "VocaMac-0.8.0-arm64.dmg"
-dmgURL = "https://github.com/VocaHQ/vocamac/releases/download/v0.8.0/VocaMac-0.8.0-arm64.dmg"
-dmgSize = "90 MB"
+dmg = "VocaMac-0.9.0-arm64.dmg"
+dmgURL = "https://github.com/VocaHQ/vocamac/releases/download/v0.9.0/VocaMac-0.9.0-arm64.dmg"
+dmgSize = "99 MB"
 
 [requirements]
 os = "macOS 14 Sonoma or later"
@@ -27,7 +27,7 @@ archNote = "Apple Silicon only. There is no supported Intel build."
 signing = "Developer ID signed and notarized by Apple"
 permissions = ["Microphone", "Accessibility", "Input Monitoring"]
 
-# Languages that can actually be pinned in Settings in v0.8.0, verified by
+# Languages that can actually be pinned in Settings in v0.9.0, verified by
 # counting the tags in the Transcription Language picker in SettingsView.swift.
 # The Whisper model is trained on ~99 languages, but only these are selectable,
 # so the site must not claim "99+ languages".
@@ -43,7 +43,7 @@ runtime = "CoreML"
 modelRepo = "argmaxinc/whisperkit-coreml"
 modelRepoURL = "https://huggingface.co/argmaxinc/whisperkit-coreml"
 
-# The WhisperKit model picker shown in Settings in v0.8.0 (ModelSize.standardCatalog).
+# The WhisperKit model picker shown in Settings in v0.9.0 (ModelSize.standardCatalog).
 # size/ram are the values the app itself reports.
 [[models]]
 id = "tiny"
@@ -109,7 +109,7 @@ ram = "10 GB"
 quality = "Best"
 note = "Highest accuracy. Wants a 16 GB Mac and patience."
 
-# Additional engines and models in v0.8.0. Sizes and notes follow the shipped
+# Additional engines and models in v0.9.0. Sizes and notes follow the shipped
 # catalogs in WhisperModel.swift and SherpaModelCatalog.swift.
 [[releaseModels]]
 id = "parakeet-v3"

--- a/web/tests/site.test.mjs
+++ b/web/tests/site.test.mjs
@@ -56,14 +56,14 @@ test("keeps navigation and anchors accessible", () => {
 });
 
 test("keeps the PRODUCT.md product boundary explicit", () => {
-  assert.match(index, /v0\.8\.0/);
+  assert.match(index, /v0\.9\.0/);
   assert.match(index, /macOS 14\+|macOS 14 Sonoma/);
   assert.match(index, /Apple Silicon/);
   assert.match(index, /WhisperKit/);
   assert.match(index, /model downloads/i);
   assert.match(index, /Beta/);
   assert.match(index, /includes Parakeet/i);
-  assert.match(index, /Additional engines and models available in v0\.8\.0/i);
+  assert.match(index, /Additional engines and models available in v0\.9\.0/i);
   assert.match(index, /Parakeet/);
   assert.match(index, /sherpa-onnx/);
   assert.doesNotMatch(index, /Stable release/i);
@@ -96,7 +96,7 @@ test("emits valid structured metadata", () => {
   assert.ok(jsonLd, "homepage JSON-LD is present");
   const structured = JSON.parse(jsonLd);
   assert.equal(structured["@type"], "SoftwareApplication");
-  assert.equal(structured.softwareVersion, "0.8.0");
+  assert.equal(structured.softwareVersion, "0.9.0");
   assert.equal(structured.processorRequirements, "Apple Silicon");
 });
 
@@ -141,7 +141,7 @@ test("keeps content available without javascript", () => {
   assert.match(index, /<details[^>]+open/);
   assert.match(index, /<summary>Does my voice leave my Mac\?<\/summary>/);
   assert.match(index, /brew install --cask vocamac/);
-  assert.match(index, /Download v0\.8\.0 DMG/);
+  assert.match(index, /Download v0\.9\.0 DMG/);
   assert.match(script, /IntersectionObserver/);
   assert.match(script, /setTimeout\(function \(\) \{ revealItems\.forEach\(reveal\); \}, 800\)/);
   assert.match(script, /event\.key === "Escape"/);


### PR DESCRIPTION
## Summary

Publishes the verified v0.9.0 release facts on vocamac.com after the signed artifacts became available.

- update the stable version, tag, release date, release URL, DMG name, download URL, and displayed 99 MB size
- update the version-scoped product comments to v0.9.0
- move the website assertions from v0.8.0 to v0.9.0

## Verification

- public release: https://github.com/VocaHQ/vocamac/releases/tag/v0.9.0
- DMG: `VocaMac-0.9.0-arm64.dmg`, 99,238,000 bytes
- SHA-256: `a06db1d2ff92085f86a85171ecb79930a75092e99dcb7cdb25e537249ff9195d`
- `npm run check`: Hugo build and all 10 website tests pass
- `git diff --check`
