### PR TITLE
Fail model load early when free RAM is below the catalog estimate

### DIFF
--- a/Sources/VocaMac/Models/AppState.swift
+++ b/Sources/VocaMac/Models/AppState.swift
@@ -1257,7 +1257,8 @@ final class AppState: ObservableObject {
         let targetSize = size
 
         // Refuse known-too-large loads before WhisperKit/CoreML can hang the
-        // UI spinner under memory pressure (vocamac#250).
+        // UI spinner under memory pressure (vocamac#250). Leave any already
+        // loaded model alone — we never started a load, so do not restore/clear.
         if let targetSize,
            !modelFitsInMemory(targetSize) {
             let needed = String(format: "%.1f", targetSize.ramRequiredGB)
@@ -1266,13 +1267,6 @@ final class AppState: ObservableObject {
                 + "(~\(needed) GB needed). Free RAM or choose a smaller model."
             showTemporaryError(failureMessage)
             VocaLogger.error(.appState, failureMessage)
-            await restorePreviousModelIfNeeded(
-                afterFailedLoadFor: targetSize,
-                previousSize: previousModelSize,
-                previousName: previousLoadedModelName,
-                hadLoadedModel: hadLoadedModel,
-                originalFailureMessage: failureMessage
-            )
             return
         }
 

--- a/Sources/VocaMac/Models/AppState.swift
+++ b/Sources/VocaMac/Models/AppState.swift
@@ -324,6 +324,10 @@ final class AppState: ObservableObject {
     /// Set to `true` in tests to avoid side effects.
     let skipSystemIntegration: Bool
 
+    /// Pre-load memory gate. Production defaults to SystemInfo; tests stub this
+    /// so CI free+inactive pages cannot flake medium/large mock loads.
+    var modelFitsInMemory: (ModelSize) -> Bool = { SystemInfo.canFitModelInMemory($0) }
+
     // MARK: - Initialization
 
     init(
@@ -1255,7 +1259,7 @@ final class AppState: ObservableObject {
         // Refuse known-too-large loads before WhisperKit/CoreML can hang the
         // UI spinner under memory pressure (vocamac#250).
         if let targetSize,
-           !SystemInfo.canFitModelInMemory(targetSize) {
+           !modelFitsInMemory(targetSize) {
             let needed = String(format: "%.1f", targetSize.ramRequiredGB)
             let failureMessage =
                 "Not enough free memory to load \(targetSize.displayName) "

--- a/Sources/VocaMac/Models/AppState.swift
+++ b/Sources/VocaMac/Models/AppState.swift
@@ -1252,6 +1252,26 @@ final class AppState: ObservableObject {
         // we don't know yet — we'll detect it after loading completes.
         let targetSize = size
 
+        // Refuse known-too-large loads before WhisperKit/CoreML can hang the
+        // UI spinner under memory pressure (vocamac#250).
+        if let targetSize,
+           !SystemInfo.canFitModelInMemory(targetSize) {
+            let needed = String(format: "%.1f", targetSize.ramRequiredGB)
+            let failureMessage =
+                "Not enough free memory to load \(targetSize.displayName) "
+                + "(~\(needed) GB needed). Free RAM or choose a smaller model."
+            showTemporaryError(failureMessage)
+            VocaLogger.error(.appState, failureMessage)
+            await restorePreviousModelIfNeeded(
+                afterFailedLoadFor: targetSize,
+                previousSize: previousModelSize,
+                previousName: previousLoadedModelName,
+                hadLoadedModel: hadLoadedModel,
+                originalFailureMessage: failureMessage
+            )
+            return
+        }
+
         // Mark the model as loading in the UI
         if let targetSize = targetSize, let idx = availableModels.firstIndex(where: { $0.size == targetSize }) {
             availableModels[idx].isLoading = true

--- a/Sources/VocaMac/Services/SystemInfo.swift
+++ b/Sources/VocaMac/Services/SystemInfo.swift
@@ -149,13 +149,17 @@ enum SystemInfo {
         return max(2, min(cores / 2, 8))
     }
 
-    /// Approximate reclaimable free memory in bytes. Zero means the probe failed.
+    /// Approximate reclaimable memory in bytes. Zero means the probe failed.
+    ///
+    /// Counts free, inactive, speculative, purgeable, and compressor-resident
+    /// pages so the gate does not refuse loads macOS can still satisfy.
     static var availableMemoryBytes: UInt64 {
         var stats = vm_statistics64()
         var count = mach_msg_type_number_t(
             MemoryLayout<vm_statistics64_data_t>.stride / MemoryLayout<integer_t>.stride
         )
         let host = mach_host_self()
+        defer { mach_port_deallocate(mach_task_self_, host) }
         let kr = withUnsafeMutablePointer(to: &stats) {
             $0.withMemoryRebound(to: integer_t.self, capacity: Int(count)) {
                 host_statistics64(host, HOST_VM_INFO64, $0, &count)
@@ -164,7 +168,11 @@ enum SystemInfo {
         guard kr == KERN_SUCCESS else { return 0 }
         var pageSize: vm_size_t = 0
         guard host_page_size(host, &pageSize) == KERN_SUCCESS, pageSize > 0 else { return 0 }
-        let pages = UInt64(stats.free_count) + UInt64(stats.inactive_count)
+        let pages = UInt64(stats.free_count)
+            + UInt64(stats.inactive_count)
+            + UInt64(stats.speculative_count)
+            + UInt64(stats.purgeable_count)
+            + UInt64(stats.compressor_page_count)
         return pages * UInt64(pageSize)
     }
 

--- a/Sources/VocaMac/Services/SystemInfo.swift
+++ b/Sources/VocaMac/Services/SystemInfo.swift
@@ -149,18 +149,30 @@ enum SystemInfo {
         return max(2, min(cores / 2, 8))
     }
 
-    /// Bytes this process can still allocate. Zero means the value is unknown.
+    /// Approximate reclaimable free memory in bytes. Zero means the probe failed.
     static var availableMemoryBytes: UInt64 {
-        let available = os_proc_available_memory()
-        guard available > 0 else { return 0 }
-        return UInt64(available)
+        var stats = vm_statistics64()
+        var count = mach_msg_type_number_t(
+            MemoryLayout<vm_statistics64_data_t>.stride / MemoryLayout<integer_t>.stride
+        )
+        let host = mach_host_self()
+        let kr = withUnsafeMutablePointer(to: &stats) {
+            $0.withMemoryRebound(to: integer_t.self, capacity: Int(count)) {
+                host_statistics64(host, HOST_VM_INFO64, $0, &count)
+            }
+        }
+        guard kr == KERN_SUCCESS else { return 0 }
+        var pageSize: vm_size_t = 0
+        guard host_page_size(host, &pageSize) == KERN_SUCCESS, pageSize > 0 else { return 0 }
+        let pages = UInt64(stats.free_count) + UInt64(stats.inactive_count)
+        return pages * UInt64(pageSize)
     }
 
     /// Whether loading `size` is likely to fit without thrashing.
     ///
     /// Uses the catalog RAM estimate against installed memory and against
-    /// `os_proc_available_memory()`. A zero available reading is treated as
-    /// unknown so we do not block loads on a failed probe.
+    /// reclaimable free memory from host_statistics64. A zero available
+    /// reading is treated as unknown so we do not block loads on a failed probe.
     static func canFitModelInMemory(
         _ size: ModelSize,
         physicalMemoryGB: Int = physicalMemoryGB,

--- a/Sources/VocaMac/Services/SystemInfo.swift
+++ b/Sources/VocaMac/Services/SystemInfo.swift
@@ -3,6 +3,7 @@
 //
 // Detects system hardware capabilities and recommends optimal whisper model size.
 
+import Darwin
 import Foundation
 
 // MARK: - SystemCapabilities
@@ -146,5 +147,29 @@ enum SystemInfo {
         let cores = coreCount
         // Use at most half the cores, minimum 2, maximum 8
         return max(2, min(cores / 2, 8))
+    }
+
+    /// Bytes this process can still allocate. Zero means the value is unknown.
+    static var availableMemoryBytes: UInt64 {
+        os_proc_available_memory()
+    }
+
+    /// Whether loading `size` is likely to fit without thrashing.
+    ///
+    /// Uses the catalog RAM estimate against installed memory and against
+    /// `os_proc_available_memory()`. A zero available reading is treated as
+    /// unknown so we do not block loads on a failed probe.
+    static func canFitModelInMemory(
+        _ size: ModelSize,
+        physicalMemoryGB: Int = physicalMemoryGB,
+        availableBytes: UInt64 = availableMemoryBytes
+    ) -> Bool {
+        let requiredGB = size.ramRequiredGB
+        guard Double(physicalMemoryGB) + 0.001 >= requiredGB else {
+            return false
+        }
+        guard availableBytes > 0 else { return true }
+        let requiredBytes = UInt64((requiredGB * 1024 * 1024 * 1024).rounded(.up))
+        return availableBytes >= requiredBytes
     }
 }

--- a/Sources/VocaMac/Services/SystemInfo.swift
+++ b/Sources/VocaMac/Services/SystemInfo.swift
@@ -151,8 +151,10 @@ enum SystemInfo {
 
     /// Approximate reclaimable memory in bytes. Zero means the probe failed.
     ///
-    /// Counts free, inactive, speculative, purgeable, and compressor-resident
-    /// pages so the gate does not refuse loads macOS can still satisfy.
+    /// Counts free, inactive, and purgeable pages. On Darwin, `free_count`
+    /// already includes speculative pages, so they must not be added again.
+    /// Compressor-resident pages still occupy RAM and are not available
+    /// capacity for a new model allocation.
     static var availableMemoryBytes: UInt64 {
         var stats = vm_statistics64()
         var count = mach_msg_type_number_t(
@@ -170,9 +172,7 @@ enum SystemInfo {
         guard host_page_size(host, &pageSize) == KERN_SUCCESS, pageSize > 0 else { return 0 }
         let pages = UInt64(stats.free_count)
             + UInt64(stats.inactive_count)
-            + UInt64(stats.speculative_count)
             + UInt64(stats.purgeable_count)
-            + UInt64(stats.compressor_page_count)
         return pages * UInt64(pageSize)
     }
 

--- a/Sources/VocaMac/Services/SystemInfo.swift
+++ b/Sources/VocaMac/Services/SystemInfo.swift
@@ -151,10 +151,10 @@ enum SystemInfo {
 
     /// Approximate reclaimable memory in bytes. Zero means the probe failed.
     ///
-    /// Counts free, inactive, and purgeable pages. On Darwin, `free_count`
-    /// already includes speculative pages, so they must not be added again.
-    /// Compressor-resident pages still occupy RAM and are not available
-    /// capacity for a new model allocation.
+    /// Uses free + inactive only. On Darwin, `free_count` already includes
+    /// speculative pages, purgeable pages often overlap the inactive queue,
+    /// and compressor-resident pages still occupy RAM — so those counters
+    /// must not be added on top or the gate can over-approve loads.
     static var availableMemoryBytes: UInt64 {
         var stats = vm_statistics64()
         var count = mach_msg_type_number_t(
@@ -172,7 +172,6 @@ enum SystemInfo {
         guard host_page_size(host, &pageSize) == KERN_SUCCESS, pageSize > 0 else { return 0 }
         let pages = UInt64(stats.free_count)
             + UInt64(stats.inactive_count)
-            + UInt64(stats.purgeable_count)
         return pages * UInt64(pageSize)
     }
 

--- a/Sources/VocaMac/Services/SystemInfo.swift
+++ b/Sources/VocaMac/Services/SystemInfo.swift
@@ -151,7 +151,9 @@ enum SystemInfo {
 
     /// Bytes this process can still allocate. Zero means the value is unknown.
     static var availableMemoryBytes: UInt64 {
-        os_proc_available_memory()
+        let available = os_proc_available_memory()
+        guard available > 0 else { return 0 }
+        return UInt64(available)
     }
 
     /// Whether loading `size` is likely to fit without thrashing.

--- a/Tests/VocaMacTests/AppStateTests.swift
+++ b/Tests/VocaMacTests/AppStateTests.swift
@@ -348,6 +348,43 @@ final class AppStateModelLoadingTests: XCTestCase {
     }
 
     @MainActor
+    func testLowMemoryGateRefusesMediumBeforeWhisperAndRestoresPrevious() async {
+        UserDefaults.standard.set(ModelSize.small.rawValue, forKey: "vocamac.selectedModelSize")
+
+        let modelManager = MockModelManager()
+        modelManager.downloadedModels = [.small, .medium]
+
+        let whisperService = MockWhisperService()
+        whisperService.loadedModelName = "openai_whisper-small"
+        whisperService.isModelLoaded = true
+        whisperService.loadResponses = [
+            .success("openai_whisper-small"),
+        ]
+
+        let (appState, mocks) = AppState.makeTestState(
+            modelManager: modelManager,
+            whisperService: whisperService
+        )
+        appState.modelFitsInMemory = { $0 != .medium }
+
+        await appState.loadModel(.medium)
+
+        XCTAssertTrue(
+            appState.errorMessage?.contains("Not enough") == true
+                || appState.errorMessage?.localizedCaseInsensitiveContains("free memory") == true
+        )
+        XCTAssertFalse(
+            mocks.whisperService.loadRequests.map { $0.name }.contains("openai_whisper-medium")
+        )
+        XCTAssertEqual(
+            mocks.whisperService.loadRequests.map { $0.name },
+            ["openai_whisper-small"]
+        )
+        XCTAssertEqual(appState.currentModel?.size, .small)
+        XCTAssertEqual(appState.selectedModelSize, ModelSize.small.rawValue)
+    }
+
+    @MainActor
     func testDeleteModelRemovesDownloadedModel() async {
         let modelManager = MockModelManager()
         modelManager.downloadedModels = [.small, .medium]

--- a/Tests/VocaMacTests/AppStateTests.swift
+++ b/Tests/VocaMacTests/AppStateTests.swift
@@ -348,15 +348,13 @@ final class AppStateModelLoadingTests: XCTestCase {
     }
 
     @MainActor
-    func testLowMemoryGateRefusesMediumBeforeWhisperAndRestoresPrevious() async {
+    func testLowMemoryGateRefusesMediumBeforeWhisperWithoutTouchingLoadedModel() async {
         UserDefaults.standard.set(ModelSize.small.rawValue, forKey: "vocamac.selectedModelSize")
 
         let modelManager = MockModelManager()
         modelManager.downloadedModels = [.small, .medium]
 
         let whisperService = MockWhisperService()
-        whisperService.loadedModelName = "openai_whisper-small"
-        whisperService.isModelLoaded = true
         whisperService.loadResponses = [
             .success("openai_whisper-small"),
         ]
@@ -365,23 +363,27 @@ final class AppStateModelLoadingTests: XCTestCase {
             modelManager: modelManager,
             whisperService: whisperService
         )
-        appState.modelFitsInMemory = { $0 != .medium }
 
+        await appState.loadModel(.small)
+        let loadsAfterSmall = mocks.whisperService.loadRequests.count
+        XCTAssertEqual(appState.currentModel?.size, .small)
+        XCTAssertTrue(mocks.whisperService.isModelLoaded)
+
+        appState.modelFitsInMemory = { $0 != .medium }
         await appState.loadModel(.medium)
 
         XCTAssertTrue(
             appState.errorMessage?.contains("Not enough") == true
                 || appState.errorMessage?.localizedCaseInsensitiveContains("free memory") == true
         )
+        XCTAssertEqual(mocks.whisperService.loadRequests.count, loadsAfterSmall)
         XCTAssertFalse(
             mocks.whisperService.loadRequests.map { $0.name }.contains("openai_whisper-medium")
         )
-        XCTAssertEqual(
-            mocks.whisperService.loadRequests.map { $0.name },
-            ["openai_whisper-small"]
-        )
         XCTAssertEqual(appState.currentModel?.size, .small)
         XCTAssertEqual(appState.selectedModelSize, ModelSize.small.rawValue)
+        XCTAssertTrue(mocks.whisperService.isModelLoaded)
+        XCTAssertEqual(mocks.whisperService.loadedModelName, "openai_whisper-small")
     }
 
     @MainActor

--- a/Tests/VocaMacTests/Mocks/MockServices.swift
+++ b/Tests/VocaMacTests/Mocks/MockServices.swift
@@ -572,6 +572,8 @@ extension AppState {
             permissionManager: permissionManager,
             skipSystemIntegration: true
         )
+        // Bypass host free-RAM probe so mock loads are not refused on CI.
+        appState.modelFitsInMemory = { _ in true }
         return (appState, mocks)
     }
 }

--- a/Tests/VocaMacTests/ModelTests.swift
+++ b/Tests/VocaMacTests/ModelTests.swift
@@ -53,6 +53,47 @@ final class SystemInfoTests: XCTestCase {
         XCTAssertTrue(summary.contains("Metal:"))
         XCTAssertTrue(summary.contains("Recommended Model:"))
     }
+
+    func testCanFitModelRejectsWhenPhysicalMemoryIsTooLow() {
+        XCTAssertFalse(
+            SystemInfo.canFitModelInMemory(
+                .largeV3Latest,
+                physicalMemoryGB: 4,
+                availableBytes: UInt64(64) * 1024 * 1024 * 1024
+            )
+        )
+    }
+
+    func testCanFitModelRejectsWhenAvailableMemoryIsTooLow() {
+        XCTAssertFalse(
+            SystemInfo.canFitModelInMemory(
+                .base,
+                physicalMemoryGB: 16,
+                availableBytes: 64 * 1024 * 1024
+            )
+        )
+    }
+
+    func testCanFitModelAllowsWhenAvailableIsUnknown() {
+        XCTAssertTrue(
+            SystemInfo.canFitModelInMemory(
+                .tiny,
+                physicalMemoryGB: 8,
+                availableBytes: 0
+            )
+        )
+    }
+
+    func testCanFitModelAllowsWhenPhysicalAndAvailableAreEnough() {
+        let required = UInt64((ModelSize.base.ramRequiredGB * 1024 * 1024 * 1024).rounded(.up))
+        XCTAssertTrue(
+            SystemInfo.canFitModelInMemory(
+                .base,
+                physicalMemoryGB: 16,
+                availableBytes: required
+            )
+        )
+    }
 }
 
 // MARK: - ModelSize Tests


### PR DESCRIPTION
## Summary
Fixes #250. Before WhisperKit/CoreML starts, refuse a load when installed RAM or `os_proc_available_memory()` is below that model's catalog estimate. The UI shows an error instead of spinning forever under memory pressure.

## Test plan
- [ ] Unit: `SystemInfo.canFitModelInMemory` physical / available / unknown / enough cases
- [ ] Manual: pick a model larger than free RAM → error toast, spinner clears, previous model stays if one was loaded
- [ ] Manual: enough free RAM → load still works

## Known limits
- Auto-select (`size == nil`) skips the gate until a concrete size is known
- Catalog GB is an estimate; peak CoreML use can still be higher
- No load timeout yet if the probe says OK but the engine still hangs