### PR TITLE
fix: recover empty short Whisper transcriptions

### DIFF
--- a/Sources/VocaMac/Services/WhisperService.swift
+++ b/Sources/VocaMac/Services/WhisperService.swift
@@ -206,6 +206,22 @@ final class WhisperService: @unchecked Sendable {
                 fullText = Self.filterHallucinationTokens(rawText)
             }
 
+            // Whisper Tiny can return no tokens for valid sub-second speech.
+            // Retry only an empty short result with trailing silence so normal
+            // successful dictation keeps the single-pass fast path.
+            if let paddedAudio = Self.paddedAudioForShortEmptyTranscription(
+                audioData,
+                transcription: fullText
+            ) {
+                VocaLogger.warning(
+                    .whisperService,
+                    "Short transcription was empty for \(loadedModelName ?? "unknown model"); retrying with trailing silence"
+                )
+                results = try await kit.transcribe(audioArray: paddedAudio, decodeOptions: options)
+                rawText = results.map { $0.text }.joined(separator: " ")
+                fullText = Self.filterHallucinationTokens(rawText)
+            }
+
             let elapsed = CFAbsoluteTimeGetCurrent() - startTime
 
             // Get detected language from first result
@@ -291,6 +307,24 @@ final class WhisperService: @unchecked Sendable {
 
     static func shouldRetryWithoutVocabulary(rawText: String, promptTokens: [Int]?) -> Bool {
         promptTokens != nil && rawText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+    }
+
+    /// Some Whisper models return no tokens for otherwise valid sub-second
+    /// speech. A small trailing-silence pad gives the retry more context without
+    /// changing the reported audio length.
+    static func paddedAudioForShortEmptyTranscription(
+        _ audio: [Float],
+        transcription: String
+    ) -> [Float]? {
+        let minimumSampleCount = 17_600 // 1.1 seconds at 16 kHz
+        guard transcription.isEmpty,
+              !audio.isEmpty,
+              audio.count < minimumSampleCount else {
+            return nil
+        }
+        var padded = audio
+        padded.append(contentsOf: repeatElement(0, count: minimumSampleCount - audio.count))
+        return padded
     }
 
     /// Encode custom vocabulary into WhisperKit conditioning tokens.

--- a/Sources/VocaMac/Services/WhisperService.swift
+++ b/Sources/VocaMac/Services/WhisperService.swift
@@ -174,6 +174,7 @@ final class WhisperService: @unchecked Sendable {
             usePrefillPrompt: language != nil || promptTokens != nil,
             detectLanguage: language == nil,
             wordTimestamps: false,
+            windowClipTime: Self.windowClipTime(sampleCount: audioData.count),
             promptTokens: promptTokens,
             chunkingStrategy: nil  // No chunking for short dictation clips
         )
@@ -202,22 +203,6 @@ final class WhisperService: @unchecked Sendable {
                 options.promptTokens = nil
                 options.usePrefillPrompt = language != nil
                 results = try await kit.transcribe(audioArray: audioData, decodeOptions: options)
-                rawText = results.map { $0.text }.joined(separator: " ")
-                fullText = Self.filterHallucinationTokens(rawText)
-            }
-
-            // Whisper Tiny can return no tokens for valid sub-second speech.
-            // Retry only an empty short result with trailing silence so normal
-            // successful dictation keeps the single-pass fast path.
-            if let paddedAudio = Self.paddedAudioForShortEmptyTranscription(
-                audioData,
-                transcription: fullText
-            ) {
-                VocaLogger.warning(
-                    .whisperService,
-                    "Short transcription was empty for \(loadedModelName ?? "unknown model"); retrying with trailing silence"
-                )
-                results = try await kit.transcribe(audioArray: paddedAudio, decodeOptions: options)
                 rawText = results.map { $0.text }.joined(separator: " ")
                 fullText = Self.filterHallucinationTokens(rawText)
             }
@@ -309,22 +294,11 @@ final class WhisperService: @unchecked Sendable {
         promptTokens != nil && rawText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
     }
 
-    /// Some Whisper models return no tokens for otherwise valid sub-second
-    /// speech. A small trailing-silence pad gives the retry more context without
-    /// changing the reported audio length.
-    static func paddedAudioForShortEmptyTranscription(
-        _ audio: [Float],
-        transcription: String
-    ) -> [Float]? {
-        let minimumSampleCount = 17_600 // 1.1 seconds at 16 kHz
-        guard transcription.isEmpty,
-              !audio.isEmpty,
-              audio.count < minimumSampleCount else {
-            return nil
-        }
-        var padded = audio
-        padded.append(contentsOf: repeatElement(0, count: minimumSampleCount - audio.count))
-        return padded
+    /// WhisperKit only decodes while seek < end - windowClipTime. Its default
+    /// one-second exclusion skips the entire clip at or below 16,000 samples.
+    /// Retain the default trailing-window protection for longer recordings.
+    static func windowClipTime(sampleCount: Int) -> Float {
+        sampleCount <= 16_000 ? 0 : 1
     }
 
     /// Encode custom vocabulary into WhisperKit conditioning tokens.

--- a/Tests/VocaMacTests/WhisperServiceTests.swift
+++ b/Tests/VocaMacTests/WhisperServiceTests.swift
@@ -96,3 +96,33 @@ final class WhisperServiceVocabularyTests: XCTestCase {
         XCTAssertFalse(WhisperService.shouldRetryWithoutVocabulary(rawText: "", promptTokens: nil))
     }
 }
+
+// MARK: - WhisperService Short Audio Tests
+
+final class WhisperServiceShortAudioTests: XCTestCase {
+    func testEmptyShortTranscriptionPadsToMinimumDecoderWindow() throws {
+        let audio: [Float] = [0.25, -0.5, 0.75]
+        let padded = try XCTUnwrap(
+            WhisperService.paddedAudioForShortEmptyTranscription(audio, transcription: "")
+        )
+
+        XCTAssertEqual(padded.count, 17_600)
+        XCTAssertEqual(Array(padded.prefix(audio.count)), audio)
+        XCTAssertTrue(padded.dropFirst(audio.count).allSatisfy { $0 == 0 })
+    }
+
+    func testSuccessfulOrLongTranscriptionDoesNotRetry() {
+        XCTAssertNil(
+            WhisperService.paddedAudioForShortEmptyTranscription([0.5], transcription: "Hello")
+        )
+        XCTAssertNil(
+            WhisperService.paddedAudioForShortEmptyTranscription(
+                Array(repeating: 0.5, count: 17_600),
+                transcription: ""
+            )
+        )
+        XCTAssertNil(
+            WhisperService.paddedAudioForShortEmptyTranscription([], transcription: "")
+        )
+    }
+}

--- a/Tests/VocaMacTests/WhisperServiceTests.swift
+++ b/Tests/VocaMacTests/WhisperServiceTests.swift
@@ -4,6 +4,7 @@
 // Tests for WhisperService: translation and hallucination filtering.
 
 import XCTest
+import WhisperKit
 @testable import VocaMac
 
 // MARK: - WhisperService Translation Tests
@@ -100,29 +101,17 @@ final class WhisperServiceVocabularyTests: XCTestCase {
 // MARK: - WhisperService Short Audio Tests
 
 final class WhisperServiceShortAudioTests: XCTestCase {
-    func testEmptyShortTranscriptionPadsToMinimumDecoderWindow() throws {
-        let audio: [Float] = [0.25, -0.5, 0.75]
-        let padded = try XCTUnwrap(
-            WhisperService.paddedAudioForShortEmptyTranscription(audio, transcription: "")
-        )
-
-        XCTAssertEqual(padded.count, 17_600)
-        XCTAssertEqual(Array(padded.prefix(audio.count)), audio)
-        XCTAssertTrue(padded.dropFirst(audio.count).allSatisfy { $0 == 0 })
+    func testShortClipsEnterWhisperKitDecodeLoop() {
+        for count in [1, 7_970, 15_999, 16_000] {
+            let options = DecodingOptions(windowClipTime: WhisperService.windowClipTime(sampleCount: count))
+            let excludedSamples = Int(options.windowClipTime * Float(WhisperKit.sampleRate))
+            XCTAssertGreaterThan(count - excludedSamples, 0, "Clip of \(count) samples must be decoded")
+        }
     }
 
-    func testSuccessfulOrLongTranscriptionDoesNotRetry() {
-        XCTAssertNil(
-            WhisperService.paddedAudioForShortEmptyTranscription([0.5], transcription: "Hello")
-        )
-        XCTAssertNil(
-            WhisperService.paddedAudioForShortEmptyTranscription(
-                Array(repeating: 0.5, count: 17_600),
-                transcription: ""
-            )
-        )
-        XCTAssertNil(
-            WhisperService.paddedAudioForShortEmptyTranscription([], transcription: "")
-        )
+    func testLongerClipsKeepDefaultTrailingWindowProtection() {
+        for count in [16_001, 17_600, 480_000, 960_000] {
+            XCTAssertEqual(WhisperService.windowClipTime(sampleCount: count), DecodingOptions().windowClipTime)
+        }
     }
 }


### PR DESCRIPTION
## Problem

WhisperKit defaults to excluding one second at the end of a decoding window. Its decode loop runs only while `seek < end - windowPadding`, so recordings of one second or less never enter the loop and return empty text. A current-source Tiny reproduction returned empty for a 0.498-second synthetic “Hello” recording.

## Changes

Set `windowClipTime` to zero for clips of at most 16,000 samples (one second at 16 kHz). Longer clips retain WhisperKit's default trailing-window protection. Short speech is decoded directly using the original samples and duration, with no additional padding or retry. Existing vocabulary recovery and no-speech filtering remain in place.

## Validation

- 14 focused Whisper service tests passed, including decode-loop eligibility at one sample, sub-second lengths, exactly one second, and preservation of default options above the boundary.
- Live Tiny CLI: the original 0.498-second fixture and exactly one-second fixture both returned `Hello.` with their original durations.
- Digital silence was rejected by the existing CLI audio validation.
- App compiled as part of `swift test`; `git diff --check` passed.
- Full suite before self-review: 444 tests, one environment-dependent skip, no failures. The revised code received the focused checks above; CI reruns on the new commit.
