### PR TITLE
ui: improve screenshot gallery hierarchy

### DIFF
--- a/web/layouts/_default/screenshots.html
+++ b/web/layouts/_default/screenshots.html
@@ -12,19 +12,27 @@
     <div class="shell">
         <h2 class="sr-only" id="gallery-title">VocaMac screenshot gallery</h2>
         <div class="gallery">
-            <figure class="shot reveal">
-                <div class="shot-frame"><img src="/screenshots/menu-bar-idle.png" alt="VocaMac menu bar icon in its idle state" width="472" height="68" loading="lazy"></div>
-                <figcaption><strong>Menu bar · idle</strong>VocaMac stays ready without taking over the desktop.</figcaption>
-            </figure>
-            <figure class="shot reveal">
-                <div class="shot-frame"><img src="/screenshots/menu-bar-recording.png" alt="VocaMac menu bar icon in its recording state" width="636" height="76" loading="lazy"></div>
-                <figcaption><strong>Menu bar · recording</strong>A visible state change confirms that audio capture is active.</figcaption>
-            </figure>
-            <figure class="shot reveal">
-                <div class="shot-frame"><img src="/screenshots/popover-panel.png" alt="VocaMac popover showing status, model, microphone, and last transcription" width="768" height="816" loading="lazy"></div>
-                <figcaption><strong>Popover panel</strong>Check readiness, the selected model, microphone, and last result.</figcaption>
-            </figure>
-            <figure class="shot reveal">
+            <div class="gallery-overview">
+                <div class="gallery-menu-states">
+                    <figure class="shot shot-menu reveal">
+                        <div class="shot-frame"><img src="/screenshots/menu-bar-idle.png" alt="VocaMac menu bar icon in its idle state" width="472" height="68" loading="lazy"></div>
+                        <figcaption><strong>Menu bar · idle</strong>Ready without taking over your desktop.</figcaption>
+                    </figure>
+                    <figure class="shot shot-menu reveal">
+                        <div class="shot-frame"><img src="/screenshots/menu-bar-recording.png" alt="VocaMac menu bar icon in its recording state" width="636" height="76" loading="lazy"></div>
+                        <figcaption><strong>Menu bar · recording</strong>A clear state change confirms audio capture.</figcaption>
+                    </figure>
+                </div>
+                <figure class="shot shot-popover reveal">
+                    <div class="shot-frame"><img src="/screenshots/popover-panel.png" alt="VocaMac popover showing status, model, microphone, and last transcription" width="768" height="816" loading="lazy"></div>
+                    <figcaption><strong>Popover panel</strong>Check readiness, the selected model, microphone, and last result.</figcaption>
+                </figure>
+            </div>
+            <div class="gallery-divider">
+                <p class="section-tag">make it yours</p>
+                <p>Settings are organised around the choices that change your dictation.</p>
+            </div>
+            <figure class="shot shot-featured reveal">
                 <div class="shot-frame"><img src="/screenshots/settings-general.png" alt="VocaMac Settings Dictation page" width="1520" height="1288" loading="lazy"></div>
                 <figcaption><strong>Dictation</strong>Choose the activation mode, hotkey, and output behavior.</figcaption>
             </figure>
@@ -32,7 +40,7 @@
                 <div class="shot-frame"><img src="/screenshots/settings-snippets.png" alt="VocaMac Settings Snippets page" width="1520" height="1288" loading="lazy"></div>
                 <figcaption><strong>Snippets</strong>Expand a spoken trigger into the text you actually want.</figcaption>
             </figure>
-            <figure class="shot reveal">
+            <figure class="shot shot-wide reveal">
                 <div class="shot-frame"><img src="/screenshots/settings-models.png" alt="VocaMac Settings Speech Model page" width="1520" height="1288" loading="lazy"></div>
                 <figcaption><strong>Speech Model</strong>Pick an engine and manage local models.</figcaption>
             </figure>

--- a/web/static/style.css
+++ b/web/static/style.css
@@ -1666,10 +1666,66 @@ details.source-install summary {
 
 .gallery {
   display: grid;
-  gap: 2rem;
-  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
-  padding: 3.5rem 0;
+  gap: 1.8rem;
+  grid-template-columns: repeat(12, minmax(0, 1fr));
+  padding: 2.2rem 0 3.5rem;
 }
+
+.gallery-overview {
+  display: grid;
+  grid-column: 1 / -1;
+  gap: 1.8rem;
+  grid-template-columns: minmax(0, 5fr) minmax(0, 7fr);
+  align-items: stretch;
+}
+
+.gallery-menu-states {
+  display: grid;
+  gap: 1.8rem;
+}
+
+.shot-menu .shot-frame {
+  aspect-ratio: auto;
+  min-height: 10.25rem;
+  padding: 1.5rem;
+}
+
+.shot-menu .shot-frame img {
+  width: 100%;
+  max-height: none;
+}
+
+.shot-popover .shot-frame {
+  height: calc(100% - 6.6rem);
+  min-height: 24rem;
+}
+
+.shot-popover .shot-frame img {
+  height: 100%;
+}
+
+.gallery-divider {
+  display: flex;
+  grid-column: 1 / -1;
+  gap: 1rem 2rem;
+  align-items: baseline;
+  justify-content: space-between;
+  margin-top: 1.2rem;
+  padding-top: 1.8rem;
+  border-top: 1px solid var(--line);
+}
+
+.gallery-divider > p:last-child {
+  max-width: 43ch;
+  color: var(--muted);
+}
+
+.gallery > .shot {
+  grid-column: span 4;
+  align-self: start;
+}
+.gallery > .shot-featured { grid-column: span 8; }
+.gallery > .shot-wide { grid-column: span 8; }
 
 .not-found { padding: 6rem 0; text-align: center; }
 .not-found h1 { font-size: clamp(3rem, 9vw, 5.5rem); }
@@ -1708,6 +1764,7 @@ details.source-install summary {
   .doc-aside { padding: 0 0 1rem; }
   .doc-aside-inner { position: static; }
   .prose { padding-top: 2.5rem; }
+  .gallery > .shot, .gallery > .shot-featured, .gallery > .shot-wide { grid-column: span 6; }
 }
 
 @media (max-width: 920px) {
@@ -1784,6 +1841,14 @@ details.source-install summary {
   .feature-cta { align-items: stretch; flex-direction: column; }
   .page-hero-head { gap: 1rem; flex-direction: column; }
   .install-card .btn { width: 100%; }
+  .gallery { gap: 1.2rem; padding-top: 1.8rem; }
+  .gallery-overview { grid-template-columns: minmax(0, 1fr); gap: 1.2rem; }
+  .gallery-menu-states { gap: 1.2rem; }
+  .shot-menu .shot-frame { min-height: 8.5rem; }
+  .shot-popover .shot-frame { height: auto; min-height: 20rem; }
+  .gallery-divider { display: block; margin-top: 0.6rem; padding-top: 1.4rem; }
+  .gallery-divider > p:last-child { margin-top: 0.65rem; }
+  .gallery > .shot, .gallery > .shot-featured, .gallery > .shot-wide { grid-column: 1 / -1; }
 }
 
 /* 42 bars crowd a phone-width panel back into a solid block, so drop every


### PR DESCRIPTION
## Problem

The screenshot gallery treated every product state as the same card size. This left the narrow menu-bar captures surrounded by empty space and made the popover and model-management screens harder to inspect at a glance.

## Change

- Group the idle and recording menu-bar states into compact proportional cards.
- Give the popover and primary settings screens larger placements in a responsive editorial grid.
- Add a visual divider before the settings collection and preserve the existing lightbox behavior and image alternatives.

## Verification

- `npm run check`
- `npx --yes html-validate 'public/**/*.html'`
- `npx --yes stylelint static/style.css`
- Reviewed the local `/screenshots/` page in Chrome.
