### PR TITLE
Point About Discord at the standing invite

### DIFF
--- a/Sources/VocaMac/Models/AboutSocialMark.swift
+++ b/Sources/VocaMac/Models/AboutSocialMark.swift
@@ -39,7 +39,7 @@ enum AboutSocialMark: String, CaseIterable, Identifiable {
         case .github:
             return URL(string: "https://github.com/VocaHQ/vocamac/issues")!
         case .discord:
-            return URL(string: "https://discord.gg/UMJduhcqn")!
+            return URL(string: "https://discord.gg/t6muquAJbm")!
         case .x:
             return URL(string: "https://x.com/vocahq")!
         case .mail:

--- a/Tests/VocaMacTests/AboutSocialMarkTests.swift
+++ b/Tests/VocaMacTests/AboutSocialMarkTests.swift
@@ -39,7 +39,7 @@ final class AboutSocialMarkTests: XCTestCase {
         )
         XCTAssertEqual(
             AboutSocialMark.discord.url.absoluteString,
-            "https://discord.gg/UMJduhcqn"
+            "https://discord.gg/t6muquAJbm"
         )
         XCTAssertEqual(AboutSocialMark.x.url.absoluteString, "https://x.com/vocahq")
         XCTAssertEqual(AboutSocialMark.mail.url.absoluteString, "mailto:hello@vocahq.com")


### PR DESCRIPTION
About still used an invite that expires. This points the Talk to us Discord button at https://discord.gg/t6muquAJbm, the same standing invite README already uses.

Draft until CI is green.