### PR TITLE
fix: retry an ONNX decode that comes back empty

### DIFF
--- a/Sources/VocaMac/Services/SherpaAudioPreparation.swift
+++ b/Sources/VocaMac/Services/SherpaAudioPreparation.swift
@@ -34,17 +34,39 @@ enum SherpaAudioPreparation {
         }
     }
 
-    static func prepare(_ samples: [Float]) -> [Float] {
+    /// Alternative ways to distribute the same silence, used to retry a decode
+    /// that came back empty.
+    ///
+    /// The decoders are chaotically sensitive to exact framing. Measured on a
+    /// real 4s recording that decoded to nothing: scaling every sample by
+    /// 1.001 recovered the whole sentence and 0.999 did not, and shifting the
+    /// speech by 100ms flipped the result either way. No perturbation is right
+    /// in general — but a decode that returned nothing has nothing to lose,
+    /// and reframing recovers it.
+    ///
+    /// Every layout adds exactly as much silence as the first attempt, so a
+    /// retry can never push a segment past the one-pass limit the segmenter
+    /// exists to respect.
+    static let recoveryLayouts: [(lead: Int, tail: Int)] = [
+        (lead: 2 * edgeSilenceSampleCount, tail: 0),
+        (lead: 0, tail: 2 * edgeSilenceSampleCount),
+        (lead: edgeSilenceSampleCount / 2, tail: 3 * edgeSilenceSampleCount / 2),
+    ]
+
+    static func prepare(
+        _ samples: [Float],
+        lead: Int = edgeSilenceSampleCount,
+        tail: Int = edgeSilenceSampleCount
+    ) -> [Float] {
         // Do not ask generative decoders to invent words for digital silence.
         guard samples.contains(where: { $0 != 0 }) else { return [] }
 
-        let edge = repeatElement(Float.zero, count: edgeSilenceSampleCount)
-        let paddedCount = samples.count + 2 * edgeSilenceSampleCount
+        let paddedCount = samples.count + lead + tail
         var prepared: [Float] = []
         prepared.reserveCapacity(max(minimumSampleCount, paddedCount))
-        prepared.append(contentsOf: edge)
+        prepared.append(contentsOf: repeatElement(Float.zero, count: lead))
         prepared.append(contentsOf: samples)
-        prepared.append(contentsOf: edge)
+        prepared.append(contentsOf: repeatElement(Float.zero, count: tail))
 
         if prepared.count < minimumSampleCount {
             prepared.append(

--- a/Sources/VocaMac/Services/SherpaService.swift
+++ b/Sources/VocaMac/Services/SherpaService.swift
@@ -371,9 +371,7 @@ final class SherpaService: @unchecked Sendable {
         var detected = ""
         for segment in segments {
             try Task.checkCancellation()
-            let samples = SherpaAudioPreparation.prepare(segment)
-            guard !samples.isEmpty else { continue }
-            let result = try decodeSegment(samples)
+            guard let result = try decode(segment, with: decodeSegment) else { continue }
             try Task.checkCancellation()
             let piece = result.text.trimmingCharacters(in: .whitespacesAndNewlines)
             if !piece.isEmpty { pieces.append(piece) }
@@ -381,6 +379,45 @@ final class SherpaService: @unchecked Sendable {
         }
         let joinLanguage = detected.isEmpty ? (language ?? "") : detected
         return (joinTranscriptPieces(pieces, language: joinLanguage), detected)
+    }
+
+    /// Decode one segment, retrying with a different silence layout when the
+    /// model returns nothing.
+    ///
+    /// These decoders stop as soon as they emit end-of-transcript, and for
+    /// some inputs they emit it as their very first token — the recording is
+    /// dropped with no error to show for it. Which inputs is not predictable:
+    /// the same words shifted by a few milliseconds decode either perfectly or
+    /// not at all. Retrying the same audio framed differently recovers it, and
+    /// only ever runs after an attempt that produced nothing.
+    ///
+    /// Returns nil when the segment held no audio to decode.
+    static func decode(
+        _ segment: [Float],
+        with decodeSegment: ([Float]) throws -> (text: String, lang: String)
+    ) throws -> (text: String, lang: String)? {
+        let samples = SherpaAudioPreparation.prepare(segment)
+        guard !samples.isEmpty else { return nil }
+
+        let first = try decodeSegment(samples)
+        guard first.text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+            return first
+        }
+
+        for layout in SherpaAudioPreparation.recoveryLayouts {
+            try Task.checkCancellation()
+            let retry = try decodeSegment(
+                SherpaAudioPreparation.prepare(segment, lead: layout.lead, tail: layout.tail)
+            )
+            if !retry.text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                VocaLogger.info(
+                    .sherpaService,
+                    "Recovered an empty decode by reframing the segment"
+                )
+                return retry
+            }
+        }
+        return first
     }
 
     /// Join Chinese/Japanese segments without spaces. Korean, like Western

--- a/Tests/VocaMacTests/SherpaAudioPreparationTests.swift
+++ b/Tests/VocaMacTests/SherpaAudioPreparationTests.swift
@@ -63,6 +63,27 @@ final class SherpaAudioPreparationTests: XCTestCase {
         }
     }
 
+    /// A retry must never buy its second chance by overrunning the model's
+    /// one-pass limit, so every layout adds exactly as much as the first try.
+    func testEveryRecoveryLayoutAddsTheSameSilenceAsTheFirstAttempt() {
+        let speech = [Float](repeating: 0.1, count: 40_000)
+        let first = SherpaAudioPreparation.prepare(speech)
+        for layout in SherpaAudioPreparation.recoveryLayouts {
+            let retry = SherpaAudioPreparation.prepare(
+                speech, lead: layout.lead, tail: layout.tail
+            )
+            XCTAssertEqual(retry.count, first.count)
+            XCTAssertEqual(Array(retry[layout.lead..<(layout.lead + speech.count)]), speech)
+        }
+    }
+
+    func testRecoveryLayoutsAreAllDifferentFromTheFirstAttempt() {
+        let normal = SherpaAudioPreparation.edgeSilenceSampleCount
+        for layout in SherpaAudioPreparation.recoveryLayouts {
+            XCTAssertNotEqual(layout.lead, normal, "a retry that reframes nothing decodes the same")
+        }
+    }
+
     func testEmptyAndDigitalSilenceDoNotReachDecoder() {
         XCTAssertEqual(SherpaAudioPreparation.prepare([]), [])
         XCTAssertEqual(SherpaAudioPreparation.prepare([Float](repeating: 0, count: 32_000)), [])

--- a/Tests/VocaMacTests/SherpaServiceTests.swift
+++ b/Tests/VocaMacTests/SherpaServiceTests.swift
@@ -185,6 +185,40 @@ final class SherpaServiceTests: XCTestCase {
         XCTAssertEqual(result.text, "안녕하세요 반갑습니다")
     }
 
+    func testEmptyDecodeIsRetriedWithADifferentFrameUntilItRecovers() {
+        var attempts: [Int] = []
+        let result = try? SherpaService.decodeSegments(
+            [[Float](repeating: 0.2, count: 32_000)], language: "en"
+        ) { samples in
+            attempts.append(samples.count)
+            // Fail every framing but the last one on the ladder.
+            let isLastLayout = attempts.count == SherpaAudioPreparation.recoveryLayouts.count + 1
+            return (isLastLayout ? "recovered" : "", "en")
+        }
+        XCTAssertEqual(result?.text, "recovered")
+        XCTAssertEqual(attempts.count, SherpaAudioPreparation.recoveryLayouts.count + 1)
+        XCTAssertEqual(Set(attempts).count, 1, "a retry must not change the segment's length")
+    }
+
+    func testASuccessfulDecodeIsNeverRetried() {
+        var attempts = 0
+        _ = try? SherpaService.decodeSegments([[0.3, 0.4]], language: "en") { _ in
+            attempts += 1
+            return ("got it", "en")
+        }
+        XCTAssertEqual(attempts, 1)
+    }
+
+    func testAudioThatDecodesToNothingGivesUpAfterTheLadder() {
+        var attempts = 0
+        let result = try? SherpaService.decodeSegments([[0.3, 0.4]], language: "en") { _ in
+            attempts += 1
+            return ("", "en")
+        }
+        XCTAssertEqual(attempts, SherpaAudioPreparation.recoveryLayouts.count + 1)
+        XCTAssertEqual(result?.text, "")
+    }
+
     func testFailedLaterSegmentDoesNotReturnPartialSuccess() {
         var calls = 0
         XCTAssertThrowsError(try SherpaService.decodeSegments([[0.1], [0.2]], language: "en") { _ in


### PR DESCRIPTION
Follow-up to #256. That fix was real but incomplete — recordings were still being dropped, and this is the actual mechanism.

## What the padding fix missed

#256 assumed speech starting in sample zero was the trigger. It was *a* trigger, and padding killed it: 174 generated clips and 12 with synthetic room-noise floors all pass. But real recordings kept coming back empty.

A dump of one — a 4.0s clip this app dropped — shows why:

| input | result |
|---|---|
| the recording as captured | `""` |
| **the same samples ×1.001** | `"Hey, let's see if this sucks for eight seconds of audio."` |
| the same samples ×0.999 | `""` |
| speech shifted 100ms later | full sentence |
| speech shifted 300ms later | `""` |
| speech shifted 500ms later | full sentence |

A **0.1% amplitude change** is the difference between a perfect transcript and nothing at all. The decoders stop the moment they emit `<|endoftext|>` and for some inputs emit it as their very first token:

```cpp
std::vector<int32_t> tokens = {max_token_id};   // if this is eos...
for (...) { if (tokens.back() == eos) break; } // ...the loop never runs
tokens.pop_back();                              // ...and this empties it
```

Which inputs land on that knife edge is not predictable from anything the app can measure — level, duration, DC offset, noise floor and language were all tested and none separate the failures. So no amount of tuning the padding fixes this. It is chaotic sensitivity in an upstream greedy decoder.

## The fix

When a segment decodes to nothing, decode it again with the same silence distributed differently: all in front, all behind, then split unevenly.

Two properties keep this honest:

- **Length-neutral.** Every layout adds exactly as much silence as the first attempt, so a retry can never push a segment past the one-pass limit the segmenter exists to respect — the concern raised in review on #256.
- **Only after a failure.** A decode that produced text is never retried, so the normal path costs nothing. A failing decode is the cheap case anyway (~0.13s for 4s of audio, since it stops on token one).

## Verification

From the dumped recording I derived **20 inputs, each independently confirmed to decode to nothing** on this model (gain-scaled and time-shifted variants — every one a genuine reproduction of the bug).

**The ladder recovers all 20**, including one (`+2000ms lead-in`) that no single reframing in the search recovered on its own. The 11 clips that already worked are unchanged.

`swift test`: 481 tests, 0 failures. New tests cover that a retry never changes the segment's length, that a successful decode is never retried, and that the ladder terminates.

## Upstream

The real defect is in sherpa-onnx: `offline-recognizer-canary-impl.h` takes `argmax` of the first decoder logits unguarded, so when that argmax is `<|endoftext|>` the token loop never runs and `tokens.pop_back()` empties the result. Its reference script (`scripts/nemo/canary/test_180m_flash.py`) has the same structure, so the C++ is faithful to the reference — neither guards the first generated position, which is never a legitimate place for end-of-transcript when the audio contains speech.

Worth reporting upstream; this fix is a workaround at the only layer we control.

## Note

The dumped-audio diagnostic that made this debuggable (writes the samples behind an empty decode to a WAV, opt-in via a hidden default) is deliberately **not** in this PR — one logical change per PR. Happy to send it separately if useful; it will pay for itself the next time this class of bug appears.