### PR TITLE
fix: reduce dictation latency and main-thread contention

### DIFF
--- a/Sources/VocaMac/Models/AppState.swift
+++ b/Sources/VocaMac/Models/AppState.swift
@@ -61,10 +61,26 @@ final class AppState: ObservableObject {
     @Published var appStatus: AppStatus = .idle
 
     /// Whether the app is actively recording audio
-    @Published var isRecording: Bool = false
+    private var recordingGeneration = UUID()
+    private var recordingTranscription: RecordingTranscription?
+    private var finishingTranscription: RecordingTranscription?
+    private var isStoppingAudio = false
+    @Published var isRecording: Bool = false {
+        didSet {
+            if !isRecording {
+                audioEngine.onAudioSamples = nil
+                recordingTranscription?.cancel()
+                recordingTranscription = nil
+            }
+        }
+    }
 
     /// Current audio input level (0.0 - 1.0) for visual feedback
-    @Published var audioLevel: Float = 0.0
+    let audioMeter = AudioMeterState()
+    var audioLevel: Float {
+        get { audioMeter.level }
+        set { audioMeter.update(newValue) }
+    }
 
     /// The most recent transcription result
     @Published var lastTranscription: VocaTranscription?
@@ -453,6 +469,12 @@ final class AppState: ObservableObject {
     // MARK: - Setup
 
     private func setupServices() {
+        textInjector.onFailure = { [weak self] message in
+            Task { @MainActor in
+                guard let self, !self.isRecording else { return }
+                self.showTemporaryError(message)
+            }
+        }
         // Detect system capabilities
         systemCapabilities = SystemInfo.detect()
 
@@ -532,6 +554,7 @@ final class AppState: ObservableObject {
             Task { @MainActor in
                 guard let self = self else { return }
                 VocaLogger.warning(.appState, "Audio device changed — recovering from interrupted recording")
+                self.recordingGeneration = UUID()
                 self.isRecording = false
                 self.audioLevel = 0.0
                 self.cursorOverlay.hide()
@@ -896,6 +919,8 @@ final class AppState: ObservableObject {
     /// It unconditionally resets the audio engine, hotkey state, cursor overlay,
     /// and all published state back to idle.
     func forceRecovery() {
+        recordingGeneration = UUID()
+        finishingTranscription?.cancel()
         VocaLogger.warning(.appState, "Force recovery: resetting all state to idle (was appStatus=\(appStatus.rawValue), isRecording=\(isRecording))")
 
         // Reset audio engine unconditionally
@@ -968,6 +993,7 @@ final class AppState: ObservableObject {
             appStatus = .idle
         }
 
+        recordingGeneration = UUID()
         appStatus = .recording
         isRecording = true
         errorMessage = nil
@@ -986,6 +1012,11 @@ final class AppState: ObservableObject {
         // mic buffer is negligible and handled well by WhisperKit's noise model.
         isStartingAudio = true
         pendingStopDuringStart = nil
+        let session = whisperService.startStreaming(language: selectedLanguage == "auto" ? nil : selectedLanguage)
+        recordingTranscription = session
+        audioEngine.onAudioSamples = session.map { session in
+            { samples, offset in session.append(samples, at: offset) }
+        }
         let didStartRecording = await startAudioEngine(
             silenceThreshold: Float(silenceThreshold),
             silenceDuration: silenceDuration,
@@ -1051,7 +1082,19 @@ final class AppState: ObservableObject {
             return
         }
 
+        guard !isStoppingAudio else { return }
+        isStoppingAudio = true
+        let generation = recordingGeneration
         let audioData = await stopAudioEngine()
+        isStoppingAudio = false
+        guard generation == recordingGeneration else { return }
+        let session = recordingTranscription
+        recordingTranscription = nil
+        finishingTranscription = session
+        defer {
+            session?.cancel()
+            if finishingTranscription === session { finishingTranscription = nil }
+        }
         isRecording = false
         audioLevel = 0.0
 
@@ -1084,13 +1127,29 @@ final class AppState: ObservableObject {
 
         do {
             let language = selectedLanguage == "auto" ? nil : selectedLanguage
-            let result = try await whisperService.transcribe(
-                audioData: audioData,
-                language: language,
-                translate: translationEnabled,
-                vocabulary: customVocabulary
-            )
+            let result: VocaTranscription
+            if let session, session.language == language {
+                do {
+                    result = try await session.finish(expectedSampleCount: audioData.count)
+                } catch {
+                    guard generation == recordingGeneration else { return }
+                    try Task.checkCancellation()
+                    PerformanceTrace.event("StreamingBatchFallback")
+                    VocaLogger.warning(.appState, "Live transcription unavailable; decoding the complete recording")
+                    result = try await whisperService.transcribe(
+                        audioData: audioData, language: language,
+                        translate: translationEnabled, vocabulary: customVocabulary
+                    )
+                }
+            } else {
+                session?.cancel()
+                result = try await whisperService.transcribe(
+                    audioData: audioData, language: language,
+                    translate: translationEnabled, vocabulary: customVocabulary
+                )
+            }
 
+            guard generation == recordingGeneration else { return }
             lastTranscription = result
 
             // Update stats
@@ -1128,6 +1187,7 @@ final class AppState: ObservableObject {
             cursorOverlay.hide()
             appStatus = .idle
         } catch {
+            guard generation == recordingGeneration else { return }
             cursorOverlay.hide()
             errorMessage = "Transcription failed: \(error.localizedDescription)"
             appStatus = .error

--- a/Sources/VocaMac/Models/AudioMeterState.swift
+++ b/Sources/VocaMac/Models/AudioMeterState.swift
@@ -1,0 +1,32 @@
+import SwiftUI
+
+/// High-frequency meter changes do not invalidate AppState's other observers.
+@MainActor
+final class AudioMeterState: ObservableObject {
+    @Published private(set) var level: Float = 0
+
+    func update(_ value: Float) {
+        let next = value.isFinite ? min(1, max(0, value)) : 0
+        guard next != level else { return }
+        level = next
+    }
+}
+
+struct ObservedAudioLevelView: View {
+    @ObservedObject var meter: AudioMeterState
+    var tint: Color? = nil
+
+    var body: some View {
+        if let tint {
+            GeometryReader { geometry in
+                ZStack(alignment: .leading) {
+                    Capsule().fill(Color.secondary.opacity(0.15))
+                    Capsule().fill(tint)
+                        .frame(width: max(4, geometry.size.width * CGFloat(meter.level)))
+                }
+            }
+        } else {
+            AudioLevelView(level: meter.level)
+        }
+    }
+}

--- a/Sources/VocaMac/Services/AppleSpeechService.swift
+++ b/Sources/VocaMac/Services/AppleSpeechService.swift
@@ -60,6 +60,8 @@ final class AppleSpeechService: @unchecked Sendable {
 
     /// Whether the engine has been prepared (assets checked/installed)
     private var isPrepared = false
+    private var preparedSession: (any PreparedSpeechSession)?
+    private var preparedLocale: String?
 
     var isModelLoaded: Bool { isPrepared }
 
@@ -87,7 +89,9 @@ final class AppleSpeechService: @unchecked Sendable {
 
         onPhaseChange?("Checking speech assets…")
         let locale = language.map { Locale(identifier: $0) } ?? Locale.current
-        try await AppleSpeechEngine.prepareAssets(for: locale, onPhaseChange: onPhaseChange)
+        await unloadModel()
+        preparedSession = try await AppleSpeechEngine.prepareSession(for: locale, onPhaseChange: onPhaseChange)
+        preparedLocale = locale.identifier
         isPrepared = true
 
         let elapsed = CFAbsoluteTimeGetCurrent() - startTime
@@ -97,8 +101,12 @@ final class AppleSpeechService: @unchecked Sendable {
         #endif
     }
 
-    func unloadModel() {
+    func unloadModel() async {
         isPrepared = false
+        let session = preparedSession
+        preparedSession = nil
+        preparedLocale = nil
+        await session?.cancel()
     }
 
     // MARK: - Transcription
@@ -112,43 +120,46 @@ final class AppleSpeechService: @unchecked Sendable {
         audioData: [Float],
         language: String? = nil
     ) async throws -> VocaTranscription {
+        guard !audioData.isEmpty else { throw AppleSpeechError.emptyAudio }
+        let cursor = AudioChunkCursor(audioData)
+        return try await transcribe(
+            chunks: AsyncThrowingStream(unfolding: { await cursor.next() }), language: language
+        )
+    }
+
+    /// Own one prepared analyzer for one utterance. Finished sessions are never reused.
+    func transcribe(chunks: AsyncThrowingStream<[Float], Error>, language: String?) async throws -> VocaTranscription {
         #if compiler(>=6.2)
         guard #available(macOS 26.0, *) else { throw AppleSpeechError.unsupportedSystem }
         guard isPrepared else { throw AppleSpeechError.modelNotLoaded }
-        guard !audioData.isEmpty else { throw AppleSpeechError.emptyAudio }
-
-        let audioLengthSeconds = Double(audioData.count) / 16000.0
-        VocaLogger.info(.appleSpeechService, "Apple Speech transcribing \(String(format: "%.1f", audioLengthSeconds))s of audio...")
-
-        let startTime = CFAbsoluteTimeGetCurrent()
-        let requestedLocale = language.map { Locale(identifier: $0) } ?? Locale.current
-
+        let locale = language.map { Locale(identifier: $0) } ?? Locale.current
+        let start = CFAbsoluteTimeGetCurrent()
+        let session: any PreparedSpeechSession
+        if let preparedSession, preparedLocale == locale.identifier {
+            session = preparedSession
+            self.preparedSession = nil
+        } else {
+            await preparedSession?.cancel()
+            preparedSession = nil
+            session = try await AppleSpeechEngine.prepareSession(for: locale)
+        }
         do {
-            let text = try await AppleSpeechEngine.transcribe(
-                samples: audioData,
-                locale: requestedLocale
-            )
-
-            let elapsed = CFAbsoluteTimeGetCurrent() - startTime
-            VocaLogger.info(.appleSpeechService, "Apple Speech transcription completed in \(String(format: "%.2f", elapsed))s")
-            VocaLogger.info(.appleSpeechService, "Result: \(text.prefix(100))...")
-
+            try Task.checkCancellation()
+            let (text, count) = try await session.transcribe(chunks)
             return VocaTranscription(
-                text: text,
-                duration: elapsed,
-                detectedLanguage: language ?? requestedLocale.language.languageCode?.identifier ?? "auto",
-                audioLengthSeconds: audioLengthSeconds,
-                modelUsed: .appleSpeech
+                text: text, duration: CFAbsoluteTimeGetCurrent() - start,
+                detectedLanguage: language ?? locale.language.languageCode?.identifier ?? "auto",
+                audioLengthSeconds: Double(count) / 16_000, modelUsed: .appleSpeech
             )
-        } catch let error as AppleSpeechError {
-            throw error
         } catch {
-            throw AppleSpeechError.transcriptionFailed(reason: error.localizedDescription)
+            await session.cancel()
+            throw error
         }
         #else
         throw AppleSpeechError.unsupportedSystem
         #endif
     }
+
 }
 
 // MARK: - AppleSpeechEngine (SpeechAnalyzer wrapper)
@@ -174,139 +185,165 @@ enum AppleSpeechEngine {
         }
     }
 
-    /// Ensure the system has transcription assets installed for the locale.
-    static func prepareAssets(
-        for locale: Locale,
-        onPhaseChange: ((String) -> Void)? = nil
-    ) async throws {
+    /// Resolve assets and preheat before the first recording rather than after stop.
+    fileprivate static func prepareSession(
+        for locale: Locale, onPhaseChange: ((String) -> Void)? = nil
+    ) async throws -> any PreparedSpeechSession {
+        let interval = PerformanceTrace.begin("AppleSpeechPreparation")
+        defer { PerformanceTrace.end(interval) }
         guard let resolved = await resolveSupportedLocale(matching: locale) else {
             throw AppleSpeechError.localeNotSupported(locale.identifier)
         }
-
         let transcriber = SpeechTranscriber(
-            locale: resolved,
-            transcriptionOptions: [],
-            reportingOptions: [],
-            attributeOptions: []
+            locale: resolved, transcriptionOptions: [], reportingOptions: [], attributeOptions: []
         )
-
         if let request = try await AssetInventory.assetInstallationRequest(supporting: [transcriber]) {
             onPhaseChange?("Downloading speech assets…")
-            VocaLogger.info(.appleSpeechService, "Downloading system speech assets for \(resolved.identifier)...")
             try await request.downloadAndInstall()
         }
-    }
-
-    /// Transcribe a full clip of 16kHz mono Float32 samples.
-    static func transcribe(samples: [Float], locale: Locale) async throws -> String {
-        guard let resolved = await resolveSupportedLocale(matching: locale) else {
-            throw AppleSpeechError.localeNotSupported(locale.identifier)
-        }
-
-        let transcriber = SpeechTranscriber(
-            locale: resolved,
-            transcriptionOptions: [],
-            reportingOptions: [],
-            attributeOptions: []
-        )
-
-        // Assets for the app's warm-up locale are installed at load time, but
-        // the user may dictate in a different language — install on demand.
-        if let request = try await AssetInventory.assetInstallationRequest(supporting: [transcriber]) {
-            try await request.downloadAndInstall()
-        }
-
-        let analyzer = SpeechAnalyzer(modules: [transcriber])
-
-        guard let analysisFormat = await SpeechAnalyzer.bestAvailableAudioFormat(
-            compatibleWith: [transcriber]
-        ) else {
+        guard let format = await SpeechAnalyzer.bestAvailableAudioFormat(compatibleWith: [transcriber]) else {
             throw AppleSpeechError.audioFormatUnavailable
         }
+        let analyzer = SpeechAnalyzer(modules: [transcriber])
+        onPhaseChange?("Preparing speech recognition…")
+        do {
+            try await analyzer.prepareToAnalyze(in: format)
+            try Task.checkCancellation()
+            return ApplePreparedSpeechSession(analyzer: analyzer, transcriber: transcriber, format: format)
+        } catch {
+            await analyzer.cancelAndFinishNow()
+            throw error
+        }
+    }
+}
 
-        // Collect final results concurrently while audio is analyzed.
-        let collector = Task { () -> String in
+@available(macOS 26.0, *)
+private actor ApplePreparedSpeechSession: PreparedSpeechSession {
+    let analyzer: SpeechAnalyzer
+    let transcriber: SpeechTranscriber
+    let format: AVAudioFormat
+    private var started = false
+
+    init(analyzer: SpeechAnalyzer, transcriber: SpeechTranscriber, format: AVAudioFormat) {
+        self.analyzer = analyzer
+        self.transcriber = transcriber
+        self.format = format
+    }
+
+    func transcribe(_ chunks: AsyncThrowingStream<[Float], Error>) async throws -> (String, Int) {
+        guard !started else { throw AppleSpeechError.modelNotLoaded }
+        started = true
+        let collector = Task { [transcriber] in
             var pieces: [String] = []
             for try await result in transcriber.results where result.isFinal {
                 pieces.append(String(result.text.characters))
             }
-            return pieces.joined()
+            return pieces.joined().trimmingCharacters(in: .whitespacesAndNewlines)
         }
-
-        let (inputSequence, inputBuilder) = AsyncStream.makeStream(of: AnalyzerInput.self)
-        try await analyzer.start(inputSequence: inputSequence)
-
-        let inputBuffer = try pcmBuffer(from: samples)
-        let analysisBuffer = try convert(inputBuffer, to: analysisFormat)
-        inputBuilder.yield(AnalyzerInput(buffer: analysisBuffer))
-        inputBuilder.finish()
-
-        try await analyzer.finalizeAndFinishThroughEndOfInput()
-
-        let text = try await collector.value
-        return text.trimmingCharacters(in: .whitespacesAndNewlines)
+        let source = SpeechInputCursor(chunks: chunks, format: format)
+        do {
+            return try await withTaskCancellationHandler {
+                let input = AsyncThrowingStream<AnalyzerInput, Error>(unfolding: { try await source.next() })
+                let end = try await analyzer.analyzeSequence(input)
+                if let end { try await analyzer.finalizeAndFinish(through: end) }
+                else { await analyzer.cancelAndFinishNow() }
+                let text = try await collector.value
+                return (text, await source.sampleCount)
+            } onCancel: {
+                collector.cancel()
+                Task { await self.cancel() }
+            }
+        } catch {
+            collector.cancel()
+            await analyzer.cancelAndFinishNow()
+            _ = try? await collector.value
+            throw error
+        }
     }
 
-    // MARK: Audio plumbing
+    func cancel() async { await analyzer.cancelAndFinishNow() }
+}
 
-    /// Wrap raw samples in an AVAudioPCMBuffer (16kHz mono Float32).
-    private static func pcmBuffer(from samples: [Float]) throws -> AVAudioPCMBuffer {
-        guard let format = AVAudioFormat(
-            commonFormat: .pcmFormatFloat32,
-            sampleRate: inputSampleRate,
-            channels: 1,
-            interleaved: false
-        ), let buffer = AVAudioPCMBuffer(
-            pcmFormat: format,
-            frameCapacity: AVAudioFrameCount(samples.count)
-        ) else {
-            throw AppleSpeechError.audioFormatUnavailable
-        }
+/// Lazily convert only the next chunk requested by SpeechAnalyzer. The converter
+/// spans chunks and drains once at EOF so resampling does not drop boundary frames.
+@available(macOS 26.0, *)
+actor SpeechInputCursor {
+    private var iterator: AsyncThrowingStream<[Float], Error>.Iterator
+    private let format: AVAudioFormat
+    private let converter: AVAudioConverter?
+    private(set) var sampleCount = 0
+    private var ended = false
 
-        buffer.frameLength = AVAudioFrameCount(samples.count)
-        if let channelData = buffer.floatChannelData {
+    init(chunks: AsyncThrowingStream<[Float], Error>, format: AVAudioFormat) {
+        iterator = chunks.makeAsyncIterator()
+        self.format = format
+        converter = format == AudioEngine.whisperFormat ? nil : AVAudioConverter(from: AudioEngine.whisperFormat, to: format)
+    }
+
+    func next() async throws -> AnalyzerInput? {
+        guard !ended else { return nil }
+        // A single analyzer owns this iterator; move it out across the suspension.
+        var currentIterator = iterator
+        let samples = try await currentIterator.next()
+        iterator = currentIterator
+        try Task.checkCancellation()
+        if samples == nil { ended = true }
+        if let samples, samples.isEmpty { return try await next() }
+        let count = samples?.count ?? 0
+        sampleCount += count
+        var input: AVAudioPCMBuffer?
+        if let samples, !samples.isEmpty {
+            guard let buffer = AVAudioPCMBuffer(pcmFormat: AudioEngine.whisperFormat, frameCapacity: AVAudioFrameCount(count)),
+                  let destination = buffer.floatChannelData?[0] else { throw AppleSpeechError.audioFormatUnavailable }
+            buffer.frameLength = AVAudioFrameCount(count)
             samples.withUnsafeBufferPointer { source in
-                channelData[0].update(from: source.baseAddress!, count: samples.count)
+                if let base = source.baseAddress { destination.update(from: base, count: count) }
             }
+            input = buffer
         }
-        return buffer
-    }
-
-    /// Convert a buffer to the analyzer's preferred format if they differ.
-    private static func convert(
-        _ buffer: AVAudioPCMBuffer,
-        to format: AVAudioFormat
-    ) throws -> AVAudioPCMBuffer {
-        if buffer.format == format {
-            return buffer
+        guard let converter else {
+            guard format == AudioEngine.whisperFormat else { throw AppleSpeechError.audioFormatUnavailable }
+            return input.map { AnalyzerInput(buffer: $0) }
         }
-
-        guard let converter = AVAudioConverter(from: buffer.format, to: format) else {
+        let capacity = AVAudioFrameCount(ceil(Double(max(1, count)) * format.sampleRate / 16_000) + 1024)
+        guard let output = AVAudioPCMBuffer(pcmFormat: format, frameCapacity: capacity) else {
             throw AppleSpeechError.audioFormatUnavailable
         }
-
-        let ratio = format.sampleRate / buffer.format.sampleRate
-        let capacity = AVAudioFrameCount((Double(buffer.frameLength) * ratio).rounded(.up) + 1024)
-        guard let converted = AVAudioPCMBuffer(pcmFormat: format, frameCapacity: capacity) else {
-            throw AppleSpeechError.audioFormatUnavailable
+        let provider = SpeechConverterInput(buffer: input, isEnd: samples == nil)
+        var error: NSError?
+        let interval = PerformanceTrace.begin("AppleSpeechAudioConversion")
+        let status = converter.convert(to: output, error: &error) { _, state in
+            provider.next(state)
         }
-
-        var fed = false
-        var conversionError: NSError?
-        converter.convert(to: converted, error: &conversionError) { _, outStatus in
-            if fed {
-                outStatus.pointee = .endOfStream
-                return nil
-            }
-            fed = true
-            outStatus.pointee = .haveData
-            return buffer
-        }
-
-        if let conversionError {
-            throw AppleSpeechError.transcriptionFailed(reason: conversionError.localizedDescription)
-        }
-        return converted
+        PerformanceTrace.end(interval)
+        if let error { throw error }
+        guard status != .error else { throw AppleSpeechError.audioFormatUnavailable }
+        if output.frameLength == 0 { return ended ? nil : try await next() }
+        return AnalyzerInput(buffer: output)
     }
 }
+/// AVAudioConverter invokes its input block synchronously and serially. This
+/// holder owns the buffer until conversion returns; it never escapes to a task.
+private final class SpeechConverterInput: @unchecked Sendable {
+    private let buffer: AVAudioPCMBuffer?
+    private let isEnd: Bool
+    private var supplied = false
+    init(buffer: AVAudioPCMBuffer?, isEnd: Bool) { self.buffer = buffer; self.isEnd = isEnd }
+    func next(_ state: UnsafeMutablePointer<AVAudioConverterInputStatus>) -> AVAudioBuffer? {
+        guard !supplied, let buffer else {
+            state.pointee = isEnd ? .endOfStream : .noDataNow
+            return nil
+        }
+        supplied = true
+        state.pointee = .haveData
+        return buffer
+    }
+}
+
 #endif
+
+/// Availability-erased session storage keeps the macOS 14 executable loadable.
+private protocol PreparedSpeechSession: Sendable {
+    func transcribe(_ chunks: AsyncThrowingStream<[Float], Error>) async throws -> (String, Int)
+    func cancel() async
+}

--- a/Sources/VocaMac/Services/AudioEngine.swift
+++ b/Sources/VocaMac/Services/AudioEngine.swift
@@ -45,6 +45,23 @@ final class AudioConverterCache {
     }
 }
 
+/// Tap-owned scratch buffers. A format/size change replaces storage; callers must
+/// consume the contents before the next callback reuses them.
+final class AudioPCMBufferCache {
+    private var storage: AVAudioPCMBuffer?
+    private(set) var creationCount = 0
+
+    func buffer(format: AVAudioFormat, capacity: AVAudioFrameCount) -> AVAudioPCMBuffer? {
+        if let storage, storage.format == format, storage.frameCapacity >= capacity {
+            storage.frameLength = 0
+            return storage
+        }
+        storage = AVAudioPCMBuffer(pcmFormat: format, frameCapacity: capacity)
+        if storage != nil { creationCount += 1 }
+        return storage
+    }
+}
+
 /// Tracks continuous silence independently of total recording time.
 struct SilenceDetector {
     private(set) var lastSoundTime: Date
@@ -92,7 +109,14 @@ final class AudioEngine {
     /// (e.g. tap-to-pause) for any other app playing audio.
     private var engine: AVAudioEngine?
     private var pendingEngineRelease: DispatchWorkItem?
-    private var audioBuffer: [Float] = []
+    private let capturedAudio = OSAllocatedUnfairLock(initialState: [Float]())
+    private let monoBufferCache = AudioPCMBufferCache()
+    private let outputBufferCache = AudioPCMBufferCache()
+    private let sampleObserver = OSAllocatedUnfairLock<(([Float], Int) -> Void)?>(initialState: nil)
+    var onAudioSamples: (([Float], Int) -> Void)? {
+        get { sampleObserver.withLock { $0 } }
+        set { sampleObserver.withLock { $0 = newValue } }
+    }
     private let converterCache = AudioConverterCache()
     private var _isCurrentlyRecording = false
     /// Realtime-safe capture lifecycle for the input tap.
@@ -125,7 +149,6 @@ final class AudioEngine {
     /// Last UID passed to `startRecording`, used to rebuild the graph after a
     /// configuration change without dropping the user's selected microphone.
     private var lastPreferredInputDeviceUID: String?
-    private let bufferQueue = DispatchQueue(label: "com.vocamac.audio-buffer", qos: .userInteractive)
     private let lifecycleQueue = DispatchQueue(label: "com.vocamac.audio-engine.lifecycle", qos: .userInitiated)
     private let recordingPreparationLock = NSLock()
     private var _isPreparingRecording = false
@@ -741,6 +764,10 @@ final class AudioEngine {
     /// Resets per-recording state before a new capture attempt.
     private func resetRecordingState() {
         clearAudioBuffer()
+        // Allocate before the tap starts, including room for route preparation.
+        // Cap speculative reservation; unexpectedly long recordings can still grow.
+        let seconds = maxDuration.isFinite ? min(600, max(0, maxDuration)) : 60
+        capturedAudio.withLock { $0.reserveCapacity(Int((seconds + 10) * 16_000)) }
         silenceDetector.withLock { $0.reset() }
         recordingStartTime = Date()
         maxDurationCallbackFired = false
@@ -787,17 +814,16 @@ final class AudioEngine {
 
     /// Clears captured audio samples while preserving buffer capacity.
     private func clearAudioBuffer() {
-        bufferQueue.sync {
-            audioBuffer.removeAll(keepingCapacity: true)
-        }
+        capturedAudio.withLock { $0.removeAll(keepingCapacity: true) }
     }
 
     /// Returns captured samples and clears the backing buffer.
     private func capturedSamplesAndResetBuffer() -> [Float] {
-        bufferQueue.sync {
-            let copy = audioBuffer
-            audioBuffer.removeAll(keepingCapacity: true)
-            return copy
+        capturedAudio.withLock { samples in
+            // Transfer ownership instead of retaining a second full-capacity array.
+            let result = samples
+            samples = []
+            return result
         }
     }
 
@@ -1099,7 +1125,9 @@ final class AudioEngine {
             inputChannel: preferredInputChannel,
             converterProvider: { [converterCache] source, destination in
                 converterCache.converter(from: source, to: destination)
-            }
+            },
+            monoBufferCache: monoBufferCache,
+            outputBufferCache: outputBufferCache
         ) else {
             return
         }
@@ -1123,13 +1151,23 @@ final class AudioEngine {
         // is detected — the triggering frame and any trailing audio are preserved.
         if let channelData = convertedBuffer.floatChannelData {
             let frameCount = Int(convertedBuffer.frameLength)
-            bufferQueue.sync {
+            let offset = capturedAudio.withLockUnchecked { samples in
+                let offset = samples.count
                 Self.appendCapturedSamples(
                     channelData[0],
                     count: frameCount,
                     muted: isApplicationInputMuted,
-                    to: &audioBuffer
+                    to: &samples
                 )
+                return offset
+            }
+            // Only streaming engines need an owned copy beyond this callback.
+            // The observer has bounded buffering and never waits for inference.
+            if let observer = sampleObserver.withLock({ $0 }) {
+                let chunk = isApplicationInputMuted
+                    ? [Float](repeating: 0, count: frameCount)
+                    : Array(UnsafeBufferPointer(start: channelData[0], count: frameCount))
+                observer(chunk, offset)
             }
         }
 
@@ -1175,13 +1213,16 @@ final class AudioEngine {
         _ buffer: AVAudioPCMBuffer,
         from inputFormat: AVAudioFormat,
         inputChannel: Int = 0,
-        converterProvider: ((AVAudioFormat, AVAudioFormat) -> AVAudioConverter?)? = nil
+        converterProvider: ((AVAudioFormat, AVAudioFormat) -> AVAudioConverter?)? = nil,
+        monoBufferCache: AudioPCMBufferCache? = nil,
+        outputBufferCache: AudioPCMBufferCache? = nil
     ) -> AVAudioPCMBuffer? {
         let sourceBuffer: AVAudioPCMBuffer
         if inputFormat.channelCount > 1 {
             guard let monoBuffer = monoBuffer(
                 from: buffer,
-                selecting: inputChannel
+                selecting: inputChannel,
+                cache: monoBufferCache
             ) else {
                 VocaLogger.error(.audioEngine, "Failed to read multi-channel microphone samples")
                 return nil
@@ -1215,10 +1256,8 @@ final class AudioEngine {
             AVAudioFrameCount(ceil(Double(sourceBuffer.frameLength) * ratio))
         )
 
-        guard let outputBuffer = AVAudioPCMBuffer(
-            pcmFormat: whisperFormat,
-            frameCapacity: outputFrameCapacity
-        ) else {
+        guard let outputBuffer = outputBufferCache?.buffer(format: whisperFormat, capacity: outputFrameCapacity)
+            ?? AVAudioPCMBuffer(pcmFormat: whisperFormat, frameCapacity: outputFrameCapacity) else {
             return nil
         }
 
@@ -1308,7 +1347,8 @@ final class AudioEngine {
     /// Copies one selected channel into a mono Float32 buffer without attenuation.
     static func monoBuffer(
         from buffer: AVAudioPCMBuffer,
-        selecting requestedChannel: Int
+        selecting requestedChannel: Int,
+        cache: AudioPCMBufferCache? = nil
     ) -> AVAudioPCMBuffer? {
         let format = buffer.format
         let channelCount = Int(format.channelCount)
@@ -1324,10 +1364,8 @@ final class AudioEngine {
                 channels: 1,
                 interleaved: false
               ),
-              let monoBuffer = AVAudioPCMBuffer(
-                pcmFormat: monoFormat,
-                frameCapacity: buffer.frameLength
-              ),
+              let monoBuffer = cache?.buffer(format: monoFormat, capacity: buffer.frameLength)
+                ?? AVAudioPCMBuffer(pcmFormat: monoFormat, frameCapacity: buffer.frameLength),
               let monoData = monoBuffer.floatChannelData?[0] else {
             return nil
         }

--- a/Sources/VocaMac/Services/AudioSegmenter.swift
+++ b/Sources/VocaMac/Services/AudioSegmenter.swift
@@ -135,7 +135,13 @@ enum AudioSegmenter {
 
     /// Convenience wrapper that measures energy directly from the samples.
     static func segment(_ samples: [Float], maxSeconds: Double, sampleRate: Int = 16_000) -> [[Float]] {
-        let ranges = segmentRanges(
+        let ranges = ranges(for: samples, maxSeconds: maxSeconds, sampleRate: sampleRate)
+        if ranges.count <= 1 { return samples.isEmpty ? [] : [samples] }
+        return ranges.map { Array(samples[$0]) }
+    }
+
+    static func ranges(for samples: [Float], maxSeconds: Double, sampleRate: Int = 16_000) -> [Range<Int>] {
+        segmentRanges(
             sampleCount: samples.count,
             maxSeconds: maxSeconds,
             sampleRate: sampleRate
@@ -144,10 +150,5 @@ enum AudioSegmenter {
             for i in range { sum += samples[i] * samples[i] }
             return sum / Float(range.count)
         }
-
-        if ranges.count <= 1 {
-            return samples.isEmpty ? [] : [samples]
-        }
-        return ranges.map { Array(samples[$0]) }
     }
 }

--- a/Sources/VocaMac/Services/AutoPauseMonitor.swift
+++ b/Sources/VocaMac/Services/AutoPauseMonitor.swift
@@ -153,6 +153,14 @@ final class AutoPauseMonitor: ObservableObject {
     private(set) var isRunning: Bool = false
 
     private var timer: Timer?
+    private struct Configuration: Equatable {
+        let enabled: Bool
+        let apps: [AutoPauseAppEntry]
+        let interval: TimeInterval
+    }
+    private var lastConfiguration: Configuration?
+    private var configurationObserver: NSObjectProtocol?
+    var isPolling: Bool { timer != nil }
     private var lastPollInterval: TimeInterval = defaultPollIntervalSeconds
 
     init(
@@ -171,19 +179,28 @@ final class AutoPauseMonitor: ObservableObject {
 
     deinit {
         timer?.invalidate()
+        if let configurationObserver { NotificationCenter.default.removeObserver(configurationObserver) }
     }
 
     /// Start periodic polling. Safe to call if already started.
     func start() {
         guard !isRunning else { return }
         isRunning = true
-        scheduleTimer(immediate: true)
+        configurationObserver = NotificationCenter.default.addObserver(
+            forName: UserDefaults.didChangeNotification, object: nil, queue: .main
+        ) { [weak self] _ in
+            Task { @MainActor in self?.configurationDidChange() }
+        }
+        configurationDidChange()
         VocaLogger.info(.general, "Auto-pause monitor started")
     }
 
     /// Stop polling.
     func stop() {
         isRunning = false
+        lastConfiguration = nil
+        if let configurationObserver { NotificationCenter.default.removeObserver(configurationObserver) }
+        configurationObserver = nil
         timer?.invalidate()
         timer = nil
         VocaLogger.info(.general, "Auto-pause monitor stopped")
@@ -193,7 +210,7 @@ final class AutoPauseMonitor: ObservableObject {
     @discardableResult
     func checkOnce() -> Bool {
         let (enabled, apps, _) = readConfig()
-        guard enabled else {
+        guard enabled, !apps.isEmpty else {
             activeTrigger = nil
             clearPauseIfNeeded()
             return false
@@ -224,6 +241,25 @@ final class AutoPauseMonitor: ObservableObject {
         min(maxPollIntervalSeconds, max(minPollIntervalSeconds, seconds))
     }
 
+    /// Re-arm only when enabled and configured; preference notifications wake a stopped monitor.
+    func configurationDidChange() {
+        guard isRunning else { return }
+        let (enabled, apps, interval) = readConfig()
+        let configuration = Configuration(enabled: enabled, apps: apps, interval: interval)
+        guard configuration != lastConfiguration else { return }
+        lastConfiguration = configuration
+        guard enabled, !apps.isEmpty else {
+            timer?.invalidate()
+            timer = nil
+            clearPauseIfNeeded()
+            return
+        }
+        if timer == nil || interval != lastPollInterval {
+            scheduleTimer(immediate: false)
+        }
+        checkOnce()
+    }
+
     private func scheduleTimer(immediate: Bool) {
         timer?.invalidate()
         let (_, _, interval) = readConfig()
@@ -238,6 +274,7 @@ final class AutoPauseMonitor: ObservableObject {
                 self?.pollFromTimer()
             }
         }
+        timer.tolerance = min(1, interval * 0.2)
         // Allow firing while UI tracking runs (settings window scroll, etc.).
         RunLoop.main.add(timer, forMode: .common)
         self.timer = timer

--- a/Sources/VocaMac/Services/CursorOverlayManager.swift
+++ b/Sources/VocaMac/Services/CursorOverlayManager.swift
@@ -115,6 +115,9 @@ final class CursorOverlayManager {
 
     /// Timer to follow the caret or active display when needed.
     private var repositionTimer: Timer?
+    private let positionQueue = DispatchQueue(label: "com.vocamac.caret", qos: .userInitiated)
+    private var isPositionQueryRunning = false
+    private var positionGeneration = UUID()
 
     /// Timer for the recording duration shown by the live panel.
     private var elapsedTimer: Timer?
@@ -128,6 +131,7 @@ final class CursorOverlayManager {
             return
         }
 
+        positionGeneration = UUID()
         viewModel.style = style
         viewModel.position = position
         // Capture has not begun yet — `transitionToRecording()` says when it has.
@@ -198,6 +202,7 @@ final class CursorOverlayManager {
 
     /// Hides the recording overlay and resets its transient state.
     func hide() {
+        positionGeneration = UUID()
         repositionTimer?.invalidate()
         repositionTimer = nil
         elapsedTimer?.invalidate()
@@ -217,6 +222,7 @@ final class CursorOverlayManager {
 
     /// Updates the current audio level used to animate the waveform.
     func updateAudioLevel(_ level: Float) {
+        guard overlayPanel != nil, viewModel.phase == .recording else { return }
         // Mild pre-gain so quiet speech still drives a lively waveform.
         let target = min(max(level * 2.6, 0), 1)
         let smoothing: Float = target > viewModel.audioLevel ? 0.78 : 0.28
@@ -240,10 +246,10 @@ final class CursorOverlayManager {
     private func positionPanel(_ panel: NSPanel, size: CGSize) {
         switch viewModel.position {
         case .nearCursor:
-            panel.setFrameOrigin(detectIndicatorPosition(panelSize: size))
+            requestCaretPosition(panel, size: size)
         case .top, .bottom:
             guard let screen = activeScreen else {
-                panel.setFrameOrigin(detectIndicatorPosition(panelSize: size))
+                requestCaretPosition(panel, size: size)
                 return
             }
 
@@ -287,124 +293,38 @@ final class CursorOverlayManager {
         }
     }
 
-    // MARK: - Caret Position Detection
-
-    private func detectIndicatorPosition(panelSize: CGSize) -> NSPoint {
-        let systemWide = AXUIElementCreateSystemWide()
-
-        var focusedApp: AnyObject?
-        guard AXUIElementCopyAttributeValue(systemWide, kAXFocusedApplicationAttribute as CFString, &focusedApp) == .success else {
-            return clamped(mousePosition(), panelSize: panelSize)
+    /// At most one query runs at once. Hide/show and focus changes invalidate its result.
+    private func requestCaretPosition(_ panel: NSPanel, size: CGSize) {
+        guard !isPositionQueryRunning else { return }
+        let frames = NSScreen.screens.map(\.visibleFrame)
+        let top = NSScreen.screens.first?.frame.maxY ?? 0
+        let mouse = NSEvent.mouseLocation
+        let fallback = CGPoint(x: mouse.x + 16, y: mouse.y - 40)
+        if !panel.isVisible {
+            panel.setFrameOrigin(OverlayPlacement.clampedOrigin(fallback, panelSize: size, visibleFrames: frames))
         }
-        let app = focusedApp as! AXUIElement
-
-        var focusedElement: AnyObject?
-        if AXUIElementCopyAttributeValue(app, kAXFocusedUIElementAttribute as CFString, &focusedElement) == .success,
-           focusedElement != nil {
-            let element = focusedElement as! AXUIElement
-
-            if let caretRect = getCaretRectFromElement(element) {
-                VocaLogger.debug(.cursorOverlay, "Positioned via caret")
-                return OverlayPlacement.origin(
-                    near: caretRect,
-                    panelSize: panelSize,
-                    visibleFrames: visibleScreenFrames
-                )
-            }
-
-            if let elementRect = convertAXRectToAppKit(getElementRect(element)) {
-                VocaLogger.debug(.cursorOverlay, "Positioned via focused element")
-                return OverlayPlacement.origin(
-                    near: elementRect,
-                    panelSize: panelSize,
-                    visibleFrames: visibleScreenFrames
-                )
-            }
-        }
-
-        if let windowRect = convertAXRectToAppKit(getFocusedWindowRect(app)) {
-            VocaLogger.debug(.cursorOverlay, "Positioned via focused window")
-            return clamped(
-                NSPoint(x: windowRect.maxX - panelSize.width - 20, y: windowRect.maxY - panelSize.height - 20),
-                panelSize: panelSize
+        guard let pid = NSWorkspace.shared.frontmostApplication?.processIdentifier else { return }
+        let generation = positionGeneration
+        isPositionQueryRunning = true
+        positionQueue.async { [weak self] in
+            let interval = PerformanceTrace.begin("CaretAccessibilityQuery")
+            let origin = CaretPositionQuery.position(
+                panelSize: size, visibleScreenFrames: frames,
+                primaryScreenTop: top, mouse: fallback, applicationPID: pid
             )
+            PerformanceTrace.end(interval)
+            Task { @MainActor [weak self] in
+                guard let self else { return }
+                self.isPositionQueryRunning = false
+                guard self.positionGeneration == generation,
+                      self.overlayPanel === panel,
+                      self.viewModel.position == .nearCursor,
+                      NSWorkspace.shared.frontmostApplication?.processIdentifier == pid else { return }
+                if panel.frame.origin != origin { panel.setFrameOrigin(origin) }
+            }
         }
-
-        VocaLogger.debug(.cursorOverlay, "Positioned via mouse cursor (fallback)")
-        return clamped(mousePosition(), panelSize: panelSize)
     }
 
-    private func getCaretRectFromElement(_ element: AXUIElement) -> CGRect? {
-        var selectedRange: AnyObject?
-        let rangeResult = AXUIElementCopyAttributeValue(element, kAXSelectedTextRangeAttribute as CFString, &selectedRange)
-        guard rangeResult == .success, let range = selectedRange else { return nil }
-
-        var bounds: AnyObject?
-        guard AXUIElementCopyParameterizedAttributeValue(element, kAXBoundsForRangeParameterizedAttribute as CFString, range, &bounds) == .success else { return nil }
-
-        var rect = CGRect.zero
-        guard AXValueGetValue(bounds as! AXValue, .cgRect, &rect) else { return nil }
-
-        return convertAXRectToAppKit(rect)
-    }
-
-    private func getElementRect(_ element: AXUIElement) -> CGRect? {
-        var positionValue: AnyObject?
-        guard AXUIElementCopyAttributeValue(element, kAXPositionAttribute as CFString, &positionValue) == .success else { return nil }
-
-        var sizeValue: AnyObject?
-        guard AXUIElementCopyAttributeValue(element, kAXSizeAttribute as CFString, &sizeValue) == .success else { return nil }
-
-        var position = CGPoint.zero
-        var size = CGSize.zero
-        guard AXValueGetValue(positionValue as! AXValue, .cgPoint, &position),
-              AXValueGetValue(sizeValue as! AXValue, .cgSize, &size) else { return nil }
-
-        return CGRect(origin: position, size: size)
-    }
-
-    private func getFocusedWindowRect(_ app: AXUIElement) -> CGRect? {
-        var window: AnyObject?
-        var result = AXUIElementCopyAttributeValue(app, kAXFocusedWindowAttribute as CFString, &window)
-
-        if result != .success {
-            result = AXUIElementCopyAttributeValue(app, kAXMainWindowAttribute as CFString, &window)
-        }
-
-        guard result == .success, window != nil else { return nil }
-        return getElementRect(window as! AXUIElement)
-    }
-
-    // MARK: - Coordinate Helpers
-
-    private func convertAXRectToAppKit(_ rect: CGRect?) -> CGRect? {
-        guard let rect,
-              rect.origin.x.isFinite,
-              rect.origin.y.isFinite,
-              rect.width.isFinite,
-              rect.height.isFinite,
-              let primaryScreenTop = NSScreen.screens.first?.frame.maxY else { return nil }
-        var converted = rect
-        converted.origin.y = primaryScreenTop - rect.origin.y - rect.height
-        return converted
-    }
-
-    private func mousePosition() -> NSPoint {
-        let loc = NSEvent.mouseLocation
-        return NSPoint(x: loc.x + 16, y: loc.y - 40)
-    }
-
-    private func clamped(_ point: NSPoint, panelSize: CGSize) -> NSPoint {
-        OverlayPlacement.clampedOrigin(
-            point,
-            panelSize: panelSize,
-            visibleFrames: visibleScreenFrames
-        )
-    }
-
-    private var visibleScreenFrames: [CGRect] {
-        NSScreen.screens.map(\.visibleFrame)
-    }
 }
 
 // MARK: - IndicatorPhase
@@ -746,3 +666,108 @@ struct HandyOverlayView: View {
 // MARK: - CursorOverlayManaging Conformance
 
 extension CursorOverlayManager: CursorOverlayManaging {}
+
+/// Immutable desktop geometry keeps synchronous Accessibility IPC off the main actor.
+private enum CaretPositionQuery {
+    // MARK: - Caret Position Detection
+
+    static func position(panelSize: CGSize, visibleScreenFrames: [CGRect], primaryScreenTop: CGFloat, mouse: CGPoint, applicationPID: pid_t) -> NSPoint {
+        let systemWide = AXUIElementCreateApplication(applicationPID)
+        AXUIElementSetMessagingTimeout(systemWide, 0.1)
+
+        let app = systemWide
+
+        var focusedElement: AnyObject?
+        if AXUIElementCopyAttributeValue(app, kAXFocusedUIElementAttribute as CFString, &focusedElement) == .success,
+           focusedElement != nil {
+            let element = focusedElement as! AXUIElement
+            AXUIElementSetMessagingTimeout(element, 0.1)
+
+            if let caretRect = getCaretRectFromElement(element, primaryScreenTop: primaryScreenTop) {
+                VocaLogger.debug(.cursorOverlay, "Positioned via caret")
+                return OverlayPlacement.origin(
+                    near: caretRect,
+                    panelSize: panelSize,
+                    visibleFrames: visibleScreenFrames
+                )
+            }
+
+            if let elementRect = convertAXRectToAppKit(getElementRect(element), primaryScreenTop: primaryScreenTop) {
+                VocaLogger.debug(.cursorOverlay, "Positioned via focused element")
+                return OverlayPlacement.origin(
+                    near: elementRect,
+                    panelSize: panelSize,
+                    visibleFrames: visibleScreenFrames
+                )
+            }
+        }
+
+        if let windowRect = convertAXRectToAppKit(getFocusedWindowRect(app), primaryScreenTop: primaryScreenTop) {
+            VocaLogger.debug(.cursorOverlay, "Positioned via focused window")
+            return OverlayPlacement.clampedOrigin(
+                NSPoint(x: windowRect.maxX - panelSize.width - 20, y: windowRect.maxY - panelSize.height - 20),
+                panelSize: panelSize, visibleFrames: visibleScreenFrames
+            )
+        }
+
+        VocaLogger.debug(.cursorOverlay, "Positioned via mouse cursor (fallback)")
+        return OverlayPlacement.clampedOrigin(mouse, panelSize: panelSize, visibleFrames: visibleScreenFrames)
+    }
+
+    private static func getCaretRectFromElement(_ element: AXUIElement, primaryScreenTop: CGFloat) -> CGRect? {
+        var selectedRange: AnyObject?
+        let rangeResult = AXUIElementCopyAttributeValue(element, kAXSelectedTextRangeAttribute as CFString, &selectedRange)
+        guard rangeResult == .success, let range = selectedRange else { return nil }
+
+        var bounds: AnyObject?
+        guard AXUIElementCopyParameterizedAttributeValue(element, kAXBoundsForRangeParameterizedAttribute as CFString, range, &bounds) == .success else { return nil }
+
+        var rect = CGRect.zero
+        guard AXValueGetValue(bounds as! AXValue, .cgRect, &rect) else { return nil }
+
+        return convertAXRectToAppKit(rect, primaryScreenTop: primaryScreenTop)
+    }
+
+    private static func getElementRect(_ element: AXUIElement) -> CGRect? {
+        var positionValue: AnyObject?
+        guard AXUIElementCopyAttributeValue(element, kAXPositionAttribute as CFString, &positionValue) == .success else { return nil }
+
+        var sizeValue: AnyObject?
+        guard AXUIElementCopyAttributeValue(element, kAXSizeAttribute as CFString, &sizeValue) == .success else { return nil }
+
+        var position = CGPoint.zero
+        var size = CGSize.zero
+        guard AXValueGetValue(positionValue as! AXValue, .cgPoint, &position),
+              AXValueGetValue(sizeValue as! AXValue, .cgSize, &size) else { return nil }
+
+        return CGRect(origin: position, size: size)
+    }
+
+    private static func getFocusedWindowRect(_ app: AXUIElement) -> CGRect? {
+        var window: AnyObject?
+        var result = AXUIElementCopyAttributeValue(app, kAXFocusedWindowAttribute as CFString, &window)
+
+        if result != .success {
+            result = AXUIElementCopyAttributeValue(app, kAXMainWindowAttribute as CFString, &window)
+        }
+
+        guard result == .success, window != nil else { return nil }
+        let element = window as! AXUIElement
+        AXUIElementSetMessagingTimeout(element, 0.1)
+        return getElementRect(element)
+    }
+
+    // MARK: - Coordinate Helpers
+
+    private static func convertAXRectToAppKit(_ rect: CGRect?, primaryScreenTop: CGFloat) -> CGRect? {
+        guard let rect,
+              rect.origin.x.isFinite,
+              rect.origin.y.isFinite,
+              rect.width.isFinite,
+              rect.height.isFinite else { return nil }
+        var converted = rect
+        converted.origin.y = primaryScreenTop - rect.origin.y - rect.height
+        return converted
+    }
+
+}

--- a/Sources/VocaMac/Services/LoadSerializer.swift
+++ b/Sources/VocaMac/Services/LoadSerializer.swift
@@ -27,9 +27,11 @@ actor LoadSerializer {
         _ operation: @escaping @Sendable () async throws -> T
     ) async throws -> T {
         let previous = tail
+        let queueInterval = PerformanceTrace.begin("OperationQueueWait")
 
         let task = Task<Result<T, Error>, Never> {
             await previous?.value
+            PerformanceTrace.end(queueInterval)
             do {
                 if cancellable { try Task.checkCancellation() }
                 let value = try await operation()

--- a/Sources/VocaMac/Services/RecordingTranscription.swift
+++ b/Sources/VocaMac/Services/RecordingTranscription.swift
@@ -1,0 +1,102 @@
+import Foundation
+import os
+
+/// A bounded, nonblocking bridge from the microphone to an engine session.
+/// Overflow or a capture restart invalidates streaming; AppState retains the
+/// complete recording and retries through the normal batch path.
+final class RecordingTranscription: @unchecked Sendable {
+    enum StreamError: Error { case discontinuity, overflow, incomplete }
+
+    let language: String?
+    private struct State {
+        var sampleCount = 0
+        var ended = false
+    }
+    private let state = OSAllocatedUnfairLock(initialState: State())
+    private let continuation: AsyncThrowingStream<[Float], Error>.Continuation
+    private let task: Task<VocaTranscription, Error>
+
+    init(
+        language: String?,
+        bufferLimit: Int = 32,
+        transcribe: @escaping @Sendable (AsyncThrowingStream<[Float], Error>) async throws -> VocaTranscription
+    ) {
+        self.language = language
+        let (stream, continuation) = AsyncThrowingStream<[Float], Error>.makeStream(
+            bufferingPolicy: .bufferingOldest(max(1, bufferLimit))
+        )
+        self.continuation = continuation
+        task = Task(priority: .userInitiated) { try await transcribe(stream) }
+    }
+
+    func append(_ samples: [Float], at offset: Int) {
+        guard !samples.isEmpty else { return }
+        state.withLock { state in
+            guard !state.ended else { return }
+            guard offset == state.sampleCount else {
+                state.ended = true
+                continuation.finish(throwing: StreamError.discontinuity)
+                return
+            }
+            state.sampleCount += samples.count
+            if case .dropped = continuation.yield(samples) {
+                state.ended = true
+                continuation.finish(throwing: StreamError.overflow)
+            }
+        }
+    }
+
+    func finish(expectedSampleCount: Int) async throws -> VocaTranscription {
+        let interval = PerformanceTrace.begin("StreamingFinalize")
+        defer { PerformanceTrace.end(interval) }
+        let complete = state.withLock { state in
+            let complete = state.sampleCount == expectedSampleCount && !state.ended
+            state.ended = true
+            return complete
+        }
+        guard complete else {
+            cancel()
+            _ = try? await task.value
+            throw StreamError.incomplete
+        }
+        let start = ProcessInfo.processInfo.systemUptime
+        continuation.finish()
+        return try await withTaskCancellationHandler {
+            let result = try await task.value
+            try Task.checkCancellation()
+            guard result.audioLengthSeconds.isFinite,
+                  abs(result.audioLengthSeconds * 16_000 - Double(expectedSampleCount)) < 0.5 else {
+                throw StreamError.incomplete
+            }
+            // Match the batch UI's latency metric: time spent waiting after stop,
+            // not the user's speaking time overlapped by live inference.
+            return VocaTranscription(
+                text: result.text, duration: ProcessInfo.processInfo.systemUptime - start,
+                detectedLanguage: result.detectedLanguage,
+                audioLengthSeconds: result.audioLengthSeconds, modelUsed: result.modelUsed
+            )
+        } onCancel: { self.cancel() }
+    }
+
+    func cancel() {
+        state.withLock { $0.ended = true }
+        continuation.finish(throwing: CancellationError())
+        task.cancel()
+    }
+
+    deinit { continuation.finish(); task.cancel() }
+}
+
+/// Pull-based batch input avoids enqueuing another full recording in a stream.
+actor AudioChunkCursor {
+    private let samples: [Float]
+    private var offset = 0
+    init(_ samples: [Float]) { self.samples = samples }
+
+    func next() -> [Float]? {
+        guard offset < samples.count else { return nil }
+        let end = min(samples.count, offset + 16_000)
+        defer { offset = end }
+        return Array(samples[offset..<end])
+    }
+}

--- a/Sources/VocaMac/Services/ServiceProtocols.swift
+++ b/Sources/VocaMac/Services/ServiceProtocols.swift
@@ -12,6 +12,7 @@ import Combine
 protocol AudioRecording: AnyObject {
     var isCurrentlyRecording: Bool { get }
     var onAudioLevel: ((Float) -> Void)? { get set }
+    var onAudioSamples: (([Float], Int) -> Void)? { get set }
     var onSilenceDetected: (() -> Void)? { get set }
     var onMaxDurationReached: (() -> Void)? { get set }
     var onAudioDeviceChanged: (() -> Void)? { get set }
@@ -32,6 +33,13 @@ protocol AudioRecording: AnyObject {
     func forceReset()
     func checkPermissionStatus() -> PermissionStatus
     func requestPermission(completion: @escaping (Bool) -> Void)
+}
+
+extension AudioRecording {
+    var onAudioSamples: (([Float], Int) -> Void)? {
+        get { nil }
+        set { }
+    }
 }
 
 // MARK: - SoundPlaying
@@ -146,6 +154,7 @@ extension ModelManaging {
 protocol SpeechTranscribing: AnyObject {
     var loadedModelName: String? { get }
     var isModelLoaded: Bool { get }
+    func startStreaming(language: String?) -> RecordingTranscription?
     func transcribe(audioData: [Float], language: String?, translate: Bool, vocabulary: String) async throws -> VocaTranscription
     func _loadModel(name: String?, folder: URL?, onPhaseChange: ((String) -> Void)?) async throws
     /// Release the currently loaded model (and any sibling engines) to free memory.
@@ -153,6 +162,8 @@ protocol SpeechTranscribing: AnyObject {
 }
 
 extension SpeechTranscribing {
+    func startStreaming(language: String?) -> RecordingTranscription? { nil }
+
     func loadModel(name: String? = nil, folder: URL? = nil, onPhaseChange: ((String) -> Void)? = nil) async throws {
         try await _loadModel(name: name, folder: folder, onPhaseChange: onPhaseChange)
     }
@@ -161,7 +172,15 @@ extension SpeechTranscribing {
 // MARK: - TextInjecting
 
 protocol TextInjecting: AnyObject {
+    var onFailure: ((String) -> Void)? { get set }
     func inject(text: String, preserveClipboard: Bool)
+}
+
+extension TextInjecting {
+    var onFailure: ((String) -> Void)? {
+        get { nil }
+        set { }
+    }
 }
 
 // MARK: - StatsManaging

--- a/Sources/VocaMac/Services/SherpaAudioPreparation.swift
+++ b/Sources/VocaMac/Services/SherpaAudioPreparation.swift
@@ -58,21 +58,22 @@ enum SherpaAudioPreparation {
         lead: Int = edgeSilenceSampleCount,
         tail: Int = edgeSilenceSampleCount
     ) -> [Float] {
-        // Do not ask generative decoders to invent words for digital silence.
-        guard samples.contains(where: { $0 != 0 }) else { return [] }
+        var result: [Float] = []
+        prepare(samples, lead: lead, tail: tail, into: &result)
+        return result
+    }
 
+    /// Reuse scratch storage across recovery attempts without changing their framing.
+    static func prepare(
+        _ samples: [Float], lead: Int = edgeSilenceSampleCount,
+        tail: Int = edgeSilenceSampleCount, into prepared: inout [Float]
+    ) {
+        prepared.removeAll(keepingCapacity: true)
+        guard samples.contains(where: { $0 != 0 }) else { return }
         let paddedCount = samples.count + lead + tail
-        var prepared: [Float] = []
         prepared.reserveCapacity(max(minimumSampleCount, paddedCount))
         prepared.append(contentsOf: repeatElement(Float.zero, count: lead))
         prepared.append(contentsOf: samples)
-        prepared.append(contentsOf: repeatElement(Float.zero, count: tail))
-
-        if prepared.count < minimumSampleCount {
-            prepared.append(
-                contentsOf: repeatElement(Float.zero, count: minimumSampleCount - prepared.count)
-            )
-        }
-        return prepared
+        prepared.append(contentsOf: repeatElement(Float.zero, count: max(tail, minimumSampleCount - samples.count - lead)))
     }
 }

--- a/Sources/VocaMac/Services/SherpaService.swift
+++ b/Sources/VocaMac/Services/SherpaService.swift
@@ -284,22 +284,22 @@ final class SherpaService: @unchecked Sendable {
         // the same limit, so the speech budget is what is left after it.
         let segmentLimit = SherpaModelCatalog.spec(for: size)?.maxSegmentSeconds
         let maxSeconds = segmentLimit.map { $0 - SherpaAudioPreparation.addedSilenceSeconds }
-        let segments: [[Float]]
+        let segments: [Range<Int>]
         if let maxSeconds, audioLengthSeconds > maxSeconds {
-            segments = AudioSegmenter.segment(audioData, maxSeconds: maxSeconds)
+            segments = AudioSegmenter.ranges(for: audioData, maxSeconds: maxSeconds)
             VocaLogger.info(
                 .sherpaService,
                 "Audio exceeds \(String(format: "%.1f", maxSeconds))s for \(size.rawValue) — split into \(segments.count) segments"
             )
         } else {
-            segments = [audioData]
+            segments = [audioData.indices]
         }
 
         // Detached work stays off the UI executor while retaining Swift task
         // cancellation. Native inference is synchronous: finish the current
         // segment safely, then discard its result and stop before the next one.
         let worker = Task.detached(priority: .userInitiated) {
-            try Self.decodeRequest(segments: segments, language: language, request: request)
+            try Self.decodeRequest(audioData: audioData, segments: segments, language: language, request: request)
         }
         let decoded = try await withTaskCancellationHandler {
             let result = try await worker.value
@@ -351,22 +351,22 @@ final class SherpaService: @unchecked Sendable {
 
     /// Serialize native decoding for a retained model without holding the state lock.
     private static func decodeRequest(
-        segments: [[Float]], language: String?, request: LoadedRecognizer
+        audioData: [Float], segments: [Range<Int>], language: String?, request: LoadedRecognizer
     ) throws -> (text: String, lang: String) {
         try Task.checkCancellation()
         request.decodeLock.lock()
         defer { request.decodeLock.unlock() }
-        return try decodeSegments(segments, language: language) { samples in
+        return try decodeSegments(segments.lazy.map { Array(audioData[$0]) }, language: language) { samples in
             try decode(samples: samples, recognizer: request.pointer)
         }
     }
 
     /// Application-level segment processing, shared by native decoding and regressions.
-    static func decodeSegments(
-        _ segments: [[Float]],
+    static func decodeSegments<Segments: Sequence>(
+        _ segments: Segments,
         language: String?,
         decodeSegment: ([Float]) throws -> (text: String, lang: String)
-    ) throws -> (text: String, lang: String) {
+    ) throws -> (text: String, lang: String) where Segments.Element == [Float] {
         try Task.checkCancellation()
         var pieces: [String] = []
         var detected = ""
@@ -397,19 +397,28 @@ final class SherpaService: @unchecked Sendable {
         _ segment: [Float],
         with decodeSegment: ([Float]) throws -> (text: String, lang: String)
     ) throws -> (text: String, lang: String)? {
-        let samples = SherpaAudioPreparation.prepare(segment)
+        var samples = SherpaAudioPreparation.prepare(segment)
         guard !samples.isEmpty else { return nil }
 
-        let first = try decodeSegment(samples)
+        let firstInterval = PerformanceTrace.begin("ONNXFirstAttempt")
+        let first: (text: String, lang: String)
+        do {
+            defer { PerformanceTrace.end(firstInterval) }
+            first = try decodeSegment(samples)
+        }
         guard first.text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
             return first
         }
 
         for layout in SherpaAudioPreparation.recoveryLayouts {
             try Task.checkCancellation()
-            let retry = try decodeSegment(
-                SherpaAudioPreparation.prepare(segment, lead: layout.lead, tail: layout.tail)
-            )
+            let retryInterval = PerformanceTrace.begin("ONNXRecoveryAttempt")
+            let retry: (text: String, lang: String)
+            do {
+                defer { PerformanceTrace.end(retryInterval) }
+                SherpaAudioPreparation.prepare(segment, lead: layout.lead, tail: layout.tail, into: &samples)
+                retry = try decodeSegment(samples)
+            }
             if !retry.text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
                 VocaLogger.info(
                     .sherpaService,

--- a/Sources/VocaMac/Services/TextInjector.swift
+++ b/Sources/VocaMac/Services/TextInjector.swift
@@ -45,12 +45,7 @@ final class TextInjector {
     private struct ClipboardInjectionRequest {
         let text: String
         let preserveClipboard: Bool
-    }
-
-    /// Clipboard state used to restore the correct contents after a paste.
-    private struct ClipboardPasteState {
-        let snapshot: PasteboardSnapshot?
-        let expectedChangeCount: Int
+        let targetPID: pid_t?
     }
 
     /// A process-wide serial queue for the system pasteboard. TextInjector is
@@ -91,6 +86,9 @@ final class TextInjector {
     private let accessibilityTrustedOverride: Bool?
     private let accessibilityInjectionOverride: ((String) -> Bool)?
     private let pasteActionOverride: (() -> Void)?
+    private let accessibilityWorkerOverride: (@Sendable (String) -> Bool)?
+    private let frontmostPIDProvider: () -> pid_t?
+    var onFailure: ((String) -> Void)?
 
     /// Clipboard fallback injections must run one at a time. Otherwise a
     /// delayed restore from one injection can replace the transcription from
@@ -108,12 +106,16 @@ final class TextInjector {
         pasteboard: NSPasteboard = .general,
         accessibilityTrustedOverride: Bool? = nil,
         accessibilityInjectionOverride: ((String) -> Bool)? = nil,
-        pasteActionOverride: (() -> Void)? = nil
+        pasteActionOverride: (() -> Void)? = nil,
+        accessibilityWorkerOverride: (@Sendable (String) -> Bool)? = nil,
+        frontmostPIDProvider: @escaping () -> pid_t? = { NSWorkspace.shared.frontmostApplication?.processIdentifier }
     ) {
         self.pasteboard = pasteboard
         self.accessibilityTrustedOverride = accessibilityTrustedOverride
         self.accessibilityInjectionOverride = accessibilityInjectionOverride
         self.pasteActionOverride = pasteActionOverride
+        self.accessibilityWorkerOverride = accessibilityWorkerOverride
+        self.frontmostPIDProvider = frontmostPIDProvider
     }
 
     // MARK: - Public API
@@ -135,30 +137,64 @@ final class TextInjector {
     func inject(text: String, preserveClipboard: Bool = true) {
         guard !text.isEmpty else { return }
 
-        // Check accessibility permission
-        let trusted = accessibilityTrustedOverride ?? AXIsProcessTrusted()
-        VocaLogger.debug(.textInjector, "AXIsProcessTrusted = \(trusted ? "YES" : "NO")")
+        let enqueue = { [self] in
+            let targetPID = frontmostPIDProvider()
+            let interval = PerformanceTrace.begin("TextDeliveryQueueAndDispatch")
+            Self.clipboardInjectionCoordinator.enqueue { [self] finish in
+                let complete = {
+                    PerformanceTrace.end(interval)
+                    finish()
+                }
+                performInjection(text: text, preserveClipboard: preserveClipboard,
+                                 targetPID: targetPID, completion: complete)
+            }
+        }
+        if Thread.isMainThread { enqueue() }
+        else { DispatchQueue.main.async(execute: enqueue) }
+    }
 
-        if !trusted {
-            VocaLogger.warning(.textInjector, "No accessibility permission. Copying to clipboard only.")
+    private enum AccessibilityInsertion { case inserted, unavailable, uncertain }
+
+    private static let accessibilityQueue = DispatchQueue(label: "com.vocamac.text-accessibility", qos: .userInitiated)
+
+    /// Clipboard operations remain on main; only cross-process AX work runs on the worker.
+    private func performInjection(text: String, preserveClipboard: Bool, targetPID: pid_t?, completion: @escaping () -> Void) {
+        let trusted = accessibilityTrustedOverride ?? AXIsProcessTrusted()
+        guard trusted else {
             pasteboard.clearContents()
             pasteboard.setString(text, forType: .string)
+            completion()
             return
         }
-
-        // Strategy 1: Accessibility API direct insertion.
-        // Works with Raycast, Spotlight, and any app whose focused text field
-        // is writable via the AX API. Preferred because it does not touch the
-        // clipboard and does not require dispatching a keyboard shortcut.
-        let injectedViaAccessibility = accessibilityInjectionOverride?(text) ?? injectViaAccessibility(text: text)
-        if injectedViaAccessibility {
-            VocaLogger.info(.textInjector, "Text injected via Accessibility API")
+        let deliverFallback = { [self] (result: AccessibilityInsertion) in
+            if result == .inserted {
+                PerformanceTrace.event("AccessibilityTextInserted")
+                completion()
+            } else if result == .uncertain {
+                onFailure?("The target app did not confirm text insertion. Check the field before retrying; your transcript is available in VocaMac.")
+                completion()
+            } else if targetPID == frontmostPIDProvider() {
+                processClipboardInjection(
+                    ClipboardInjectionRequest(text: text, preserveClipboard: preserveClipboard, targetPID: targetPID),
+                    completion: completion
+                )
+            } else {
+                // Focus changed while another process was responding. Do not paste into a different app.
+                reportFocusChange()
+                completion()
+            }
+        }
+        if let accessibilityInjectionOverride {
+            deliverFallback(accessibilityInjectionOverride(text) ? .inserted : .unavailable)
             return
         }
-
-        // Strategy 2: Clipboard + Cmd+V (legacy fallback).
-        VocaLogger.info(.textInjector, "AX injection unavailable — falling back to clipboard + Cmd+V")
-        injectViaClipboard(text: text, preserveClipboard: preserveClipboard)
+        Self.accessibilityQueue.async { [self] in
+            let interval = PerformanceTrace.begin("TextAccessibilityQueryAndWrite")
+            let inserted = accessibilityWorkerOverride.map { $0(text) ? AccessibilityInsertion.inserted : .unavailable }
+                ?? injectViaAccessibility(text: text, targetPID: targetPID)
+            PerformanceTrace.end(interval)
+            DispatchQueue.main.async { deliverFallback(inserted) }
+        }
     }
 
     // MARK: - Strategy 1: Accessibility API
@@ -184,8 +220,9 @@ final class TextInjector {
     ///            `false` if the focused element is unreachable, has an
     ///            unsupported role, or the write was rejected.
     @discardableResult
-    private func injectViaAccessibility(text: String) -> Bool {
+    private func injectViaAccessibility(text: String, targetPID: pid_t?) -> AccessibilityInsertion {
         let systemWide = AXUIElementCreateSystemWide()
+        AXUIElementSetMessagingTimeout(systemWide, 0.1)
         var focusedRef: CFTypeRef?
 
         let fetchResult = AXUIElementCopyAttributeValue(
@@ -195,17 +232,21 @@ final class TextInjector {
         )
         guard fetchResult == .success, let focusedRef else {
             VocaLogger.debug(.textInjector, "AX: no focused element (\(fetchResult.rawValue))")
-            return false
+            return .unavailable
         }
 
         // The returned CFTypeRef must be an AXUIElement.
         guard CFGetTypeID(focusedRef) == AXUIElementGetTypeID() else {
             VocaLogger.debug(.textInjector, "AX: focused element is not an AXUIElement")
-            return false
+            return .unavailable
         }
 
         // swiftlint:disable force_cast
         let element = focusedRef as! AXUIElement
+        var elementPID: pid_t = 0
+        guard AXUIElementGetPid(element, &elementPID) == .success,
+              elementPID == targetPID else { return .unavailable }
+        AXUIElementSetMessagingTimeout(element, 0.1)
         // swiftlint:enable force_cast
 
         // Gate on element role. Only single-line input fields reliably handle
@@ -218,9 +259,11 @@ final class TextInjector {
         let supportedRoles: Set<String> = ["AXTextField", "AXSearchField", "AXComboBox"]
         guard supportedRoles.contains(role) else {
             VocaLogger.debug(.textInjector, "AX: skipping role '\(role)' — not a single-line input field")
-            return false
+            return .unavailable
         }
 
+        // A timed-out write may still be applied by the target. It must never
+        // trigger an automatic second insertion via Cmd+V.
         let setResult = AXUIElementSetAttributeValue(
             element,
             kAXSelectedTextAttribute as CFString,
@@ -229,36 +272,14 @@ final class TextInjector {
 
         if setResult == .success {
             VocaLogger.debug(.textInjector, "AX: inserted \(text.count) chars via kAXSelectedTextAttribute (role: \(role))")
-            return true
+            return .inserted
         }
 
         VocaLogger.debug(.textInjector, "AX: kAXSelectedTextAttribute write failed (\(setResult.rawValue)) — element may be read-only")
-        return false
+        return setResult == .cannotComplete ? .uncertain : .unavailable
     }
 
     // MARK: - Strategy 2: Clipboard + Cmd+V
-
-    /// Inject text via the system clipboard followed by a simulated Cmd+V.
-    /// This is the original injection strategy and acts as a fallback for
-    /// apps whose focused element is not writable via the Accessibility API.
-    private func injectViaClipboard(text: String, preserveClipboard: Bool) {
-        let request = ClipboardInjectionRequest(text: text, preserveClipboard: preserveClipboard)
-
-        // NSPasteboard and the queue state are handled on the main queue. The
-        // public API is normally called from AppState's main actor, but this
-        // keeps the fallback safe if another caller invokes it elsewhere.
-        let enqueue = { [weak self] () -> Void in
-            guard let self else { return }
-            Self.clipboardInjectionCoordinator.enqueue { [self] finish in
-                self.processClipboardInjection(request, completion: finish)
-            }
-        }
-        if Thread.isMainThread {
-            enqueue()
-        } else {
-            DispatchQueue.main.async(execute: enqueue)
-        }
-    }
 
     /// Process one clipboard injection. The coordinator starts the next
     /// operation only after `completion` is called.
@@ -266,94 +287,59 @@ final class TextInjector {
         _ request: ClipboardInjectionRequest,
         completion: @escaping () -> Void
     ) {
-        let interval = PerformanceTrace.begin("TextInjectionToPaste")
-        let pasteboard = self.pasteboard
-
-        // Deep-copy current clipboard state before we overwrite it.
-        // NSPasteboardItem objects are invalidated when the pasteboard is cleared,
-        // so we must extract the raw data eagerly.
-        let snapshot = request.preserveClipboard ? captureSnapshot(pasteboard) : nil
-
-        guard writeTranscribedText(request.text, to: pasteboard) else {
-            PerformanceTrace.end(interval)
-            completion()
-            return
-        }
-
-        // Record the changeCount right after we write the transcribed text.
-        // We check this before restoring so we don't clobber a newer clipboard
-        // entry if the user (or another app) copies something in the meantime.
-        let changeCountAfterWrite = pasteboard.changeCount
-
-        // Delay to let clipboard settle, then simulate Cmd+V
-        DispatchQueue.main.asyncAfter(deadline: .now() + prePasteDelay) { [self] in
-            // A clipboard manager, another VocaMac injection, or the user may
-            // have changed the pasteboard during the delay. Reassert the
-            // transcription immediately before posting Cmd+V so the event
-            // cannot consume stale clipboard contents.
-            let pasteState = prepareClipboardForPaste(
-                request: request,
-                originalSnapshot: snapshot,
-                changeCountAfterWrite: changeCountAfterWrite,
-                pasteboard: pasteboard
-            )
-
-            VocaLogger.debug(.textInjector, "Simulating Cmd+V...")
-            simulatePaste()
-            PerformanceTrace.end(interval)
-
-            // Always wait before starting the next queued injection, even
-            // when preservation is disabled. Otherwise the next request could
-            // overwrite the pasteboard before this paste event is consumed.
-            DispatchQueue.main.asyncAfter(deadline: .now() + clipboardRestoreDelay) { [self] in
-                if request.preserveClipboard {
-                    // Guard: only restore if the pasteboard hasn't been modified
-                    // by the user or another app since the transcription was
-                    // reasserted for this paste event.
-                    guard pasteboard.changeCount == pasteState.expectedChangeCount else {
-                        VocaLogger.debug(.textInjector, "Clipboard was modified externally — skipping restore")
-                        completion()
-                        return
-                    }
-
-                    if let snapshot = pasteState.snapshot {
-                        restoreSnapshot(snapshot, to: pasteboard)
-                    } else {
-                        // Previous clipboard was empty; clear the transcribed text
-                        pasteboard.clearContents()
-                    }
-                    VocaLogger.debug(.textInjector, "Clipboard restored")
+        Task { @MainActor [self] in
+            let interval = PerformanceTrace.begin("TextInjectionToPaste")
+            defer { PerformanceTrace.end(interval); completion() }
+            do {
+                guard request.targetPID == frontmostPIDProvider() else { reportFocusChange(); return }
+                var snapshot = request.preserveClipboard ? try await captureStableSnapshot(pasteboard) : nil
+                guard writeTranscribedText(request.text, to: pasteboard) else { return }
+                var expectedChangeCount = pasteboard.changeCount
+                try await Task.sleep(nanoseconds: UInt64(prePasteDelay * 1_000_000_000))
+                if pasteboard.changeCount != expectedChangeCount {
+                    snapshot = request.preserveClipboard ? try await captureStableSnapshot(pasteboard) : nil
+                    guard writeTranscribedText(request.text, to: pasteboard) else { return }
+                    expectedChangeCount = pasteboard.changeCount
                 }
-
-                completion()
+                guard request.targetPID == frontmostPIDProvider() else {
+                    if request.preserveClipboard, pasteboard.changeCount == expectedChangeCount {
+                        if let snapshot { restoreSnapshot(snapshot, to: pasteboard) }
+                        else { pasteboard.clearContents() }
+                    }
+                    reportFocusChange()
+                    return
+                }
+                simulatePaste()
+                PerformanceTrace.event("PasteEventPosted")
+                // Keep the clipboard stable until the target has consumed the event.
+                try await Task.sleep(nanoseconds: UInt64(clipboardRestoreDelay * 1_000_000_000))
+                if request.preserveClipboard, pasteboard.changeCount == expectedChangeCount {
+                    if let snapshot { restoreSnapshot(snapshot, to: pasteboard) }
+                    else { pasteboard.clearContents() }
+                }
+            } catch {
+                VocaLogger.warning(.textInjector, "Clipboard changed repeatedly while being preserved; insertion abandoned")
+                onFailure?("The clipboard kept changing, so text was not pasted. Your transcript is available in VocaMac.")
             }
         }
     }
 
-    /// Ensure the transcription is still the current pasteboard contents just
-    /// before Cmd+V is posted. If an external change occurred, preserve that
-    /// newer clipboard state instead of restoring an older snapshot over it.
-    private func prepareClipboardForPaste(
-        request: ClipboardInjectionRequest,
-        originalSnapshot: PasteboardSnapshot?,
-        changeCountAfterWrite: Int,
-        pasteboard: NSPasteboard
-    ) -> ClipboardPasteState {
-        guard pasteboard.changeCount != changeCountAfterWrite else {
-            return ClipboardPasteState(
-                snapshot: originalSnapshot,
-                expectedChangeCount: changeCountAfterWrite
-            )
+    private func reportFocusChange() {
+        VocaLogger.warning(.textInjector, "Focus changed during text insertion; paste cancelled")
+        onFailure?("The active app changed before text could be pasted. Your transcript is available in VocaMac.")
+    }
+
+    private enum SnapshotError: Error { case changed }
+
+    /// A yield lets other apps or clipboard managers write. Never combine types
+    /// from different clipboard generations, or clear an entry we did not preserve.
+    @MainActor
+    private func captureStableSnapshot(_ pasteboard: NSPasteboard) async throws -> PasteboardSnapshot? {
+        for _ in 0..<3 {
+            do { return try await captureSnapshot(pasteboard) }
+            catch SnapshotError.changed { continue }
         }
-
-        VocaLogger.debug(.textInjector, "Clipboard changed before Cmd+V — reasserting transcription")
-        let snapshotToRestore = request.preserveClipboard ? captureSnapshot(pasteboard) : nil
-        _ = writeTranscribedText(request.text, to: pasteboard)
-
-        return ClipboardPasteState(
-            snapshot: snapshotToRestore,
-            expectedChangeCount: pasteboard.changeCount
-        )
+        throw SnapshotError.changed
     }
 
     /// Write one transcription to the pasteboard and report whether the text
@@ -371,18 +357,36 @@ final class TextInjector {
     /// Deep-copy every item and type from the pasteboard into plain `Data` values.
     /// This must be called *before* `clearContents()` because NSPasteboardItem
     /// objects are invalidated when the pasteboard changes.
-    private func captureSnapshot(_ pasteboard: NSPasteboard) -> PasteboardSnapshot? {
+    @MainActor
+    private func captureSnapshot(_ pasteboard: NSPasteboard) async throws -> PasteboardSnapshot? {
+        let interval = PerformanceTrace.begin("ClipboardSnapshot")
+        defer { PerformanceTrace.end(interval) }
+        var totalBytes = 0
+        defer { VocaLogger.debug(.textInjector, "Clipboard snapshot bytes: \(totalBytes)") }
         guard let pasteboardItems = pasteboard.pasteboardItems, !pasteboardItems.isEmpty else {
             return nil
         }
 
+        let generation = pasteboard.changeCount
         var itemSnapshots: [PasteboardItemSnapshot] = []
+        var sliceStart = ProcessInfo.processInfo.systemUptime
+        var representations = 0
 
         for item in pasteboardItems {
             var dataByType: [(NSPasteboard.PasteboardType, Data)] = []
             for type in item.types {
+                guard pasteboard.changeCount == generation else { throw SnapshotError.changed }
                 if let data = item.data(forType: type) {
+                    totalBytes += data.count
                     dataByType.append((type, data))
+                }
+                representations += 1
+                if representations % 8 == 0 || ProcessInfo.processInfo.systemUptime - sliceStart >= 0.004 {
+                    await withCheckedContinuation { continuation in
+                        DispatchQueue.main.async { continuation.resume() }
+                    }
+                    guard pasteboard.changeCount == generation else { throw SnapshotError.changed }
+                    sliceStart = ProcessInfo.processInfo.systemUptime
                 }
             }
             if !dataByType.isEmpty {
@@ -390,6 +394,7 @@ final class TextInjector {
             }
         }
 
+        guard pasteboard.changeCount == generation else { throw SnapshotError.changed }
         guard !itemSnapshots.isEmpty else { return nil }
         return PasteboardSnapshot(items: itemSnapshots)
     }

--- a/Sources/VocaMac/Services/TextInjector.swift
+++ b/Sources/VocaMac/Services/TextInjector.swift
@@ -166,6 +166,12 @@ final class TextInjector {
             completion()
             return
         }
+        // No destination app: skip AX and never post Cmd+V into nowhere.
+        guard targetPID != nil else {
+            reportMissingPasteTarget()
+            completion()
+            return
+        }
         let deliverFallback = { [self] (result: AccessibilityInsertion) in
             if result == .inserted {
                 PerformanceTrace.event("AccessibilityTextInserted")
@@ -173,15 +179,18 @@ final class TextInjector {
             } else if result == .uncertain {
                 onFailure?("The target app did not confirm text insertion. Check the field before retrying; your transcript is available in VocaMac.")
                 completion()
-            } else if targetPID == frontmostPIDProvider() {
-                processClipboardInjection(
-                    ClipboardInjectionRequest(text: text, preserveClipboard: preserveClipboard, targetPID: targetPID),
-                    completion: completion
-                )
             } else {
-                // Focus changed while another process was responding. Do not paste into a different app.
-                reportFocusChange()
-                completion()
+                let currentPID = frontmostPIDProvider()
+                if samePasteTarget(targetPID, currentPID) {
+                    processClipboardInjection(
+                        ClipboardInjectionRequest(text: text, preserveClipboard: preserveClipboard, targetPID: targetPID),
+                        completion: completion
+                    )
+                } else {
+                    // Focus changed or the destination app disappeared. Do not paste.
+                    reportPasteTargetMismatch(queued: targetPID, current: currentPID)
+                    completion()
+                }
             }
         }
         if let accessibilityInjectionOverride {
@@ -291,7 +300,11 @@ final class TextInjector {
             let interval = PerformanceTrace.begin("TextInjectionToPaste")
             defer { PerformanceTrace.end(interval); completion() }
             do {
-                guard request.targetPID == frontmostPIDProvider() else { reportFocusChange(); return }
+                let currentPID = frontmostPIDProvider()
+                guard samePasteTarget(request.targetPID, currentPID) else {
+                    reportPasteTargetMismatch(queued: request.targetPID, current: currentPID)
+                    return
+                }
                 var snapshot = request.preserveClipboard ? try await captureStableSnapshot(pasteboard) : nil
                 guard writeTranscribedText(request.text, to: pasteboard) else { return }
                 var expectedChangeCount = pasteboard.changeCount
@@ -301,12 +314,13 @@ final class TextInjector {
                     guard writeTranscribedText(request.text, to: pasteboard) else { return }
                     expectedChangeCount = pasteboard.changeCount
                 }
-                guard request.targetPID == frontmostPIDProvider() else {
+                let pidBeforePaste = frontmostPIDProvider()
+                guard samePasteTarget(request.targetPID, pidBeforePaste) else {
                     if request.preserveClipboard, pasteboard.changeCount == expectedChangeCount {
                         if let snapshot { restoreSnapshot(snapshot, to: pasteboard) }
                         else { pasteboard.clearContents() }
                     }
-                    reportFocusChange()
+                    reportPasteTargetMismatch(queued: request.targetPID, current: pidBeforePaste)
                     return
                 }
                 simulatePaste()
@@ -322,6 +336,25 @@ final class TextInjector {
                 onFailure?("The clipboard kept changing, so text was not pasted. Your transcript is available in VocaMac.")
             }
         }
+    }
+
+    /// Both PIDs must be known and equal. `nil == nil` is not a valid paste target.
+    private func samePasteTarget(_ queued: pid_t?, _ current: pid_t?) -> Bool {
+        guard let queued, let current else { return false }
+        return queued == current
+    }
+
+    private func reportPasteTargetMismatch(queued: pid_t?, current: pid_t?) {
+        if queued == nil || current == nil {
+            reportMissingPasteTarget()
+        } else {
+            reportFocusChange()
+        }
+    }
+
+    private func reportMissingPasteTarget() {
+        VocaLogger.warning(.textInjector, "No active app to paste into; paste cancelled")
+        onFailure?("There was no active app to paste into. Your transcript is available in VocaMac.")
     }
 
     private func reportFocusChange() {

--- a/Sources/VocaMac/Services/TranscriptionRouter.swift
+++ b/Sources/VocaMac/Services/TranscriptionRouter.swift
@@ -111,7 +111,7 @@ extension TranscriptionRouter: SpeechTranscribing {
             await parakeet.unloadModelAndWait()
         }
         if engine != .appleSpeech {
-            appleSpeech.unloadModel()
+            await appleSpeech.unloadModel()
         }
         if engine != .sherpaOnnx {
             sherpa.unloadModel()
@@ -138,6 +138,18 @@ extension TranscriptionRouter: SpeechTranscribing {
     /// The transcription language the user selected, or nil for auto-detect.
     private var languagePreference: String? {
         languagePreferenceProvider()
+    }
+
+    /// Keep the normal operation serializer for the whole live session, so a
+    /// model switch cannot unload an analyzer that is still consuming audio.
+    func startStreaming(language: String?) -> RecordingTranscription? {
+        guard activeEngine == .appleSpeech, appleSpeech.isModelLoaded else { return nil }
+        return RecordingTranscription(language: language) { [self] chunks in
+            try await operationSerializer.run { [self] in
+                guard activeEngine == .appleSpeech else { throw AppleSpeechError.modelNotLoaded }
+                return try await appleSpeech.transcribe(chunks: chunks, language: language)
+            }
+        }
     }
 
     func transcribe(
@@ -176,7 +188,7 @@ extension TranscriptionRouter: SpeechTranscribing {
             try await operationSerializer.run(cancellable: false) { [self] in
                 whisper.unloadModel()
                 await parakeet.unloadModelAndWait()
-                appleSpeech.unloadModel()
+                await appleSpeech.unloadModel()
                 sherpa.unloadModel()
             }
         } catch {

--- a/Sources/VocaMac/Services/WhisperService.swift
+++ b/Sources/VocaMac/Services/WhisperService.swift
@@ -91,7 +91,11 @@ final class WhisperService: @unchecked Sendable {
                 .appendingPathComponent("models")
 
             // Verbose logging for debugging
+            #if DEBUG
             config.verbose = true
+            #else
+            config.verbose = false
+            #endif
 
             // Prewarm the model so the CoreML pipeline (Metal/ANE) is compiled
             // at load time rather than on the first transcription request.

--- a/Sources/VocaMac/Views/MenuBarView.swift
+++ b/Sources/VocaMac/Views/MenuBarView.swift
@@ -275,7 +275,7 @@ struct MenuBarView: View {
 
             // Audio level indicator (visible during recording)
             if appState.appStatus == .recording {
-                AudioLevelView(level: appState.audioLevel)
+                ObservedAudioLevelView(meter: appState.audioMeter)
                     .frame(height: 6)
 
                 // Stop/recovery button — visible during recording so the user

--- a/Sources/VocaMac/Views/SettingsView.swift
+++ b/Sources/VocaMac/Views/SettingsView.swift
@@ -213,17 +213,10 @@ struct SettingsSidebarFooter: View {
                 }
             }
 
-            GeometryReader { geo in
-                ZStack(alignment: .leading) {
-                    Capsule()
-                        .fill(Color.secondary.opacity(0.15))
-                    Capsule()
-                        .fill(appState.appStatus == .recording
-                              ? Color(nsColor: BrandAssets.brandGreen)
-                              : Color.accentColor)
-                        .frame(width: max(4, geo.size.width * CGFloat(min(max(appState.audioLevel, 0), 1))))
-                }
-            }
+            ObservedAudioLevelView(
+                meter: appState.audioMeter,
+                tint: appState.appStatus == .recording ? Color(nsColor: BrandAssets.brandGreen) : Color.accentColor
+            )
             .frame(height: isActiveSession ? 8 : 5)
             .animation(.easeInOut(duration: 0.15), value: isActiveSession)
 

--- a/Tests/VocaMacTests/AppStateRecordingTests.swift
+++ b/Tests/VocaMacTests/AppStateRecordingTests.swift
@@ -825,3 +825,60 @@ final class AppStateSlowMicrophoneStartTests: XCTestCase {
         XCTAssertFalse(appState.isRecording)
     }
 }
+
+extension AppStateRecordingTests {
+    func testLiveResultReplacesBatchWithoutLosingFinalSamples() async {
+        let (app, mocks) = AppState.makeTestState()
+        mocks.whisperService.streamingFactory = { language in
+            RecordingTranscription(language: language) { chunks in
+                var count = 0
+                for try await chunk in chunks { count += chunk.count }
+                return VocaTranscription(text: "live result", duration: 0, detectedLanguage: "en",
+                                         audioLengthSeconds: Double(count) / 16_000, modelUsed: .appleSpeech)
+            }
+        }
+        await app.startRecording()
+        mocks.audioEngine.onAudioSamples?([0.2, 0.3], 0)
+        mocks.audioEngine.onAudioSamples?([0.4], 2)
+        mocks.audioEngine.stopRecordingResult = [0.2, 0.3, 0.4]
+        await app.stopRecordingAndTranscribe(injectResult: false)
+        XCTAssertEqual(app.lastTranscription?.text, "live result")
+        XCTAssertEqual(app.lastTranscription?.audioLengthSeconds, 3.0 / 16_000)
+        XCTAssertNil(mocks.whisperService.lastTranscribedAudioData)
+        XCTAssertNil(mocks.audioEngine.onAudioSamples)
+    }
+
+    func testIncompleteLiveResultFallsBackToFullRecording() async {
+        let (app, mocks) = AppState.makeTestState()
+        mocks.whisperService.streamingFactory = { language in
+            RecordingTranscription(language: language) { chunks in
+                for try await _ in chunks { }
+                return VocaTranscription(text: "partial", duration: 0, detectedLanguage: "en",
+                                         audioLengthSeconds: 0, modelUsed: .appleSpeech)
+            }
+        }
+        await app.startRecording()
+        mocks.audioEngine.onAudioSamples?([0.2], 0)
+        mocks.audioEngine.stopRecordingResult = [0.2, 0.3]
+        await app.stopRecordingAndTranscribe(injectResult: false)
+        XCTAssertEqual(mocks.whisperService.lastTranscribedAudioData, [0.2, 0.3])
+        XCTAssertEqual(app.lastTranscription?.text, "mock transcription")
+    }
+
+    func testCancelRecordingStopsLiveConsumer() async {
+        let (app, mocks) = AppState.makeTestState()
+        let cancelled = expectation(description: "live consumer cancelled")
+        mocks.whisperService.streamingFactory = { language in
+            RecordingTranscription(language: language) { chunks in
+                defer { cancelled.fulfill() }
+                for try await _ in chunks { }
+                throw CancellationError()
+            }
+        }
+        await app.startRecording()
+        await app.cancelRecording()
+        await fulfillment(of: [cancelled], timeout: 1)
+        XCTAssertNil(mocks.audioEngine.onAudioSamples)
+        XCTAssertNil(mocks.whisperService.lastTranscribedAudioData)
+    }
+}

--- a/Tests/VocaMacTests/AppleSpeechAudioTests.swift
+++ b/Tests/VocaMacTests/AppleSpeechAudioTests.swift
@@ -1,0 +1,81 @@
+import XCTest
+import AVFoundation
+#if canImport(Speech)
+import Speech
+#endif
+@testable import VocaMac
+
+#if compiler(>=6.2)
+final class AppleSpeechAudioTests: XCTestCase {
+    @available(macOS 26.0, *)
+    private func converted(_ samples: [Float], chunkSize: Int, format: AVAudioFormat) async throws -> [Float] {
+        let (stream, continuation) = AsyncThrowingStream<[Float], Error>.makeStream()
+        for offset in stride(from: 0, to: samples.count, by: chunkSize) {
+            continuation.yield(Array(samples[offset..<min(samples.count, offset + chunkSize)]))
+        }
+        continuation.finish()
+        let cursor = SpeechInputCursor(chunks: stream, format: format)
+        var result: [Float] = []
+        while let input = try await cursor.next() {
+            let buffer = input.buffer
+            let data = try XCTUnwrap(buffer.floatChannelData?[0])
+            result.append(contentsOf: UnsafeBufferPointer(start: data, count: Int(buffer.frameLength)))
+        }
+        let count = await cursor.sampleCount
+        XCTAssertEqual(count, samples.count)
+        return result
+    }
+
+    func testChunkBoundariesPreserveResampledWaveformAndTail() async throws {
+        guard #available(macOS 26.0, *) else { throw XCTSkip("Apple Speech requires macOS 26") }
+        let format = try XCTUnwrap(AVAudioFormat(standardFormatWithSampleRate: 48_000, channels: 1))
+        let samples = (0..<16_003).map { Float(sin(Double($0) * 0.07) * 0.4) }
+        let whole = try await converted(samples, chunkSize: samples.count, format: format)
+        let chunked = try await converted(samples, chunkSize: 137, format: format)
+        XCTAssertEqual(chunked.count, whole.count)
+        XCTAssertEqual(chunked.count, samples.count * 3)
+        let largestDifference = zip(chunked, whole).map { abs($0 - $1) }.max() ?? 0
+        XCTAssertLessThan(largestDifference, 0.0001)
+    }
+
+    func testMatchingFormatPreservesSamples() async throws {
+        guard #available(macOS 26.0, *) else { throw XCTSkip("Apple Speech requires macOS 26") }
+        let samples: [Float] = [0.1, -0.2, 0.3, -0.4, 0.5]
+        let result = try await converted(samples, chunkSize: 2, format: AudioEngine.whisperFormat)
+        XCTAssertEqual(result, samples)
+    }
+
+    /// Opt-in acceptance uses installed system assets only, never the microphone.
+    func testInstalledAppleSpeechBatchAndStreaming() async throws {
+        guard #available(macOS 26.0, *) else { throw XCTSkip("Apple Speech requires macOS 26") }
+        guard ProcessInfo.processInfo.environment["VOCAMAC_TEST_APPLE_SPEECH"] == "1" else {
+            throw XCTSkip("Set VOCAMAC_TEST_APPLE_SPEECH=1 to exercise installed system speech assets")
+        }
+        let installed = await SpeechTranscriber.installedLocales
+        guard let english = installed.first(where: { $0.language.languageCode?.identifier == "en" }) else {
+            throw XCTSkip("English Apple Speech assets are not installed")
+        }
+        let url = URL(fileURLWithPath: #filePath).deletingLastPathComponent().appendingPathComponent("Fixtures/short-yes.wav")
+        let samples = try AudioFileLoader().loadAudio(at: url).samples
+        let service = AppleSpeechService()
+        try await service.loadModel(language: english.identifier)
+        do {
+            let batch = try await service.transcribe(audioData: samples, language: english.identifier)
+            let session = RecordingTranscription(language: english.identifier) { chunks in
+                try await service.transcribe(chunks: chunks, language: english.identifier)
+            }
+            for offset in stride(from: 0, to: samples.count, by: 1024) {
+                session.append(Array(samples[offset..<min(samples.count, offset + 1024)]), at: offset)
+            }
+            let live = try await session.finish(expectedSampleCount: samples.count)
+            XCTAssertFalse(batch.text.isEmpty)
+            XCTAssertEqual(live.text.lowercased(), batch.text.lowercased())
+            XCTAssertEqual(live.audioLengthSeconds, Double(samples.count) / 16_000)
+            await service.unloadModel()
+        } catch {
+            await service.unloadModel()
+            throw error
+        }
+    }
+}
+#endif

--- a/Tests/VocaMacTests/AudioMeterStateTests.swift
+++ b/Tests/VocaMacTests/AudioMeterStateTests.swift
@@ -1,0 +1,30 @@
+import XCTest
+import Combine
+@testable import VocaMac
+
+@MainActor
+final class AudioMeterStateTests: XCTestCase {
+    func testMeterDoesNotPublishUnrelatedAppChanges() {
+        let (app, _) = AppState.makeTestState()
+        var appChanges = 0
+        var meterChanges = 0
+        let appSubscription = app.objectWillChange.sink { appChanges += 1 }
+        let meterSubscription = app.audioMeter.objectWillChange.sink { meterChanges += 1 }
+        app.audioLevel = 0.5
+        app.audioLevel = 0.5
+        app.audioLevel = 0
+        XCTAssertEqual(appChanges, 0)
+        XCTAssertEqual(meterChanges, 2)
+        withExtendedLifetime((appSubscription, meterSubscription)) { }
+    }
+
+    func testInvalidLevelsCannotReachViewGeometry() {
+        let meter = AudioMeterState()
+        for input in [Float.nan, .infinity, -1] {
+            meter.update(input)
+            XCTAssertEqual(meter.level, 0)
+        }
+        meter.update(2)
+        XCTAssertEqual(meter.level, 1)
+    }
+}

--- a/Tests/VocaMacTests/AudioPCMBufferCacheTests.swift
+++ b/Tests/VocaMacTests/AudioPCMBufferCacheTests.swift
@@ -1,0 +1,34 @@
+import AVFoundation
+import XCTest
+@testable import VocaMac
+
+final class AudioPCMBufferCacheTests: XCTestCase {
+    func testReuseAndReplacementAtFormatOrCapacityBoundary() throws {
+        let cache = AudioPCMBufferCache()
+        let first = try XCTUnwrap(cache.buffer(format: AudioEngine.whisperFormat, capacity: 32))
+        first.frameLength = 32
+        let reused = try XCTUnwrap(cache.buffer(format: AudioEngine.whisperFormat, capacity: 16))
+        XCTAssertTrue(first === reused)
+        XCTAssertEqual(reused.frameLength, 0)
+        let larger = try XCTUnwrap(cache.buffer(format: AudioEngine.whisperFormat, capacity: 64))
+        XCTAssertFalse(first === larger)
+        let stereo = try XCTUnwrap(AVAudioFormat(standardFormatWithSampleRate: 48_000, channels: 2))
+        let changed = try XCTUnwrap(cache.buffer(format: stereo, capacity: 64))
+        XCTAssertEqual(changed.format, stereo)
+        XCTAssertEqual(cache.creationCount, 3)
+    }
+
+    func testReusedMonoBufferDoesNotContainPreviousChannelSamples() throws {
+        let cache = AudioPCMBufferCache()
+        let format = try XCTUnwrap(AVAudioFormat(standardFormatWithSampleRate: 48_000, channels: 2))
+        let input = try XCTUnwrap(AVAudioPCMBuffer(pcmFormat: format, frameCapacity: 8))
+        input.frameLength = 8
+        for i in 0..<8 { input.floatChannelData?[0][i] = 1; input.floatChannelData?[1][i] = -1 }
+        _ = AudioEngine.monoBuffer(from: input, selecting: 0, cache: cache)
+        input.frameLength = 3
+        let second = try XCTUnwrap(AudioEngine.monoBuffer(from: input, selecting: 1, cache: cache))
+        XCTAssertEqual(second.frameLength, 3)
+        for i in 0..<3 { XCTAssertEqual(second.floatChannelData?[0][i], -1) }
+        XCTAssertEqual(cache.creationCount, 1)
+    }
+}

--- a/Tests/VocaMacTests/AutoPauseMonitorTests.swift
+++ b/Tests/VocaMacTests/AutoPauseMonitorTests.swift
@@ -148,3 +148,27 @@ final class AutoPauseMonitorTests: XCTestCase {
         XCTAssertEqual(AutoPauseMonitor.clampPollInterval(120), 60)
     }
 }
+
+extension AutoPauseMonitorTests {
+    func testTimerOnlyRunsWhenEnabledWithConfiguredApps() {
+        var enabled = false
+        var apps: [AutoPauseAppEntry] = []
+        var scans = 0
+        let monitor = AutoPauseMonitor(getConfig: { (enabled, apps, 5) }, processSnapshot: { scans += 1; return [] })
+        monitor.start()
+        defer { monitor.stop() }
+        XCTAssertFalse(monitor.isPolling)
+        enabled = true
+        monitor.configurationDidChange()
+        XCTAssertFalse(monitor.isPolling)
+        XCTAssertEqual(scans, 0)
+        apps = [AutoPauseAppEntry(id: "test", displayName: "Test")]
+        monitor.configurationDidChange()
+        XCTAssertTrue(monitor.isPolling)
+        XCTAssertEqual(scans, 1)
+        enabled = false
+        monitor.configurationDidChange()
+        XCTAssertFalse(monitor.isPolling)
+        XCTAssertEqual(scans, 1)
+    }
+}

--- a/Tests/VocaMacTests/ClipboardPreservationTests.swift
+++ b/Tests/VocaMacTests/ClipboardPreservationTests.swift
@@ -1,0 +1,110 @@
+import AppKit
+import XCTest
+@testable import VocaMac
+
+@MainActor
+final class ClipboardPreservationTests: XCTestCase {
+    func testManyRepresentationsArePreservedAcrossCooperativeCapture() async {
+        let board = NSPasteboard(name: .init("com.vocamac.tests.\(UUID())"))
+        defer { board.releaseGlobally() }
+        let item = NSPasteboardItem()
+        let types = (0..<24).map { NSPasteboard.PasteboardType("com.vocamac.test.\($0)") }
+        for (index, type) in types.enumerated() { item.setData(Data(repeating: UInt8(index), count: 2048), forType: type) }
+        board.writeObjects([item])
+        let pasted = expectation(description: "paste")
+        let injector = TextInjector(pasteboard: board, accessibilityTrustedOverride: true,
+                                    accessibilityInjectionOverride: { _ in false }, pasteActionOverride: {
+            XCTAssertEqual(board.string(forType: .string), "dictation")
+            pasted.fulfill()
+        })
+        injector.inject(text: "dictation", preserveClipboard: true)
+        await fulfillment(of: [pasted], timeout: 2)
+        // Wait for the deliberately retained target-app consumption window.
+        try? await Task.sleep(nanoseconds: 250_000_000)
+        for (index, type) in types.enumerated() {
+            XCTAssertEqual(board.data(forType: type), Data(repeating: UInt8(index), count: 2048))
+        }
+    }
+
+    func testChangingClipboardDuringSnapshotDoesNotRestoreMixedGenerations() async {
+        let board = NSPasteboard(name: .init("com.vocamac.tests.\(UUID())"))
+        defer { board.releaseGlobally() }
+        let types = (0..<24).map { NSPasteboard.PasteboardType("com.vocamac.test.\($0)") }
+        let provider = ChangingClipboardProvider(board: board)
+        let item = NSPasteboardItem()
+        item.setDataProvider(provider, forTypes: types)
+        board.writeObjects([item])
+        let pasted = expectation(description: "paste after snapshot restart")
+        let injector = TextInjector(pasteboard: board, accessibilityTrustedOverride: true,
+                                    accessibilityInjectionOverride: { _ in false }, pasteActionOverride: {
+            XCTAssertEqual(board.string(forType: .string), "dictation")
+            pasted.fulfill()
+        })
+        injector.inject(text: "dictation", preserveClipboard: true)
+        await fulfillment(of: [pasted], timeout: 2)
+        try? await Task.sleep(nanoseconds: 250_000_000)
+        XCTAssertEqual(board.string(forType: .string), "new clipboard")
+        XCTAssertNil(board.data(forType: types[0]))
+        withExtendedLifetime(provider) { }
+    }
+}
+
+private final class ChangingClipboardProvider: NSObject, NSPasteboardItemDataProvider {
+    let board: NSPasteboard
+    var scheduled = false
+    init(board: NSPasteboard) { self.board = board }
+    func pasteboard(_ pasteboard: NSPasteboard?, item: NSPasteboardItem, provideDataForType type: NSPasteboard.PasteboardType) {
+        item.setData(Data([1, 2, 3]), forType: type)
+        guard !scheduled else { return }
+        scheduled = true
+        DispatchQueue.main.async { [board] in
+            board.clearContents()
+            board.setString("new clipboard", forType: .string)
+        }
+    }
+}
+
+extension ClipboardPreservationTests {
+    func testSlowAccessibilityWorkerDoesNotBlockMainQueue() async {
+        let board = NSPasteboard(name: .init("com.vocamac.tests.\(UUID())"))
+        defer { board.releaseGlobally() }
+        let started = expectation(description: "worker started")
+        let finished = expectation(description: "fallback pasted")
+        let gate = DispatchSemaphore(value: 0)
+        let injector = TextInjector(
+            pasteboard: board, accessibilityTrustedOverride: true,
+            pasteActionOverride: { finished.fulfill() },
+            accessibilityWorkerOverride: { _ in
+                XCTAssertFalse(Thread.isMainThread)
+                started.fulfill()
+                _ = gate.wait(timeout: .now() + 2)
+                return false
+            }, frontmostPIDProvider: { 123 }
+        )
+        injector.inject(text: "result", preserveClipboard: false)
+        await fulfillment(of: [started], timeout: 1)
+        // This main-actor continuation executes while the worker is blocked.
+        gate.signal()
+        await fulfillment(of: [finished], timeout: 1)
+        try? await Task.sleep(nanoseconds: 200_000_000)
+    }
+
+    func testFocusChangeBeforePasteRestoresClipboardAndReportsFailure() async {
+        let board = NSPasteboard(name: .init("com.vocamac.tests.\(UUID())"))
+        defer { board.releaseGlobally() }
+        board.setString("original", forType: .string)
+        var pid: pid_t = 123
+        let cancelled = expectation(description: "focus change reported")
+        let injector = TextInjector(
+            pasteboard: board, accessibilityTrustedOverride: true,
+            accessibilityInjectionOverride: { _ in false },
+            pasteActionOverride: { XCTFail("Must not paste into another app") },
+            frontmostPIDProvider: { pid }
+        )
+        injector.onFailure = { _ in cancelled.fulfill() }
+        injector.inject(text: "result", preserveClipboard: true)
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.02) { pid = 456 }
+        await fulfillment(of: [cancelled], timeout: 1)
+        XCTAssertEqual(board.string(forType: .string), "original")
+    }
+}

--- a/Tests/VocaMacTests/ClipboardPreservationTests.swift
+++ b/Tests/VocaMacTests/ClipboardPreservationTests.swift
@@ -16,7 +16,7 @@ final class ClipboardPreservationTests: XCTestCase {
                                     accessibilityInjectionOverride: { _ in false }, pasteActionOverride: {
             XCTAssertEqual(board.string(forType: .string), "dictation")
             pasted.fulfill()
-        })
+        }, frontmostPIDProvider: { 123 })
         injector.inject(text: "dictation", preserveClipboard: true)
         await fulfillment(of: [pasted], timeout: 2)
         // Wait for the deliberately retained target-app consumption window.
@@ -39,7 +39,7 @@ final class ClipboardPreservationTests: XCTestCase {
                                     accessibilityInjectionOverride: { _ in false }, pasteActionOverride: {
             XCTAssertEqual(board.string(forType: .string), "dictation")
             pasted.fulfill()
-        })
+        }, frontmostPIDProvider: { 123 })
         injector.inject(text: "dictation", preserveClipboard: true)
         await fulfillment(of: [pasted], timeout: 2)
         try? await Task.sleep(nanoseconds: 250_000_000)
@@ -104,6 +104,23 @@ extension ClipboardPreservationTests {
         injector.onFailure = { _ in cancelled.fulfill() }
         injector.inject(text: "result", preserveClipboard: true)
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.02) { pid = 456 }
+        await fulfillment(of: [cancelled], timeout: 1)
+        XCTAssertEqual(board.string(forType: .string), "original")
+    }
+
+    func testMissingPasteTargetDoesNotPasteAndReportsFailure() async {
+        let board = NSPasteboard(name: .init("com.vocamac.tests.\(UUID())"))
+        defer { board.releaseGlobally() }
+        board.setString("original", forType: .string)
+        let cancelled = expectation(description: "missing target reported")
+        let injector = TextInjector(
+            pasteboard: board, accessibilityTrustedOverride: true,
+            accessibilityInjectionOverride: { _ in false },
+            pasteActionOverride: { XCTFail("Must not paste without a destination") },
+            frontmostPIDProvider: { nil }
+        )
+        injector.onFailure = { _ in cancelled.fulfill() }
+        injector.inject(text: "result", preserveClipboard: true)
         await fulfillment(of: [cancelled], timeout: 1)
         XCTAssertEqual(board.string(forType: .string), "original")
     }

--- a/Tests/VocaMacTests/DictationPerformanceTests.swift
+++ b/Tests/VocaMacTests/DictationPerformanceTests.swift
@@ -1,0 +1,69 @@
+import XCTest
+import Speech
+@testable import VocaMac
+
+#if compiler(>=6.2)
+final class DictationPerformanceTests: XCTestCase {
+    /// Explicit benchmark, not a hosted-runner timing gate. Input and output stay
+    /// outside the repo; transcripts in the report permit an accuracy comparison.
+    func testAppleSpeechStopLatencyBenchmark() async throws {
+        guard #available(macOS 26.0, *) else { throw XCTSkip("Apple Speech requires macOS 26") }
+        let environment = ProcessInfo.processInfo.environment
+        guard let inputPath = environment["VOCAMAC_BENCHMARK_AUDIO"],
+              let outputPath = environment["VOCAMAC_BENCHMARK_OUTPUT"] else {
+            throw XCTSkip("Set VOCAMAC_BENCHMARK_AUDIO and VOCAMAC_BENCHMARK_OUTPUT for release timing")
+        }
+        let installed = await SpeechTranscriber.installedLocales
+        guard let locale = installed.first(where: { $0.language.languageCode?.identifier == "en" }) else {
+            throw XCTSkip("English system assets must already be installed")
+        }
+        let samples = try AudioFileLoader().loadAudio(at: URL(fileURLWithPath: inputPath)).samples
+        struct Measurement: Codable {
+            let batchSeconds: Double
+            let streamingStopSeconds: Double
+            let batchText: String
+            let streamingText: String
+        }
+        struct Report: Codable {
+            let os: String
+            let audioSeconds: Double
+            let measurements: [Measurement]
+        }
+        var measurements: [Measurement] = []
+        let service = AppleSpeechService()
+        do {
+            for _ in 0..<3 {
+                try await service.loadModel(language: locale.identifier)
+                let batchStart = ProcessInfo.processInfo.systemUptime
+                let batch = try await service.transcribe(audioData: samples, language: locale.identifier)
+                let batchSeconds = ProcessInfo.processInfo.systemUptime - batchStart
+                try await service.loadModel(language: locale.identifier)
+                let live = RecordingTranscription(language: locale.identifier) { chunks in
+                    try await service.transcribe(chunks: chunks, language: locale.identifier)
+                }
+                for offset in stride(from: 0, to: samples.count, by: 1024) {
+                    let end = min(samples.count, offset + 1024)
+                    live.append(Array(samples[offset..<end]), at: offset)
+                    try await Task.sleep(nanoseconds: UInt64(Double(end - offset) / 16_000 * 1_000_000_000))
+                }
+                let stop = ProcessInfo.processInfo.systemUptime
+                let result = try await live.finish(expectedSampleCount: samples.count)
+                let streamingStopSeconds = ProcessInfo.processInfo.systemUptime - stop
+                XCTAssertFalse(batch.text.isEmpty)
+                XCTAssertFalse(result.text.isEmpty)
+                measurements.append(Measurement(batchSeconds: batchSeconds, streamingStopSeconds: streamingStopSeconds,
+                                                batchText: batch.text, streamingText: result.text))
+            }
+            await service.unloadModel()
+            let report = Report(os: ProcessInfo.processInfo.operatingSystemVersionString,
+                                audioSeconds: Double(samples.count) / 16_000, measurements: measurements)
+            let encoder = JSONEncoder()
+            encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+            try encoder.encode(report).write(to: URL(fileURLWithPath: outputPath), options: .atomic)
+        } catch {
+            await service.unloadModel()
+            throw error
+        }
+    }
+}
+#endif

--- a/Tests/VocaMacTests/Mocks/MockServices.swift
+++ b/Tests/VocaMacTests/Mocks/MockServices.swift
@@ -13,6 +13,7 @@ import Combine
 final class MockAudioEngine: AudioRecording {
     var isCurrentlyRecording = false
     var onAudioLevel: ((Float) -> Void)?
+    var onAudioSamples: (([Float], Int) -> Void)?
     var onSilenceDetected: (() -> Void)?
     var onMaxDurationReached: (() -> Void)?
     var onAudioDeviceChanged: (() -> Void)?
@@ -425,6 +426,8 @@ final class MockModelManager: ModelManaging {
 final class MockWhisperService: SpeechTranscribing {
     typealias LoadRequest = (name: String?, folder: URL?)
 
+    var streamingFactory: ((String?) -> RecordingTranscription?)?
+    func startStreaming(language: String?) -> RecordingTranscription? { streamingFactory?(language) }
     var loadedModelName: String? = "openai_whisper-tiny"
     var isModelLoaded: Bool = true
     var lastTranscribedAudioData: [Float]?

--- a/Tests/VocaMacTests/RecordingTranscriptionTests.swift
+++ b/Tests/VocaMacTests/RecordingTranscriptionTests.swift
@@ -1,0 +1,124 @@
+import XCTest
+@testable import VocaMac
+
+final class RecordingTranscriptionTests: XCTestCase {
+    private func transcript(_ count: Int) -> VocaTranscription {
+        VocaTranscription(text: "complete", duration: 0, detectedLanguage: "en",
+                          audioLengthSeconds: Double(count) / 16_000, modelUsed: .appleSpeech)
+    }
+
+    func testOrderedChunksAreConsumedBeforeRecordingFinishes() async throws {
+        let consumed = expectation(description: "first chunk processed during capture")
+        let session = RecordingTranscription(language: "en") { chunks in
+            var count = 0
+            for try await chunk in chunks {
+                if count == 0 { consumed.fulfill() }
+                count += chunk.count
+            }
+            return self.transcript(count)
+        }
+        session.append([0.1, 0.2], at: 0)
+        await fulfillment(of: [consumed], timeout: 1)
+        session.append([0.3], at: 2)
+        let result = try await session.finish(expectedSampleCount: 3)
+        XCTAssertEqual(result.audioLengthSeconds, 3.0 / 16_000)
+        XCTAssertEqual(result.text, "complete")
+    }
+
+    func testCaptureRestartFailsInsteadOfReturningMixedAudio() async {
+        let session = RecordingTranscription(language: nil) { chunks in
+            var count = 0
+            for try await chunk in chunks { count += chunk.count }
+            return self.transcript(count)
+        }
+        session.append([1, 2], at: 0)
+        session.append([3], at: 0)
+        do {
+            _ = try await session.finish(expectedSampleCount: 1)
+            XCTFail("A restarted capture must fall back to the complete batch")
+        } catch { }
+    }
+
+    func testMissingTailFailsInsteadOfReturningPartialResult() async {
+        let session = RecordingTranscription(language: nil) { chunks in
+            for try await _ in chunks { }
+            return self.transcript(1)
+        }
+        session.append([1], at: 0)
+        do {
+            _ = try await session.finish(expectedSampleCount: 2)
+            XCTFail("Missing samples must invalidate streaming")
+        } catch { }
+    }
+
+    func testOverflowIsBoundedAndFailsClosed() async {
+        let gate = TestGate()
+        let session = RecordingTranscription(language: nil, bufferLimit: 1) { chunks in
+            await gate.wait()
+            for try await _ in chunks { }
+            return self.transcript(2)
+        }
+        session.append([1], at: 0)
+        session.append([2], at: 1)
+        await gate.open()
+        do {
+            _ = try await session.finish(expectedSampleCount: 2)
+            XCTFail("Overflow must not return a partial transcript")
+        } catch { }
+    }
+
+    func testCancelUnblocksConsumerAndQueuedModelOperation() async throws {
+        let serializer = LoadSerializer()
+        let started = expectation(description: "stream holds engine")
+        let session = RecordingTranscription(language: nil) { chunks in
+            try await serializer.run {
+                started.fulfill()
+                for try await _ in chunks { }
+                return self.transcript(0)
+            }
+        }
+        await fulfillment(of: [started], timeout: 1)
+        session.cancel()
+        let result = try await serializer.run { 42 }
+        XCTAssertEqual(result, 42)
+    }
+
+    func testBatchCursorUsesBoundedChunksIncludingLastSample() async {
+        let original = (0..<32_003).map(Float.init)
+        let cursor = AudioChunkCursor(original)
+        var collected: [Float] = []
+        while let chunk = await cursor.next() {
+            XCTAssertLessThanOrEqual(chunk.count, 16_000)
+            collected += chunk
+        }
+        XCTAssertEqual(collected, original)
+    }
+}
+
+private actor TestGate {
+    private var isOpen = false
+    private var waiter: CheckedContinuation<Void, Never>?
+    func wait() async {
+        if isOpen { return }
+        await withCheckedContinuation { waiter = $0 }
+    }
+    func open() { isOpen = true; waiter?.resume(); waiter = nil }
+}
+
+extension RecordingTranscriptionTests {
+    func testConsumerReturningEarlyCannotDeliverPartialSuccess() async {
+        let session = RecordingTranscription(language: nil) { chunks in
+            for try await chunk in chunks {
+                return VocaTranscription(text: "partial", duration: 0, detectedLanguage: "en",
+                                         audioLengthSeconds: Double(chunk.count) / 16_000, modelUsed: .appleSpeech)
+            }
+            throw CancellationError()
+        }
+        session.append([1], at: 0)
+        session.append([2], at: 1)
+        do {
+            _ = try await session.finish(expectedSampleCount: 2)
+            XCTFail("An engine must consume the complete recording before returning success")
+        } catch { }
+    }
+}

--- a/Tests/VocaMacTests/ServiceTests.swift
+++ b/Tests/VocaMacTests/ServiceTests.swift
@@ -120,7 +120,8 @@ final class TextInjectorTests: XCTestCase {
             pasteActionOverride: {
                 pastedTexts.append(pasteboard.string(forType: .string) ?? "")
                 pasteExpectation.fulfill()
-            }
+            },
+            frontmostPIDProvider: { 123 }
         )
 
         injector.inject(text: "spoken transcription", preserveClipboard: true)
@@ -170,7 +171,8 @@ final class TextInjectorTests: XCTestCase {
                         finishedExpectation.fulfill()
                     }
                 }
-            }
+            },
+            frontmostPIDProvider: { 123 }
         )
 
         injector.inject(text: "first transcription", preserveClipboard: true)
@@ -324,7 +326,7 @@ final class TextInjectorTests: XCTestCase {
             throw XCTSkip("Accessibility permission is not granted; clipboard fallback cannot be triggered (AX is not even attempted).")
         }
 
-        let injector = TextInjector()
+        let injector = TextInjector(frontmostPIDProvider: { 123 })
         let expected = "fallback text after ax failure"
 
         // Seed the pasteboard with a known value so we can detect a change.

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -71,7 +71,7 @@ outside the checkout:
 ```sh
 VOCAMAC_BENCHMARK_AUDIO=/tmp/dictation.wav \
 VOCAMAC_BENCHMARK_OUTPUT=/tmp/dictation-performance.json \
-swift test -c release -Xswiftc -enable-testing --filter DictationPerformanceTests
+swift test -c release -Xswiftc -enable-testing --disable-swift-testing --filter DictationPerformanceTests
 ```
 
 This compares prepared batch time with stop-to-result time after feeding the

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -1,0 +1,85 @@
+# Dictation performance
+
+Use a release build on a fixed Mac, OS version, model and language. Record cold
+model preparation separately from warm dictation. Hosted CI timing is noisy and
+must not become a hard latency threshold.
+
+## Engine and capture behavior
+
+Apple Speech preheats its first analyzer during model loading. GUI recording
+feeds a bounded stream while the microphone runs. Each subsequent utterance
+creates a fresh analyzer while recording; a finished analyzer is never reused.
+The router serializes the complete session with model changes and unloads.
+The CLI uses the same preparation/conversion code with pull-based batch chunks.
+
+The capture stream buffers at most 32 tap chunks. Overflow, sample discontinuity,
+or an incomplete stream triggers batch decoding of the full retained recording;
+partial streamed text is never injected. Cancellation releases the consumer and
+allows queued model operations to finish. Whisper, Parakeet and ONNX retain their
+batch decoding behavior and accuracy policies.
+
+Capture reuses mono/conversion PCM buffers and reserves sample storage before
+installing the tap. It transfers the final sample array on stop. Streaming alone
+makes an additional owned copy per tap chunk, since the converter reuses its
+scratch buffer. ONNX segmentation retains ranges and materializes one segment at
+a time. Recovery framing and attempt limits remain unchanged; retries reuse
+preparation storage and expose separate timings.
+
+Accessibility queries run on serial workers with bounded messaging timeouts;
+overlay queries never accumulate while another query is pending. Results from a
+previous overlay or frontmost app are discarded. Clipboard access stays on the
+main queue, yielding between batches of representations and restarting when the
+clipboard generation changes. A single promised representation supplied by
+another app can still block that individual read. Preservation never silently
+drops formats to meet a time budget. Paste and clipboard-restore delays remain
+50 ms and 150 ms. An uncertain Accessibility write does not trigger a second paste.
+
+## Instruments
+
+Record Time Profiler, Allocations, and Points of Interest for subsystem
+`com.vocamac`, category `Performance`. Existing hotkey/start/model/stop intervals
+remain available. Additional intervals/events distinguish:
+
+- `OperationQueueWait`: waiting for earlier model/inference work.
+- `AppleSpeechPreparation`, `AppleSpeechAudioConversion`, `StreamingFinalize`:
+  analyzer setup, chunk conversion, and remaining work after stop.
+- `ONNXFirstAttempt`, `ONNXRecoveryAttempt`: initial inference versus recovery.
+- `CaretAccessibilityQuery`, `TextAccessibilityQueryAndWrite`: cross-process IPC.
+- `ClipboardSnapshot`: preservation cost; debug logging reports snapshot bytes.
+- `TextDeliveryQueueAndDispatch`, `PasteEventPosted`, `AccessibilityTextInserted`:
+  queued delivery through dispatch and clipboard restoration.
+- `StreamingBatchFallback`: invalidated live session using the complete recording.
+
+`StopToResultQueued` ends when AppState queues delivery, not when text appears in
+another app. `PasteEventPosted` also cannot prove that the target has consumed the
+paste. Measure target-side appearance separately in manual UI acceptance.
+
+## Repeatable checks
+
+```sh
+swift test
+VOCAMAC_TEST_APPLE_SPEECH=1 swift test --filter AppleSpeechAudioTests
+VOCAMAC_KEEP_RUNNING=1 CODE_SIGN_IDENTITY=- ./scripts/build.sh release
+```
+
+The Apple Speech acceptance test uses existing English system assets and skips
+when they are absent. It does not record a microphone or install speech assets.
+
+For an optional release benchmark, use a local audio fixture and write the report
+outside the checkout:
+
+```sh
+VOCAMAC_BENCHMARK_AUDIO=/tmp/dictation.wav \
+VOCAMAC_BENCHMARK_OUTPUT=/tmp/dictation-performance.json \
+swift test -c release -Xswiftc -enable-testing --filter DictationPerformanceTests
+```
+
+This compares prepared batch time with stop-to-result time after feeding the
+same clip at microphone pace. The report includes both transcripts for accuracy
+review. It measures engine behavior, not microphone startup, total energy, or
+actual paste consumption. Stop other builds before collecting timings.
+
+Before release, compare short and long clips, selected and automatic languages,
+built-in/USB/Bluetooth microphones, rapid start/stop, cancellation, model changes,
+clipboard images/rich text, and unresponsive target apps. Track median/p95 latency,
+peak resident memory, idle wakeups and transcription accuracy together.

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -10,6 +10,7 @@
 # Environment variables:
 #   APP_VERSION         — Version string to embed in Info.plist. Defaults to 0.9.0.
 #                         Set by CI for nightly builds (e.g., 0.9.0-nightly.20260512+abc1234).
+#   VOCAMAC_KEEP_RUNNING — Set to 1 for isolated validation without stopping the installed app.
 #   CODE_SIGN_IDENTITY  — Signing identity to use. Defaults to auto-detect
 #                         Developer ID Application in the login keychain.
 #                         Set to "-" to force ad-hoc signing.
@@ -53,7 +54,7 @@ else
 fi
 
 # Kill any running VocaMac instances before building
-if pgrep -f "VocaMac" > /dev/null 2>&1; then
+if [ "${VOCAMAC_KEEP_RUNNING:-0}" != "1" ] && pgrep -f "VocaMac" > /dev/null 2>&1; then
     echo "🛑 Stopping running VocaMac..."
     pkill -f "VocaMac" 2>/dev/null
     sleep 1


### PR DESCRIPTION
## Problem

Dictation can stall the UI while caret tracking and text insertion wait on another app. Apple Speech starts analysis only after recording stops, and full-clip conversion/ONNX segmentation adds avoidable allocations. Meter publication and disabled auto-pause polling also do unnecessary work.

## Changes

- Preheat Apple Speech and consume bounded audio chunks during GUI recording; retain the full recording for batch fallback on overflow, discontinuity or incomplete consumption. Serialize the live session with model operations and cancel obsolete sessions/results. Keep CLI input pull-based and preserve converter state through the final sample.
- Reuse capture PCM buffers, reserve capture storage before installing the tap, transfer the completed sample array and materialize ONNX segments one at a time. Reuse recovery scratch storage while retaining all existing recovery layouts/attempt limits.
- Move Accessibility IPC to serial workers, bound messaging timeouts, discard stale caret results, and serialize text delivery through clipboard restoration. Avoid duplicate insertion after uncertain AX writes and cancel paste if the frontmost app changes.
- Preserve every clipboard representation on the main queue while yielding between batches; restart snapshots if their clipboard generation changes. Retain the 50 ms pre-paste and 150 ms restore delays and report insertion failures.
- Isolate audio-meter observation, stop disabled/empty auto-pause timers, and turn off verbose WhisperKit logging in release builds.
- Add stage-level Instruments signposts, regression tests, an opt-in release benchmark and `docs/PERFORMANCE.md`. Add an isolated-build option that leaves the installed app running.

## Validation

- Full local suite: 511 tests, 2 skipped, 0 failures; installed Apple Speech acceptance enabled. The skipped cases are the opt-in benchmark and a real no-Accessibility-permission check (this Mac has permission).
- Real installed Apple Speech: batch and streaming matched on the short-word fixture; chunk conversion preserved the waveform and resampled tail.
- Focused clipboard/recording/auto-pause safety suite: 66 tests, 1 skipped, 0 failures.
- Release `.app` built through `scripts/build.sh`; strict/deep ad-hoc signature verification and headless `--help` passed. The built CLI transcribed a six-second speech fixture.
- `git diff --check` passed. Primary checkout and its pre-existing untracked files were preserved.

## Local release benchmark

Apple M1 Pro, 16 GB RAM, macOS 26.6.2; three paired runs per generated English clip with prepared Apple Speech. These compare the new batch path to the new streaming path, not a historical binary or target-side paste appearance.

| Clip | Median batch | Median streaming stop-to-result | Transcript comparison |
| --- | ---: | ---: | --- |
| 6.04 seconds | 158 ms | 167 ms | Identical in all pairs |
| 29.64 seconds | 625 ms | 293 ms | Identical in all pairs |

The longer clip reduced median remaining latency by 53%. The short clip showed no consistent improvement. Transcript equality does not mean perfect recognition against the source script. This is a small local sample, not a p95, energy or hardware-wide performance claim. The 29.64-second XCTest benchmark passed in 98 seconds.

## Limits

Live inference is enabled for Apple Speech; Whisper, Parakeet and ONNX keep their batch decoding/accuracy policies. ONNX retries are instrumented and allocate less, but are not removed. An individual promised clipboard representation can still block its synchronous AppKit read. Physical Bluetooth/USB recording, unresponsive external-app interaction and target-side paste consumption require manual acceptance. Local validation does not establish remote CI success or production signing.
