### PR TITLE
Fix silence detection for multi-channel microphones

### DIFF
--- a/Sources/VocaMac/Models/AppState.swift
+++ b/Sources/VocaMac/Models/AppState.swift
@@ -105,6 +105,7 @@ final class AppState: ObservableObject {
     @AppStorage("vocamac.maxRecordingDuration") var maxRecordingDuration: Int = 60
     @AppStorage("vocamac.selectedAudioDeviceID") var selectedAudioDeviceID: String = ""
     @AppStorage("vocamac.selectedAudioDeviceName") var selectedAudioDeviceName: String = ""
+    @AppStorage("vocamac.selectedAudioChannel") var selectedAudioChannel: Int = 0
     @AppStorage(PreferenceKey.selectedModelSize) var selectedModelSize: String = ModelSize.tiny.rawValue
     @AppStorage(PreferenceKey.selectedLanguage) var selectedLanguage: String = "auto"
     @AppStorage("vocamac.launchAtLogin") var launchAtLogin: Bool = false
@@ -194,7 +195,11 @@ final class AppState: ObservableObject {
     /// Persist the microphone VocaMac should use for future recordings.
     /// Passing nil restores the system-default input behavior.
     func selectAudioDevice(_ device: AudioDevice?) {
-        selectedAudioDeviceID = device?.id ?? ""
+        let newDeviceID = device?.id ?? ""
+        if selectedAudioDeviceID != newDeviceID {
+            selectedAudioChannel = 0
+        }
+        selectedAudioDeviceID = newDeviceID
         selectedAudioDeviceName = device?.name ?? ""
     }
 
@@ -254,13 +259,15 @@ final class AppState: ObservableObject {
             silenceThreshold: Float,
             silenceDuration: Double,
             maxDuration: TimeInterval,
-            preferredInputDeviceID: String?
+            preferredInputDeviceID: String?,
+            preferredInputChannel: Int
         ) -> Bool {
             audioEngine.startRecording(
                 silenceThreshold: silenceThreshold,
                 silenceDuration: silenceDuration,
                 maxDuration: maxDuration,
-                preferredInputDeviceID: preferredInputDeviceID
+                preferredInputDeviceID: preferredInputDeviceID,
+                preferredInputChannel: preferredInputChannel
             )
         }
 
@@ -939,7 +946,8 @@ final class AppState: ObservableObject {
             silenceThreshold: Float(silenceThreshold),
             silenceDuration: silenceDuration,
             maxDuration: TimeInterval(maxRecordingDuration),
-            preferredInputDeviceID: selectedAudioDeviceID.isEmpty ? nil : selectedAudioDeviceID
+            preferredInputDeviceID: selectedAudioDeviceID.isEmpty ? nil : selectedAudioDeviceID,
+            preferredInputChannel: selectedAudioChannel
         )
         isStartingAudio = false
 
@@ -1143,7 +1151,8 @@ final class AppState: ObservableObject {
         silenceThreshold: Float,
         silenceDuration: Double,
         maxDuration: TimeInterval,
-        preferredInputDeviceID: String?
+        preferredInputDeviceID: String?,
+        preferredInputChannel: Int
     ) async -> Bool {
         let worker = AudioEngineWorker(audioEngine: audioEngine)
         return await withCheckedContinuation { continuation in
@@ -1152,7 +1161,8 @@ final class AppState: ObservableObject {
                     silenceThreshold: silenceThreshold,
                     silenceDuration: silenceDuration,
                     maxDuration: maxDuration,
-                    preferredInputDeviceID: preferredInputDeviceID
+                    preferredInputDeviceID: preferredInputDeviceID,
+                    preferredInputChannel: preferredInputChannel
                 )
                 continuation.resume(returning: didStart)
             }

--- a/Sources/VocaMac/Models/AppState.swift
+++ b/Sources/VocaMac/Models/AppState.swift
@@ -101,7 +101,7 @@ final class AppState: ObservableObject {
     @AppStorage("vocamac.hotKeyModifiers") var hotKeyModifiers: HotKeyModifiers = []
     @AppStorage("vocamac.doubleTapThreshold") var doubleTapThreshold: Double = 0.4
     @AppStorage("vocamac.silenceThreshold") var silenceThreshold: Double = 0.01
-    @AppStorage("vocamac.silenceDuration") var silenceDuration: Double = 2.0
+    @AppStorage("vocamac.silenceDuration") var silenceDuration: Double = SilenceDetectionSettings.defaultDuration
     @AppStorage("vocamac.maxRecordingDuration") var maxRecordingDuration: Int = 60
     @AppStorage("vocamac.selectedAudioDeviceID") var selectedAudioDeviceID: String = ""
     @AppStorage("vocamac.selectedAudioDeviceName") var selectedAudioDeviceName: String = ""

--- a/Sources/VocaMac/Models/AppState.swift
+++ b/Sources/VocaMac/Models/AppState.swift
@@ -106,6 +106,8 @@ final class AppState: ObservableObject {
     @AppStorage("vocamac.selectedAudioDeviceID") var selectedAudioDeviceID: String = ""
     @AppStorage("vocamac.selectedAudioDeviceName") var selectedAudioDeviceName: String = ""
     @AppStorage("vocamac.selectedAudioChannel") var selectedAudioChannel: Int = 0
+    @AppStorage("vocamac.selectedAudioChannelDeviceID") var selectedAudioChannelDeviceID: String = ""
+    @AppStorage("vocamac.selectedAudioChannelCount") var selectedAudioChannelCount: Int = 0
     @AppStorage(PreferenceKey.selectedModelSize) var selectedModelSize: String = ModelSize.tiny.rawValue
     @AppStorage(PreferenceKey.selectedLanguage) var selectedLanguage: String = "auto"
     @AppStorage("vocamac.launchAtLogin") var launchAtLogin: Bool = false
@@ -198,9 +200,39 @@ final class AppState: ObservableObject {
         let newDeviceID = device?.id ?? ""
         if selectedAudioDeviceID != newDeviceID {
             selectedAudioChannel = 0
+            selectedAudioChannelDeviceID = newDeviceID
+            selectedAudioChannelCount = device?.channelCount ?? 0
         }
         selectedAudioDeviceID = newDeviceID
         selectedAudioDeviceName = device?.name ?? ""
+
+        if let device {
+            syncSelectedAudioChannel(with: device)
+        }
+    }
+
+    /// Persist the physical interface input selected for a specific device layout.
+    func selectAudioChannel(_ channel: Int, for device: AudioDevice) {
+        selectedAudioChannelDeviceID = device.id
+        selectedAudioChannelCount = device.channelCount
+        guard device.channelCount > 0, channel >= 0, channel < device.channelCount else {
+            selectedAudioChannel = 0
+            return
+        }
+        selectedAudioChannel = channel
+    }
+
+    /// Reset a saved channel when the active device or its channel layout changes.
+    func syncSelectedAudioChannel(with device: AudioDevice) {
+        let mappingIsCurrent = selectedAudioChannelDeviceID == device.id
+            && selectedAudioChannelCount == device.channelCount
+        let channelIsValid = selectedAudioChannel >= 0
+            && selectedAudioChannel < device.channelCount
+        if !mappingIsCurrent || !channelIsValid {
+            selectedAudioChannel = 0
+        }
+        selectedAudioChannelDeviceID = device.id
+        selectedAudioChannelCount = device.channelCount
     }
 
     /// Custom text snippets for expansion
@@ -260,14 +292,18 @@ final class AppState: ObservableObject {
             silenceDuration: Double,
             maxDuration: TimeInterval,
             preferredInputDeviceID: String?,
-            preferredInputChannel: Int
+            preferredInputChannel: Int,
+            preferredInputChannelDeviceID: String?,
+            preferredInputChannelCount: Int
         ) -> Bool {
             audioEngine.startRecording(
                 silenceThreshold: silenceThreshold,
                 silenceDuration: silenceDuration,
                 maxDuration: maxDuration,
                 preferredInputDeviceID: preferredInputDeviceID,
-                preferredInputChannel: preferredInputChannel
+                preferredInputChannel: preferredInputChannel,
+                preferredInputChannelDeviceID: preferredInputChannelDeviceID,
+                preferredInputChannelCount: preferredInputChannelCount
             )
         }
 
@@ -947,7 +983,11 @@ final class AppState: ObservableObject {
             silenceDuration: silenceDuration,
             maxDuration: TimeInterval(maxRecordingDuration),
             preferredInputDeviceID: selectedAudioDeviceID.isEmpty ? nil : selectedAudioDeviceID,
-            preferredInputChannel: selectedAudioChannel
+            preferredInputChannel: selectedAudioChannel,
+            preferredInputChannelDeviceID: selectedAudioChannelDeviceID.isEmpty
+                ? nil
+                : selectedAudioChannelDeviceID,
+            preferredInputChannelCount: selectedAudioChannelCount
         )
         isStartingAudio = false
 
@@ -1152,7 +1192,9 @@ final class AppState: ObservableObject {
         silenceDuration: Double,
         maxDuration: TimeInterval,
         preferredInputDeviceID: String?,
-        preferredInputChannel: Int
+        preferredInputChannel: Int,
+        preferredInputChannelDeviceID: String?,
+        preferredInputChannelCount: Int
     ) async -> Bool {
         let worker = AudioEngineWorker(audioEngine: audioEngine)
         return await withCheckedContinuation { continuation in
@@ -1162,7 +1204,9 @@ final class AppState: ObservableObject {
                     silenceDuration: silenceDuration,
                     maxDuration: maxDuration,
                     preferredInputDeviceID: preferredInputDeviceID,
-                    preferredInputChannel: preferredInputChannel
+                    preferredInputChannel: preferredInputChannel,
+                    preferredInputChannelDeviceID: preferredInputChannelDeviceID,
+                    preferredInputChannelCount: preferredInputChannelCount
                 )
                 continuation.resume(returning: didStart)
             }

--- a/Sources/VocaMac/Models/SilenceDetectionSettings.swift
+++ b/Sources/VocaMac/Models/SilenceDetectionSettings.swift
@@ -1,0 +1,15 @@
+// SilenceDetectionSettings.swift
+// VocaMac
+
+import Foundation
+
+/// Validation shared by the Audio settings UI and recording startup.
+enum SilenceDetectionSettings {
+    static let defaultDuration: TimeInterval = 2.0
+    static let durationRange: ClosedRange<TimeInterval> = 0.5...300.0
+
+    static func clampedDuration(_ duration: TimeInterval) -> TimeInterval {
+        guard duration.isFinite else { return defaultDuration }
+        return min(max(duration, durationRange.lowerBound), durationRange.upperBound)
+    }
+}

--- a/Sources/VocaMac/Services/AudioEngine.swift
+++ b/Sources/VocaMac/Services/AudioEngine.swift
@@ -99,6 +99,9 @@ final class AudioEngine {
     private var configuredInputDeviceID: AudioDeviceID?
     /// Zero-based input channel chosen by the user for multi-channel devices.
     private var preferredInputChannel = 0
+    /// Device layout the persisted input-channel index belongs to.
+    private var preferredInputChannelDeviceUID: String?
+    private var preferredInputChannelCount = 0
     /// Last UID passed to `startRecording`, used to rebuild the graph after a
     /// configuration change without dropping the user's selected microphone.
     private var lastPreferredInputDeviceUID: String?
@@ -396,6 +399,10 @@ final class AudioEngine {
             )
             return false
         }
+        syncPreferredInputChannel(
+            with: configuredInputDeviceID,
+            channelCount: Int(inputFormat.channelCount)
+        )
 
         if let startFailure = installTapAndStart(engine: engine, inputNode: inputNode, inputFormat: inputFormat) {
             VocaLogger.error(.audioEngine, "Failed to restart audio engine after configuration change: \(startFailure)")
@@ -475,6 +482,8 @@ final class AudioEngine {
     ///   - silenceDuration: Seconds of silence before triggering silence detection callback
     ///   - maxDuration: Maximum recording duration in seconds
     ///   - preferredInputChannel: Zero-based channel to capture from a multi-channel device
+    ///   - preferredInputChannelDeviceID: Device UID the saved channel belongs to
+    ///   - preferredInputChannelCount: Channel count when the selection was saved
     /// - Returns: `true` when the engine is recording, otherwise `false`.
     @discardableResult
     func startRecording(
@@ -482,7 +491,9 @@ final class AudioEngine {
         silenceDuration: Double = 2.0,
         maxDuration: TimeInterval = 60.0,
         preferredInputDeviceID: String? = nil,
-        preferredInputChannel: Int = 0
+        preferredInputChannel: Int = 0,
+        preferredInputChannelDeviceID: String? = nil,
+        preferredInputChannelCount: Int = 0
     ) -> Bool {
         lifecycleQueue.sync {
             guard !self._isCurrentlyRecording else { return true }
@@ -504,6 +515,8 @@ final class AudioEngine {
             self.silenceDuration = SilenceDetectionSettings.clampedDuration(silenceDuration)
             self.maxDuration = maxDuration
             self.preferredInputChannel = max(0, preferredInputChannel)
+            self.preferredInputChannelDeviceUID = preferredInputChannelDeviceID
+            self.preferredInputChannelCount = max(0, preferredInputChannelCount)
 
             guard Self.prepareApplicationInputForRecording() else {
                 return false
@@ -547,6 +560,10 @@ final class AudioEngine {
                     recoverFromStartFailure(notifyAppState: false)
                     return false
                 }
+                self.syncPreferredInputChannel(
+                    with: configuredInputDeviceID,
+                    channelCount: Int(inputFormat.channelCount)
+                )
 
                 // A previous failed start can leave a tap installed even when our
                 // recording flag is false. Remove any stale tap before installing a
@@ -1201,6 +1218,50 @@ final class AudioEngine {
         return outputBuffer
     }
 
+    /// Keeps a channel selection only while it still describes the live device layout.
+    private func syncPreferredInputChannel(
+        with deviceID: AudioDeviceID,
+        channelCount: Int
+    ) {
+        let activeDeviceUID = Self.audioDeviceUID(for: deviceID)
+        let resolvedChannel = Self.resolvedInputChannel(
+            requestedChannel: preferredInputChannel,
+            mappedDeviceUID: preferredInputChannelDeviceUID,
+            mappedChannelCount: preferredInputChannelCount,
+            activeDeviceUID: activeDeviceUID,
+            activeChannelCount: channelCount
+        )
+        if resolvedChannel != preferredInputChannel {
+            VocaLogger.warning(
+                .audioEngine,
+                "Saved input channel no longer matches the active device layout; using channel 1"
+            )
+        }
+        preferredInputChannel = resolvedChannel
+        preferredInputChannelDeviceUID = activeDeviceUID
+        preferredInputChannelCount = channelCount
+    }
+
+    /// Returns the saved channel only when its device identity and topology are still current.
+    static func resolvedInputChannel(
+        requestedChannel: Int,
+        mappedDeviceUID: String?,
+        mappedChannelCount: Int,
+        activeDeviceUID: String?,
+        activeChannelCount: Int
+    ) -> Int {
+        guard activeChannelCount > 0,
+              requestedChannel >= 0,
+              requestedChannel < activeChannelCount,
+              let mappedDeviceUID,
+              !mappedDeviceUID.isEmpty,
+              mappedDeviceUID == activeDeviceUID,
+              mappedChannelCount == activeChannelCount else {
+            return 0
+        }
+        return requestedChannel
+    }
+
     /// Copies one selected channel into a mono Float32 buffer without attenuation.
     static func monoBuffer(
         from buffer: AVAudioPCMBuffer,
@@ -1228,7 +1289,9 @@ final class AudioEngine {
             return nil
         }
 
-        let selectedChannel = min(max(requestedChannel, 0), channelCount - 1)
+        let selectedChannel = requestedChannel >= 0 && requestedChannel < channelCount
+            ? requestedChannel
+            : 0
 
         for frame in 0..<frameCount {
             monoData[frame] = format.isInterleaved

--- a/Sources/VocaMac/Services/AudioEngine.swift
+++ b/Sources/VocaMac/Services/AudioEngine.swift
@@ -26,6 +26,42 @@ enum AudioCapturePhase: Equatable {
     var evaluatesStopConditions: Bool { self == .recording }
 }
 
+/// Tracks continuous silence independently of total recording time.
+struct SilenceDetector {
+    private(set) var lastSoundTime: Date
+    private(set) var hasReportedSilence = false
+
+    init(now: Date = Date()) {
+        lastSoundTime = now
+    }
+
+    mutating func reset(at now: Date = Date()) {
+        lastSoundTime = now
+        hasReportedSilence = false
+    }
+
+    mutating func observe(
+        energy: Float,
+        threshold: Float,
+        duration: TimeInterval,
+        at now: Date
+    ) -> Bool {
+        if energy > threshold {
+            lastSoundTime = now
+            hasReportedSilence = false
+            return false
+        }
+
+        guard !hasReportedSilence,
+              now.timeIntervalSince(lastSoundTime) >= duration else {
+            return false
+        }
+
+        hasReportedSilence = true
+        return true
+    }
+}
+
 final class AudioEngine {
 
     // MARK: - Properties
@@ -82,6 +118,9 @@ final class AudioEngine {
     static let firstInputBufferTimeout: TimeInterval = 0.75
     static let firstInputBufferPollInterval: TimeInterval = 0.01
     static let idleEngineReleaseDelay: TimeInterval = 3.0
+    /// A nil format asks AVAudioEngine to bind the tap to the input node's live
+    /// hardware format. The format can change while USB and Bluetooth routes settle.
+    static let inputTapFormat: AVAudioFormat? = nil
 
     /// Mirrors AVAudioApplication's mute state for the realtime input tap.
     private static let applicationInputMuted = OSAllocatedUnfairLock(initialState: false)
@@ -120,7 +159,7 @@ final class AudioEngine {
     }
 
     // Silence detection
-    private var lastSoundTime: Date = Date()
+    private let silenceDetector = OSAllocatedUnfairLock(initialState: SilenceDetector())
     private var silenceThreshold: Float = 0.01
     private var silenceDuration: Double = 2.0
     private var maxDuration: TimeInterval = 60.0
@@ -286,7 +325,7 @@ final class AudioEngine {
 
                 VocaLogger.warning(.audioEngine, "Failed to restart audio graph after configuration change")
                 self.setRecordingActive(false)
-                self.silenceCallbackFired = false
+                self.silenceDetector.withLock { $0.reset() }
                 self.maxDurationCallbackFired = false
                 self.removeInputTap(reason: "audio configuration change")
                 self.retireEngineAfterConfigurationChange()
@@ -458,7 +497,7 @@ final class AudioEngine {
 
             self.lastPreferredInputDeviceUID = preferredInputDeviceID
             self.silenceThreshold = silenceThreshold
-            self.silenceDuration = silenceDuration
+            self.silenceDuration = SilenceDetectionSettings.clampedDuration(silenceDuration)
             self.maxDuration = maxDuration
 
             guard Self.prepareApplicationInputForRecording() else {
@@ -524,8 +563,12 @@ final class AudioEngine {
                 let exception = VocaObjCExceptionCatcher.catchException { [weak self] in
                     guard let self = self else { return }
 
-                    inputNode.installTap(onBus: 0, bufferSize: 4096, format: inputFormat) { [weak self] buffer, _ in
-                        self?.processAudioBuffer(buffer, inputFormat: inputFormat)
+                    inputNode.installTap(
+                        onBus: 0,
+                        bufferSize: 4096,
+                        format: Self.inputTapFormat
+                    ) { [weak self] buffer, _ in
+                        self?.processAudioBuffer(buffer, inputFormat: buffer.format)
                     }
 
                     engine.prepare()
@@ -591,7 +634,7 @@ final class AudioEngine {
                 // Anchor max-duration / startup recovery to the moment capture
                 // actually begins, not the start of Bluetooth route settling.
                 recordingStartTime = Date()
-                lastSoundTime = Date()
+                silenceDetector.withLock { $0.reset() }
                 setRecordingActive(true)
                 return true
             }
@@ -635,7 +678,7 @@ final class AudioEngine {
             VocaLogger.warning(.audioEngine, "Force reset requested (wasRecording=\(_isCurrentlyRecording))")
 
             setRecordingActive(false)
-            silenceCallbackFired = false
+            silenceDetector.withLock { $0.reset() }
             maxDurationCallbackFired = false
 
             removeInputTap(reason: "force reset")
@@ -656,9 +699,8 @@ final class AudioEngine {
     /// Resets per-recording state before a new capture attempt.
     private func resetRecordingState() {
         clearAudioBuffer()
-        lastSoundTime = Date()
+        silenceDetector.withLock { $0.reset() }
         recordingStartTime = Date()
-        silenceCallbackFired = false
         maxDurationCallbackFired = false
     }
 
@@ -674,7 +716,7 @@ final class AudioEngine {
     private func setCaptureActive(_ active: Bool) {
         if active {
             firstBufferSeen.withLock { $0 = false }
-            lastSoundTime = Date()
+            silenceDetector.withLock { $0.reset() }
         }
         capturePhase.withLock { $0 = active ? .preparing : .stopped }
     }
@@ -753,8 +795,12 @@ final class AudioEngine {
         var startError: Error?
         let exception = VocaObjCExceptionCatcher.catchException { [weak self] in
             guard let self else { return }
-            inputNode.installTap(onBus: 0, bufferSize: 4096, format: inputFormat) { [weak self] buffer, _ in
-                self?.processAudioBuffer(buffer, inputFormat: inputFormat)
+            inputNode.installTap(
+                onBus: 0,
+                bufferSize: 4096,
+                format: Self.inputTapFormat
+            ) { [weak self] buffer, _ in
+                self?.processAudioBuffer(buffer, inputFormat: buffer.format)
             }
             engine.prepare()
             do {
@@ -789,7 +835,7 @@ final class AudioEngine {
     /// Must be called on `lifecycleQueue`.
     private func abandonCancelledStart() -> Bool {
         setRecordingActive(false)
-        silenceCallbackFired = false
+        silenceDetector.withLock { $0.reset() }
         maxDurationCallbackFired = false
         removeInputTap(reason: "cancelled start")
         if engine?.isRunning == true {
@@ -804,7 +850,7 @@ final class AudioEngine {
     /// Restores AudioEngine to a clean idle state after any failed start attempt.
     private func recoverFromStartFailure(notifyAppState: Bool) {
         setRecordingActive(false)
-        silenceCallbackFired = false
+        silenceDetector.withLock { $0.reset() }
         maxDurationCallbackFired = false
         removeInputTap(reason: "start failure")
         engine?.stop()
@@ -988,9 +1034,6 @@ final class AudioEngine {
 
     // MARK: - Audio Processing
 
-    /// Whether silence detection has already fired (prevents repeated callbacks)
-    private var silenceCallbackFired = false
-
     /// Whether max duration callback has already fired
     private var maxDurationCallbackFired = false
 
@@ -1008,7 +1051,7 @@ final class AudioEngine {
         firstBufferSeen.withLock { $0 = true }
 
         // Convert to whisper format (16kHz, mono, Float32)
-        guard let convertedBuffer = convertToWhisperFormat(buffer, from: inputFormat) else {
+        guard let convertedBuffer = Self.convertToWhisperFormat(buffer, from: inputFormat) else {
             return
         }
 
@@ -1055,41 +1098,64 @@ final class AudioEngine {
             return
         }
 
-        // Silence detection
-        if energy > silenceThreshold {
-            lastSoundTime = now
-            silenceCallbackFired = false  // Reset so silence can be detected again after speech resumes
-        } else if now.timeIntervalSince(lastSoundTime) >= silenceDuration && !silenceCallbackFired {
-            silenceCallbackFired = true
+        let didDetectSilence = silenceDetector.withLock {
+            $0.observe(
+                energy: energy,
+                threshold: silenceThreshold,
+                duration: silenceDuration,
+                at: now
+            )
+        }
+        if didDetectSilence {
             DispatchQueue.main.async { [weak self] in
                 self?.onSilenceDetected?()
             }
         }
     }
 
-    /// Convert an audio buffer to whisper.cpp's required format (16kHz, mono, Float32)
-    private func convertToWhisperFormat(
+    /// Converts an audio buffer to Whisper's required 16 kHz mono Float32 format.
+    ///
+    /// AVAudioConverter's implicit multi-channel downmix only reads channel 0
+    /// for stereo input and can emit all-zero output for devices with more than
+    /// two channels. Select the channel carrying the strongest signal first so
+    /// interfaces such as the four-channel EVO4 do not turn speech into silence.
+    static func convertToWhisperFormat(
         _ buffer: AVAudioPCMBuffer,
         from inputFormat: AVAudioFormat
     ) -> AVAudioPCMBuffer? {
-        let whisperFormat = AudioEngine.whisperFormat
+        let sourceBuffer: AVAudioPCMBuffer
+        if inputFormat.channelCount > 1 {
+            guard let monoBuffer = monoBufferSelectingLoudestChannel(buffer) else {
+                VocaLogger.error(.audioEngine, "Failed to read multi-channel microphone samples")
+                return nil
+            }
+            sourceBuffer = monoBuffer
+        } else {
+            sourceBuffer = buffer
+        }
+
+        let sourceFormat = sourceBuffer.format
+        let whisperFormat = Self.whisperFormat
 
         // If input is already in the right format, return as-is
-        if inputFormat.sampleRate == whisperFormat.sampleRate
-            && inputFormat.channelCount == whisperFormat.channelCount
-            && inputFormat.commonFormat == whisperFormat.commonFormat {
-            return buffer
+        if sourceFormat.sampleRate == whisperFormat.sampleRate
+            && sourceFormat.channelCount == whisperFormat.channelCount
+            && sourceFormat.commonFormat == whisperFormat.commonFormat {
+            return sourceBuffer
         }
 
         // Create a converter
-        guard let converter = AVAudioConverter(from: inputFormat, to: whisperFormat) else {
+        guard let converter = AVAudioConverter(from: sourceFormat, to: whisperFormat) else {
             VocaLogger.error(.audioEngine, "Failed to create audio format converter")
             return nil
         }
 
         // Calculate output frame capacity based on sample rate ratio
-        let ratio = whisperFormat.sampleRate / inputFormat.sampleRate
-        let outputFrameCapacity = AVAudioFrameCount(Double(buffer.frameLength) * ratio)
+        let ratio = whisperFormat.sampleRate / sourceFormat.sampleRate
+        let outputFrameCapacity = max(
+            1,
+            AVAudioFrameCount(ceil(Double(sourceBuffer.frameLength) * ratio))
+        )
 
         guard let outputBuffer = AVAudioPCMBuffer(
             pcmFormat: whisperFormat,
@@ -1098,20 +1164,80 @@ final class AudioEngine {
             return nil
         }
 
-        var error: NSError?
+        var didProvideInput = false
         let inputBlock: AVAudioConverterInputBlock = { _, outStatus in
+            guard !didProvideInput else {
+                outStatus.pointee = .endOfStream
+                return nil
+            }
+            didProvideInput = true
             outStatus.pointee = .haveData
-            return buffer
+            return sourceBuffer
         }
 
-        converter.convert(to: outputBuffer, error: &error, withInputFrom: inputBlock)
+        var error: NSError?
+        let status = converter.convert(to: outputBuffer, error: &error, withInputFrom: inputBlock)
 
-        if let error = error {
+        if let error {
             VocaLogger.error(.audioEngine, "Conversion error: \(error)")
             return nil
         }
+        guard status != .error else { return nil }
 
         return outputBuffer
+    }
+
+    /// Copies the loudest channel into a mono Float32 buffer without attenuating it.
+    /// Audio interfaces commonly expose several physical and loopback channels,
+    /// while dictation uses one microphone source at a time.
+    static func monoBufferSelectingLoudestChannel(
+        _ buffer: AVAudioPCMBuffer
+    ) -> AVAudioPCMBuffer? {
+        let format = buffer.format
+        let channelCount = Int(format.channelCount)
+        let frameCount = Int(buffer.frameLength)
+
+        guard channelCount > 0,
+              frameCount > 0,
+              format.commonFormat == .pcmFormatFloat32,
+              let channelData = buffer.floatChannelData,
+              let monoFormat = AVAudioFormat(
+                commonFormat: .pcmFormatFloat32,
+                sampleRate: format.sampleRate,
+                channels: 1,
+                interleaved: false
+              ),
+              let monoBuffer = AVAudioPCMBuffer(
+                pcmFormat: monoFormat,
+                frameCapacity: buffer.frameLength
+              ),
+              let monoData = monoBuffer.floatChannelData?[0] else {
+            return nil
+        }
+
+        var loudestChannel = 0
+        var loudestEnergy: Double = -1
+        for channel in 0..<channelCount {
+            var sumSquares = 0.0
+            for frame in 0..<frameCount {
+                let sample = format.isInterleaved
+                    ? channelData[0][frame * channelCount + channel]
+                    : channelData[channel][frame]
+                sumSquares += Double(sample * sample)
+            }
+            if sumSquares > loudestEnergy {
+                loudestChannel = channel
+                loudestEnergy = sumSquares
+            }
+        }
+
+        for frame in 0..<frameCount {
+            monoData[frame] = format.isInterleaved
+                ? channelData[0][frame * channelCount + loudestChannel]
+                : channelData[loudestChannel][frame]
+        }
+        monoBuffer.frameLength = buffer.frameLength
+        return monoBuffer
     }
 
     /// Calculate the RMS (root mean square) energy of an audio buffer

--- a/Sources/VocaMac/Services/AudioEngine.swift
+++ b/Sources/VocaMac/Services/AudioEngine.swift
@@ -97,6 +97,8 @@ final class AudioEngine {
     /// thread, so it must use the same realtime-safe state as `capturePhase`.
     private let firstBufferSeen = OSAllocatedUnfairLock(initialState: false)
     private var configuredInputDeviceID: AudioDeviceID?
+    /// Zero-based input channel chosen by the user for multi-channel devices.
+    private var preferredInputChannel = 0
     /// Last UID passed to `startRecording`, used to rebuild the graph after a
     /// configuration change without dropping the user's selected microphone.
     private var lastPreferredInputDeviceUID: String?
@@ -472,13 +474,15 @@ final class AudioEngine {
     ///   - silenceThreshold: RMS energy threshold below which audio is considered silence
     ///   - silenceDuration: Seconds of silence before triggering silence detection callback
     ///   - maxDuration: Maximum recording duration in seconds
+    ///   - preferredInputChannel: Zero-based channel to capture from a multi-channel device
     /// - Returns: `true` when the engine is recording, otherwise `false`.
     @discardableResult
     func startRecording(
         silenceThreshold: Float = 0.01,
         silenceDuration: Double = 2.0,
         maxDuration: TimeInterval = 60.0,
-        preferredInputDeviceID: String? = nil
+        preferredInputDeviceID: String? = nil,
+        preferredInputChannel: Int = 0
     ) -> Bool {
         lifecycleQueue.sync {
             guard !self._isCurrentlyRecording else { return true }
@@ -499,6 +503,7 @@ final class AudioEngine {
             self.silenceThreshold = silenceThreshold
             self.silenceDuration = SilenceDetectionSettings.clampedDuration(silenceDuration)
             self.maxDuration = maxDuration
+            self.preferredInputChannel = max(0, preferredInputChannel)
 
             guard Self.prepareApplicationInputForRecording() else {
                 return false
@@ -1051,7 +1056,11 @@ final class AudioEngine {
         firstBufferSeen.withLock { $0 = true }
 
         // Convert to whisper format (16kHz, mono, Float32)
-        guard let convertedBuffer = Self.convertToWhisperFormat(buffer, from: inputFormat) else {
+        guard let convertedBuffer = Self.convertToWhisperFormat(
+            buffer,
+            from: inputFormat,
+            inputChannel: preferredInputChannel
+        ) else {
             return
         }
 
@@ -1117,15 +1126,20 @@ final class AudioEngine {
     ///
     /// AVAudioConverter's implicit multi-channel downmix only reads channel 0
     /// for stereo input and can emit all-zero output for devices with more than
-    /// two channels. Select the channel carrying the strongest signal first so
-    /// interfaces such as the four-channel EVO4 do not turn speech into silence.
+    /// two channels. Extract the user's selected input first so interfaces such
+    /// as the four-channel EVO4 preserve the intended microphone without mixing
+    /// in loopback or unrelated physical inputs.
     static func convertToWhisperFormat(
         _ buffer: AVAudioPCMBuffer,
-        from inputFormat: AVAudioFormat
+        from inputFormat: AVAudioFormat,
+        inputChannel: Int = 0
     ) -> AVAudioPCMBuffer? {
         let sourceBuffer: AVAudioPCMBuffer
         if inputFormat.channelCount > 1 {
-            guard let monoBuffer = monoBufferSelectingLoudestChannel(buffer) else {
+            guard let monoBuffer = monoBuffer(
+                from: buffer,
+                selecting: inputChannel
+            ) else {
                 VocaLogger.error(.audioEngine, "Failed to read multi-channel microphone samples")
                 return nil
             }
@@ -1187,11 +1201,10 @@ final class AudioEngine {
         return outputBuffer
     }
 
-    /// Copies the loudest channel into a mono Float32 buffer without attenuating it.
-    /// Audio interfaces commonly expose several physical and loopback channels,
-    /// while dictation uses one microphone source at a time.
-    static func monoBufferSelectingLoudestChannel(
-        _ buffer: AVAudioPCMBuffer
+    /// Copies one selected channel into a mono Float32 buffer without attenuation.
+    static func monoBuffer(
+        from buffer: AVAudioPCMBuffer,
+        selecting requestedChannel: Int
     ) -> AVAudioPCMBuffer? {
         let format = buffer.format
         let channelCount = Int(format.channelCount)
@@ -1215,26 +1228,12 @@ final class AudioEngine {
             return nil
         }
 
-        var loudestChannel = 0
-        var loudestEnergy: Double = -1
-        for channel in 0..<channelCount {
-            var sumSquares = 0.0
-            for frame in 0..<frameCount {
-                let sample = format.isInterleaved
-                    ? channelData[0][frame * channelCount + channel]
-                    : channelData[channel][frame]
-                sumSquares += Double(sample * sample)
-            }
-            if sumSquares > loudestEnergy {
-                loudestChannel = channel
-                loudestEnergy = sumSquares
-            }
-        }
+        let selectedChannel = min(max(requestedChannel, 0), channelCount - 1)
 
         for frame in 0..<frameCount {
             monoData[frame] = format.isInterleaved
-                ? channelData[0][frame * channelCount + loudestChannel]
-                : channelData[loudestChannel][frame]
+                ? channelData[0][frame * channelCount + selectedChannel]
+                : channelData[selectedChannel][frame]
         }
         monoBuffer.frameLength = buffer.frameLength
         return monoBuffer

--- a/Sources/VocaMac/Services/ServiceProtocols.swift
+++ b/Sources/VocaMac/Services/ServiceProtocols.swift
@@ -23,7 +23,9 @@ protocol AudioRecording: AnyObject {
         silenceDuration: Double,
         maxDuration: TimeInterval,
         preferredInputDeviceID: String?,
-        preferredInputChannel: Int
+        preferredInputChannel: Int,
+        preferredInputChannelDeviceID: String?,
+        preferredInputChannelCount: Int
     ) -> Bool
     @discardableResult func stopRecording() -> [Float]
     func cancelPendingStart()

--- a/Sources/VocaMac/Services/ServiceProtocols.swift
+++ b/Sources/VocaMac/Services/ServiceProtocols.swift
@@ -22,7 +22,8 @@ protocol AudioRecording: AnyObject {
         silenceThreshold: Float,
         silenceDuration: Double,
         maxDuration: TimeInterval,
-        preferredInputDeviceID: String?
+        preferredInputDeviceID: String?,
+        preferredInputChannel: Int
     ) -> Bool
     @discardableResult func stopRecording() -> [Float]
     func cancelPendingStart()

--- a/Sources/VocaMac/Views/SettingsView.swift
+++ b/Sources/VocaMac/Views/SettingsView.swift
@@ -1313,17 +1313,21 @@ struct AudioSettingsTab: View {
 
                 HStack {
                     Text("Auto-stop after silence")
-                    Slider(
-                        value: $appState.silenceDuration,
-                        in: 0.5...5.0,
-                        step: 0.5
+                    Spacer()
+                    TextField(
+                        "Seconds",
+                        value: silenceDurationBinding,
+                        format: .number.precision(.fractionLength(0...1))
                     )
-                    Text("\(String(format: "%.1f", appState.silenceDuration))s")
-                        .monospacedDigit()
-                        .frame(width: 35)
+                    .textFieldStyle(.roundedBorder)
+                    .multilineTextAlignment(.trailing)
+                    .monospacedDigit()
+                    .frame(width: 72)
+                    Text("seconds")
+                        .foregroundStyle(.secondary)
                 }
 
-                Text("In double-tap mode, recording auto-stops after this duration of silence. In push-to-talk mode, you control when to stop by releasing the key.")
+                Text("In double-tap mode, recording auto-stops after 0.5 to 300 seconds of continuous silence. In push-to-talk mode, you control when to stop by releasing the key.")
                     .font(.caption)
                     .foregroundStyle(.secondary)
             }
@@ -1452,6 +1456,15 @@ struct AudioSettingsTab: View {
         if let selectedAudioDevice {
             appState.selectAudioDevice(selectedAudioDevice)
         }
+    }
+
+    private var silenceDurationBinding: Binding<Double> {
+        Binding(
+            get: { appState.silenceDuration },
+            set: {
+                appState.silenceDuration = SilenceDetectionSettings.clampedDuration($0)
+            }
+        )
     }
 
     private var sensitivityLabel: String {
@@ -1715,4 +1728,3 @@ struct DebugTab: View {
         }
     }
 }
-

--- a/Sources/VocaMac/Views/SettingsView.swift
+++ b/Sources/VocaMac/Views/SettingsView.swift
@@ -1366,11 +1366,11 @@ struct AudioSettingsTab: View {
                 }
                 .onChange(of: appState.selectedAudioDeviceID) {
                     syncSelectedAudioDeviceName()
-                    clampSelectedAudioChannel()
+                    syncSelectedAudioChannel()
                 }
 
                 if activeInputChannelCount > 1 {
-                    Picker("Input channel", selection: $appState.selectedAudioChannel) {
+                    Picker("Input channel", selection: selectedAudioChannelBinding) {
                         ForEach(0..<activeInputChannelCount, id: \.self) { channel in
                             Text("Channel \(channel + 1)").tag(channel)
                         }
@@ -1469,7 +1469,7 @@ struct AudioSettingsTab: View {
     private func refreshAudioDevices() {
         audioDevices = AudioEngine.availableInputDevices()
         syncSelectedAudioDeviceName()
-        clampSelectedAudioChannel()
+        syncSelectedAudioChannel()
     }
 
     private func syncSelectedAudioDeviceName() {
@@ -1483,16 +1483,18 @@ struct AudioSettingsTab: View {
         }
     }
 
-    private func clampSelectedAudioChannel() {
-        guard activeInputChannelCount > 0 else {
-            if appState.selectedAudioDeviceID.isEmpty {
-                appState.selectedAudioChannel = 0
+    private func syncSelectedAudioChannel() {
+        guard let activeAudioDevice else { return }
+        appState.syncSelectedAudioChannel(with: activeAudioDevice)
+    }
+
+    private var selectedAudioChannelBinding: Binding<Int> {
+        Binding(
+            get: { appState.selectedAudioChannel },
+            set: { channel in
+                guard let activeAudioDevice else { return }
+                appState.selectAudioChannel(channel, for: activeAudioDevice)
             }
-            return
-        }
-        appState.selectedAudioChannel = min(
-            max(appState.selectedAudioChannel, 0),
-            activeInputChannelCount - 1
         )
     }
 

--- a/Sources/VocaMac/Views/SettingsView.swift
+++ b/Sources/VocaMac/Views/SettingsView.swift
@@ -1366,6 +1366,19 @@ struct AudioSettingsTab: View {
                 }
                 .onChange(of: appState.selectedAudioDeviceID) {
                     syncSelectedAudioDeviceName()
+                    clampSelectedAudioChannel()
+                }
+
+                if activeInputChannelCount > 1 {
+                    Picker("Input channel", selection: $appState.selectedAudioChannel) {
+                        ForEach(0..<activeInputChannelCount, id: \.self) { channel in
+                            Text("Channel \(channel + 1)").tag(channel)
+                        }
+                    }
+
+                    Text("Choose the interface input where your microphone is connected. VocaMac keeps this channel fixed so loopback or other inputs cannot replace it during recording.")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
                 }
 
                 if audioDevices.isEmpty {
@@ -1427,6 +1440,17 @@ struct AudioSettingsTab: View {
         return audioDevices.first { $0.id == appState.selectedAudioDeviceID }
     }
 
+    private var activeAudioDevice: AudioDevice? {
+        if appState.selectedAudioDeviceID.isEmpty {
+            return audioDevices.first(where: { $0.isDefault })
+        }
+        return selectedAudioDevice
+    }
+
+    private var activeInputChannelCount: Int {
+        activeAudioDevice?.channelCount ?? 0
+    }
+
     private var selectedAudioDeviceIsUnavailable: Bool {
         !appState.selectedAudioDeviceID.isEmpty && selectedAudioDevice == nil
     }
@@ -1445,6 +1469,7 @@ struct AudioSettingsTab: View {
     private func refreshAudioDevices() {
         audioDevices = AudioEngine.availableInputDevices()
         syncSelectedAudioDeviceName()
+        clampSelectedAudioChannel()
     }
 
     private func syncSelectedAudioDeviceName() {
@@ -1456,6 +1481,19 @@ struct AudioSettingsTab: View {
         if let selectedAudioDevice {
             appState.selectAudioDevice(selectedAudioDevice)
         }
+    }
+
+    private func clampSelectedAudioChannel() {
+        guard activeInputChannelCount > 0 else {
+            if appState.selectedAudioDeviceID.isEmpty {
+                appState.selectedAudioChannel = 0
+            }
+            return
+        }
+        appState.selectedAudioChannel = min(
+            max(appState.selectedAudioChannel, 0),
+            activeInputChannelCount - 1
+        )
     }
 
     private var silenceDurationBinding: Binding<Double> {

--- a/Tests/VocaMacTests/AppStateRecordingTests.swift
+++ b/Tests/VocaMacTests/AppStateRecordingTests.swift
@@ -345,6 +345,8 @@ final class AppStateRecordingTests: XCTestCase {
                       "Default audio input should follow the system default")
         XCTAssertEqual(appState.selectedAudioDeviceName, "",
                       "No device name should be persisted for system default")
+        XCTAssertEqual(appState.selectedAudioChannel, 0,
+                      "Audio interfaces should default to their first input channel")
     }
 
     func testSelectingAudioDevicePersistsIDAndName() {
@@ -362,10 +364,17 @@ final class AppStateRecordingTests: XCTestCase {
         XCTAssertEqual(appState.selectedAudioDeviceID, device.id)
         XCTAssertEqual(appState.selectedAudioDeviceName, device.name)
 
+        appState.selectedAudioChannel = 2
+        appState.selectAudioDevice(device)
+        XCTAssertEqual(appState.selectedAudioChannel, 2,
+                       "Refreshing the same device should preserve its selected channel")
+
         appState.selectAudioDevice(nil)
 
         XCTAssertEqual(appState.selectedAudioDeviceID, "")
         XCTAssertEqual(appState.selectedAudioDeviceName, "")
+        XCTAssertEqual(appState.selectedAudioChannel, 0,
+                       "Changing devices should reset to the first input channel")
     }
 
     func testActivationModeDefault() {
@@ -459,11 +468,14 @@ final class AppStateRecordingTests: XCTestCase {
     func testStartRecordingPassesSelectedAudioDeviceID() async {
         let (appState, mocks) = AppState.makeTestState()
         appState.selectedAudioDeviceID = "coreaudio-device-uid"
+        appState.selectedAudioChannel = 3
 
         await appState.startRecording()
 
         XCTAssertEqual(mocks.audioEngine.lastPreferredInputDeviceID, "coreaudio-device-uid",
                        "Selected audio device ID should be forwarded to AudioEngine")
+        XCTAssertEqual(mocks.audioEngine.lastPreferredInputChannel, 3,
+                       "Selected audio channel should be forwarded to AudioEngine")
     }
 }
 

--- a/Tests/VocaMacTests/AppStateRecordingTests.swift
+++ b/Tests/VocaMacTests/AppStateRecordingTests.swift
@@ -347,6 +347,8 @@ final class AppStateRecordingTests: XCTestCase {
                       "No device name should be persisted for system default")
         XCTAssertEqual(appState.selectedAudioChannel, 0,
                       "Audio interfaces should default to their first input channel")
+        XCTAssertEqual(appState.selectedAudioChannelDeviceID, "")
+        XCTAssertEqual(appState.selectedAudioChannelCount, 0)
     }
 
     func testSelectingAudioDevicePersistsIDAndName() {
@@ -356,7 +358,7 @@ final class AppStateRecordingTests: XCTestCase {
             name: "USB Microphone",
             isDefault: false,
             sampleRate: 48_000,
-            channelCount: 1
+            channelCount: 4
         )
 
         appState.selectAudioDevice(device)
@@ -364,7 +366,7 @@ final class AppStateRecordingTests: XCTestCase {
         XCTAssertEqual(appState.selectedAudioDeviceID, device.id)
         XCTAssertEqual(appState.selectedAudioDeviceName, device.name)
 
-        appState.selectedAudioChannel = 2
+        appState.selectAudioChannel(2, for: device)
         appState.selectAudioDevice(device)
         XCTAssertEqual(appState.selectedAudioChannel, 2,
                        "Refreshing the same device should preserve its selected channel")
@@ -375,6 +377,41 @@ final class AppStateRecordingTests: XCTestCase {
         XCTAssertEqual(appState.selectedAudioDeviceName, "")
         XCTAssertEqual(appState.selectedAudioChannel, 0,
                        "Changing devices should reset to the first input channel")
+        XCTAssertEqual(appState.selectedAudioChannelDeviceID, "")
+        XCTAssertEqual(appState.selectedAudioChannelCount, 0)
+    }
+
+    func testSelectedAudioChannelResetsWhenDeviceOrTopologyChanges() {
+        let (appState, _) = AppState.makeTestState()
+        let originalDevice = AudioDevice(
+            id: "interface-a",
+            name: "Interface A",
+            isDefault: true,
+            sampleRate: 48_000,
+            channelCount: 4
+        )
+
+        appState.selectAudioChannel(1, for: originalDevice)
+        appState.syncSelectedAudioChannel(with: AudioDevice(
+            id: "interface-b",
+            name: "Interface B",
+            isDefault: true,
+            sampleRate: 48_000,
+            channelCount: 4
+        ))
+        XCTAssertEqual(appState.selectedAudioChannel, 0)
+        XCTAssertEqual(appState.selectedAudioChannelDeviceID, "interface-b")
+
+        appState.selectAudioChannel(1, for: originalDevice)
+        appState.syncSelectedAudioChannel(with: AudioDevice(
+            id: originalDevice.id,
+            name: originalDevice.name,
+            isDefault: true,
+            sampleRate: 48_000,
+            channelCount: 2
+        ))
+        XCTAssertEqual(appState.selectedAudioChannel, 0)
+        XCTAssertEqual(appState.selectedAudioChannelCount, 2)
     }
 
     func testActivationModeDefault() {
@@ -469,6 +506,8 @@ final class AppStateRecordingTests: XCTestCase {
         let (appState, mocks) = AppState.makeTestState()
         appState.selectedAudioDeviceID = "coreaudio-device-uid"
         appState.selectedAudioChannel = 3
+        appState.selectedAudioChannelDeviceID = "coreaudio-device-uid"
+        appState.selectedAudioChannelCount = 4
 
         await appState.startRecording()
 
@@ -476,6 +515,9 @@ final class AppStateRecordingTests: XCTestCase {
                        "Selected audio device ID should be forwarded to AudioEngine")
         XCTAssertEqual(mocks.audioEngine.lastPreferredInputChannel, 3,
                        "Selected audio channel should be forwarded to AudioEngine")
+        XCTAssertEqual(mocks.audioEngine.lastPreferredInputChannelDeviceID,
+                       "coreaudio-device-uid")
+        XCTAssertEqual(mocks.audioEngine.lastPreferredInputChannelCount, 4)
     }
 }
 

--- a/Tests/VocaMacTests/Mocks/MockServices.swift
+++ b/Tests/VocaMacTests/Mocks/MockServices.swift
@@ -22,6 +22,7 @@ final class MockAudioEngine: AudioRecording {
     var lastSilenceDuration: Double?
     var lastMaxDuration: TimeInterval?
     var lastPreferredInputDeviceID: String?
+    var lastPreferredInputChannel: Int?
     var stopRecordingResult: [Float] = []
     var forceResetCallCount = 0
     var startRecordingResult = true
@@ -39,7 +40,8 @@ final class MockAudioEngine: AudioRecording {
         silenceThreshold: Float,
         silenceDuration: Double,
         maxDuration: TimeInterval,
-        preferredInputDeviceID: String?
+        preferredInputDeviceID: String?,
+        preferredInputChannel: Int
     ) -> Bool {
         cancelLock.withLock { startCancelled = false }
         if startRecordingDelay > 0 {
@@ -49,6 +51,7 @@ final class MockAudioEngine: AudioRecording {
         lastSilenceDuration = silenceDuration
         lastMaxDuration = maxDuration
         lastPreferredInputDeviceID = preferredInputDeviceID
+        lastPreferredInputChannel = preferredInputChannel
 
         if cancelLock.withLock({ startCancelled }) {
             isCurrentlyRecording = false
@@ -526,6 +529,7 @@ extension AppState {
     ) -> (appState: AppState, mocks: TestMocks) {
         UserDefaults.standard.removeObject(forKey: "vocamac.selectedAudioDeviceID")
         UserDefaults.standard.removeObject(forKey: "vocamac.selectedAudioDeviceName")
+        UserDefaults.standard.removeObject(forKey: "vocamac.selectedAudioChannel")
         UserDefaults.standard.removeObject(forKey: "vocamac.soundEffectsEnabled")
 
         let audioEngine = MockAudioEngine()

--- a/Tests/VocaMacTests/Mocks/MockServices.swift
+++ b/Tests/VocaMacTests/Mocks/MockServices.swift
@@ -23,6 +23,8 @@ final class MockAudioEngine: AudioRecording {
     var lastMaxDuration: TimeInterval?
     var lastPreferredInputDeviceID: String?
     var lastPreferredInputChannel: Int?
+    var lastPreferredInputChannelDeviceID: String?
+    var lastPreferredInputChannelCount: Int?
     var stopRecordingResult: [Float] = []
     var forceResetCallCount = 0
     var startRecordingResult = true
@@ -41,7 +43,9 @@ final class MockAudioEngine: AudioRecording {
         silenceDuration: Double,
         maxDuration: TimeInterval,
         preferredInputDeviceID: String?,
-        preferredInputChannel: Int
+        preferredInputChannel: Int,
+        preferredInputChannelDeviceID: String?,
+        preferredInputChannelCount: Int
     ) -> Bool {
         cancelLock.withLock { startCancelled = false }
         if startRecordingDelay > 0 {
@@ -52,6 +56,8 @@ final class MockAudioEngine: AudioRecording {
         lastMaxDuration = maxDuration
         lastPreferredInputDeviceID = preferredInputDeviceID
         lastPreferredInputChannel = preferredInputChannel
+        lastPreferredInputChannelDeviceID = preferredInputChannelDeviceID
+        lastPreferredInputChannelCount = preferredInputChannelCount
 
         if cancelLock.withLock({ startCancelled }) {
             isCurrentlyRecording = false
@@ -530,6 +536,8 @@ extension AppState {
         UserDefaults.standard.removeObject(forKey: "vocamac.selectedAudioDeviceID")
         UserDefaults.standard.removeObject(forKey: "vocamac.selectedAudioDeviceName")
         UserDefaults.standard.removeObject(forKey: "vocamac.selectedAudioChannel")
+        UserDefaults.standard.removeObject(forKey: "vocamac.selectedAudioChannelDeviceID")
+        UserDefaults.standard.removeObject(forKey: "vocamac.selectedAudioChannelCount")
         UserDefaults.standard.removeObject(forKey: "vocamac.soundEffectsEnabled")
 
         let audioEngine = MockAudioEngine()

--- a/Tests/VocaMacTests/ServiceTests.swift
+++ b/Tests/VocaMacTests/ServiceTests.swift
@@ -518,6 +518,58 @@ final class AudioEngineTests: XCTestCase {
         }
 
         XCTAssertEqual(peak, 0.1, accuracy: 0.01)
+
+        let fallback = try XCTUnwrap(
+            AudioEngine.convertToWhisperFormat(
+                input,
+                from: input.format,
+                inputChannel: 99
+            )
+        )
+        let fallbackSamples = try XCTUnwrap(fallback.floatChannelData?[0])
+        let fallbackPeak = (0..<Int(fallback.frameLength)).reduce(Float.zero) {
+            max($0, abs(fallbackSamples[$1]))
+        }
+        XCTAssertLessThan(
+            fallbackPeak,
+            0.01,
+            "An invalid saved index must fall back to channel 1, not the last channel"
+        )
+    }
+
+    func testInputChannelSelectionExpiresWhenDeviceLayoutChanges() {
+        XCTAssertEqual(
+            AudioEngine.resolvedInputChannel(
+                requestedChannel: 1,
+                mappedDeviceUID: "interface-a",
+                mappedChannelCount: 4,
+                activeDeviceUID: "interface-a",
+                activeChannelCount: 4
+            ),
+            1
+        )
+        XCTAssertEqual(
+            AudioEngine.resolvedInputChannel(
+                requestedChannel: 3,
+                mappedDeviceUID: "interface-a",
+                mappedChannelCount: 4,
+                activeDeviceUID: "interface-b",
+                activeChannelCount: 4
+            ),
+            0,
+            "A system-default device change must fall back to channel 1"
+        )
+        XCTAssertEqual(
+            AudioEngine.resolvedInputChannel(
+                requestedChannel: 1,
+                mappedDeviceUID: "interface-a",
+                mappedChannelCount: 4,
+                activeDeviceUID: "interface-a",
+                activeChannelCount: 2
+            ),
+            0,
+            "A topology change must fall back to channel 1"
+        )
     }
 
     func testSilenceDurationRestartsAfterSpeech() {

--- a/Tests/VocaMacTests/ServiceTests.swift
+++ b/Tests/VocaMacTests/ServiceTests.swift
@@ -4,6 +4,7 @@
 // Tests for services: KeyCodeReference, TextInjector, SoundManager, AudioEngine.
 
 import XCTest
+import AVFoundation
 import CoreAudio
 @testable import VocaMac
 
@@ -445,6 +446,94 @@ extension XCTestCase {
 
 final class AudioEngineTests: XCTestCase {
 
+    func testInputTapUsesLiveHardwareFormat() {
+        XCTAssertNil(
+            AudioEngine.inputTapFormat,
+            "A nil tap format follows the device format that is live when the tap starts"
+        )
+    }
+
+    func testFourChannelInputConvertsSpeechOutsideChannelZero() throws {
+        let layoutTag = kAudioChannelLayoutTag_DiscreteInOrder | AudioChannelLayoutTag(4)
+        let layout = try XCTUnwrap(AVAudioChannelLayout(layoutTag: layoutTag))
+        let format = AVAudioFormat(
+            standardFormatWithSampleRate: 44_100,
+            channelLayout: layout
+        )
+        let input = try XCTUnwrap(
+            AVAudioPCMBuffer(pcmFormat: format, frameCapacity: 4_096)
+        )
+        input.frameLength = 4_096
+
+        let activeChannel = 3
+        for frame in 0..<Int(input.frameLength) {
+            input.floatChannelData?[activeChannel][frame] = 0.25
+        }
+
+        let converted = try XCTUnwrap(
+            AudioEngine.convertToWhisperFormat(input, from: input.format)
+        )
+        let samples = try XCTUnwrap(converted.floatChannelData?[0])
+        let peak = (0..<Int(converted.frameLength)).reduce(Float.zero) {
+            max($0, abs(samples[$1]))
+        }
+
+        XCTAssertGreaterThan(
+            peak,
+            0.01,
+            "Speech on any physical interface channel must survive the mono conversion"
+        )
+    }
+
+    func testSilenceDurationRestartsAfterSpeech() {
+        let start = Date(timeIntervalSinceReferenceDate: 1_000)
+        var detector = SilenceDetector(now: start)
+
+        XCTAssertFalse(detector.observe(
+            energy: 0,
+            threshold: 0.01,
+            duration: 5,
+            at: start.addingTimeInterval(4)
+        ))
+        XCTAssertFalse(detector.observe(
+            energy: 0.2,
+            threshold: 0.01,
+            duration: 5,
+            at: start.addingTimeInterval(4.5)
+        ))
+        XCTAssertFalse(detector.observe(
+            energy: 0,
+            threshold: 0.01,
+            duration: 5,
+            at: start.addingTimeInterval(9)
+        ))
+        XCTAssertTrue(detector.observe(
+            energy: 0,
+            threshold: 0.01,
+            duration: 5,
+            at: start.addingTimeInterval(9.5)
+        ))
+        XCTAssertFalse(
+            detector.observe(
+                energy: 0,
+                threshold: 0.01,
+                duration: 5,
+                at: start.addingTimeInterval(15)
+            ),
+            "A continuous silent period should notify only once"
+        )
+    }
+
+    func testCustomSilenceDurationIsClampedToSupportedRange() {
+        XCTAssertEqual(SilenceDetectionSettings.clampedDuration(60), 60)
+        XCTAssertEqual(SilenceDetectionSettings.clampedDuration(0), 0.5)
+        XCTAssertEqual(SilenceDetectionSettings.clampedDuration(600), 300)
+        XCTAssertEqual(
+            SilenceDetectionSettings.clampedDuration(.nan),
+            SilenceDetectionSettings.defaultDuration
+        )
+    }
+
     func testPreparingCaptureAcceptsBuffersWithoutEvaluatingStopConditions() {
         XCTAssertFalse(AudioCapturePhase.stopped.acceptsInputBuffers)
         XCTAssertFalse(AudioCapturePhase.stopped.evaluatesStopConditions)
@@ -492,7 +581,7 @@ final class AudioEngineTests: XCTestCase {
 
         let _ = engine.stopRecording()
 
-        // The callback should have fired at most once due to the silenceCallbackFired guard
+        // The detector should notify at most once for one continuous silent period.
         XCTAssertLessThanOrEqual(silenceCallCount, 1,
             "Silence callback should fire at most once, but fired \(silenceCallCount) times")
     }

--- a/Tests/VocaMacTests/ServiceTests.swift
+++ b/Tests/VocaMacTests/ServiceTests.swift
@@ -453,7 +453,7 @@ final class AudioEngineTests: XCTestCase {
         )
     }
 
-    func testFourChannelInputConvertsSpeechOutsideChannelZero() throws {
+    func testFourChannelInputConvertsSelectedChannel() throws {
         let layoutTag = kAudioChannelLayoutTag_DiscreteInOrder | AudioChannelLayoutTag(4)
         let layout = try XCTUnwrap(AVAudioChannelLayout(layoutTag: layoutTag))
         let format = AVAudioFormat(
@@ -471,7 +471,11 @@ final class AudioEngineTests: XCTestCase {
         }
 
         let converted = try XCTUnwrap(
-            AudioEngine.convertToWhisperFormat(input, from: input.format)
+            AudioEngine.convertToWhisperFormat(
+                input,
+                from: input.format,
+                inputChannel: activeChannel
+            )
         )
         let samples = try XCTUnwrap(converted.floatChannelData?[0])
         let peak = (0..<Int(converted.frameLength)).reduce(Float.zero) {
@@ -481,8 +485,39 @@ final class AudioEngineTests: XCTestCase {
         XCTAssertGreaterThan(
             peak,
             0.01,
-            "Speech on any physical interface channel must survive the mono conversion"
+            "Speech on the selected physical interface channel must survive mono conversion"
         )
+    }
+
+    func testSelectedInputChannelDoesNotSwitchToLouderLoopbackChannel() throws {
+        let layoutTag = kAudioChannelLayoutTag_DiscreteInOrder | AudioChannelLayoutTag(4)
+        let layout = try XCTUnwrap(AVAudioChannelLayout(layoutTag: layoutTag))
+        let format = try XCTUnwrap(
+            AVAudioFormat(standardFormatWithSampleRate: 44_100, channelLayout: layout)
+        )
+        let input = try XCTUnwrap(
+            AVAudioPCMBuffer(pcmFormat: format, frameCapacity: 4_096)
+        )
+        input.frameLength = 4_096
+
+        for frame in 0..<Int(input.frameLength) {
+            input.floatChannelData?[1][frame] = 0.1
+            input.floatChannelData?[3][frame] = 0.9
+        }
+
+        let converted = try XCTUnwrap(
+            AudioEngine.convertToWhisperFormat(
+                input,
+                from: input.format,
+                inputChannel: 1
+            )
+        )
+        let samples = try XCTUnwrap(converted.floatChannelData?[0])
+        let peak = (0..<Int(converted.frameLength)).reduce(Float.zero) {
+            max($0, abs(samples[$1]))
+        }
+
+        XCTAssertEqual(peak, 0.1, accuracy: 0.01)
     }
 
     func testSilenceDurationRestartsAfterSpeech() {


### PR DESCRIPTION
## Summary

- preserve speech from multi-channel microphones and audio interfaces instead of relying on Core Audio's broken implicit downmix
- let users select and persist the physical input channel for multi-channel interfaces, keeping capture stable if loopback or another input is louder
- invalidate that channel mapping when the active device UID or channel topology changes, falling back safely to channel 1
- bind the input tap to the hardware format that is live after USB or Bluetooth route setup
- make the silence timer explicitly track continuous silence and restart its full countdown whenever speech resumes
- replace the 0.5 to 5 second slider with a custom field that accepts 0.5 to 300 seconds

## Root cause

VocaMac converted the microphone buffer directly from the device format to mono. On macOS, that conversion reads only channel 0 for stereo input and can return an all-zero buffer for devices with more than two channels. The reported EVO4 route opened as 44.1 kHz with four channels, so its input was converted to silence.

Because no buffer crossed the speech threshold, the silence timestamp never moved. The configured silence duration then behaved like a maximum recording duration, and the final zero-sample check reported that the microphone was unavailable even though Core Audio was delivering buffers.

Multi-channel buffers are now reduced to the user-selected physical channel before sample-rate conversion. The selection remains fixed for the entire recording so a louder loopback or secondary input cannot replace the microphone.

The saved index is tied to the interface UID and channel count. Both settings and the audio engine revalidate that mapping, including after an in-progress route restart, so a system-default device change or interface mode change cannot reuse a stale channel.

The permissions reset in the supplied log separately explains the temporary Accessibility and Input Monitoring failure. Those permissions recovered before the repeated zero-audio captures.

## Testing

- `swift test --filter AudioEngineTests` (14 tests, 0 failures)
- `swift test --filter AppStateRecordingTests` (37 tests, 0 failures)
- `swift test` (442 tests, 1 expected hardware-dependent skip, 0 failures)
- `swift build`
- added deterministic coverage for selected-channel conversion on four-channel input, competing loopback input, stale device/layout mappings, invalid-index fallback, selection forwarding, silence countdown reset after speech, live tap format selection, and custom duration bounds
