### PR TITLE
fix: remove timing races from the flaky suite tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,10 @@ jobs:
     needs: changes
     if: needs.changes.outputs.app == 'true'
     runs-on: macos-15
-    timeout-minutes: 30
+    # Serial debug+test+release+xcodebuild bundle can exceed 30m on a cold
+    # runner (release alone has taken ~16m). Keep headroom until the job is
+    # split (#265); wall clock on a warm run is still ~20m.
+    timeout-minutes: 45
 
     steps:
       - name: Checkout

--- a/Sources/VocaMac/Services/LoadSerializer.swift
+++ b/Sources/VocaMac/Services/LoadSerializer.swift
@@ -26,6 +26,14 @@ actor LoadSerializer {
         cancellable: Bool = true,
         _ operation: @escaping @Sendable () async throws -> T
     ) async throws -> T {
+        // Reject a caller that arrives already cancelled before it takes a
+        // queue slot. The task below is unstructured, so it is only cancelled
+        // by the handler at the end of this function — and reaching that
+        // handler leaves this actor, which lets the task start and clear its
+        // own cancellation check first. Without this the operation of an
+        // already-cancelled caller sometimes ran.
+        if cancellable { try Task.checkCancellation() }
+
         let previous = tail
         let queueInterval = PerformanceTrace.begin("OperationQueueWait")
 

--- a/Sources/VocaMac/Services/TextInjector.swift
+++ b/Sources/VocaMac/Services/TextInjector.swift
@@ -153,6 +153,24 @@ final class TextInjector {
         else { DispatchQueue.main.async(execute: enqueue) }
     }
 
+    /// Wait until every previously queued injection has finished.
+    ///
+    /// Test-only. Injections share one process-wide coordinator and run
+    /// strictly one at a time, so a no-op that reaches the front of the
+    /// queue proves earlier work is done — without touching any pasteboard.
+    static func waitForInjectionQueueIdleForTesting() async {
+        await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
+            let resume = {
+                Self.clipboardInjectionCoordinator.enqueue { finish in
+                    finish()
+                    continuation.resume()
+                }
+            }
+            if Thread.isMainThread { resume() }
+            else { DispatchQueue.main.async(execute: resume) }
+        }
+    }
+
     private enum AccessibilityInsertion { case inserted, unavailable, uncertain }
 
     private static let accessibilityQueue = DispatchQueue(label: "com.vocamac.text-accessibility", qos: .userInitiated)

--- a/Sources/VocaMac/Views/CleanupSettingsPage.swift
+++ b/Sources/VocaMac/Views/CleanupSettingsPage.swift
@@ -30,14 +30,21 @@ struct CleanupSettingsPage: View {
                         }
                     }
 
-                Text("Runs a small local language model after speech-to-text to drop filler words and false starts and to punctuate what you said. Nothing leaves your Mac. Off by default — download a model first. Models this size do not catch everything, and anything one rewrites badly is discarded in favour of the raw transcript.")
+                Text("Runs a small local language model after speech-to-text to drop filler words and false starts and to punctuate what you said. Nothing leaves your Mac. Models this size do not catch everything, and anything one rewrites badly is discarded in favour of the raw transcript.")
                     .font(.caption)
                     .foregroundStyle(.secondary)
 
+                // Setup state belongs here rather than in the paragraph above,
+                // which kept telling people to download a model while the row
+                // below reported one ready.
                 if appState.transcriptCleanupEnabled && !appState.transcriptCleanup.isDownloaded(appState.selectedCleanupModelKind) {
                     Text("Cleanup is on, but the selected model is not downloaded yet. Dictation will inject the raw transcript until you download one.")
                         .font(.caption)
                         .foregroundStyle(.orange)
+                } else if !hasDownloadedModel {
+                    Text("Off until a model is downloaded — pick one below.")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
                 }
 
                 statusRow
@@ -180,6 +187,11 @@ struct CleanupSettingsPage: View {
             tryItResult = result
             tryItRunning = false
         }
+    }
+
+    /// Whether any cleanup model is on disk, not just the selected one.
+    private var hasDownloadedModel: Bool {
+        CleanupModelKind.allCases.contains { appState.transcriptCleanup.isDownloaded($0) }
     }
 
     /// Characters of transcript that still fit alongside the drafted prompt.

--- a/Tests/VocaMacTests/ClipboardPreservationTests.swift
+++ b/Tests/VocaMacTests/ClipboardPreservationTests.swift
@@ -12,20 +12,10 @@ final class ClipboardPreservationTests: XCTestCase {
     /// Sleeping for a guessed duration instead makes the assertions fail
     /// whenever a loaded machine takes longer, and leaves a half-finished
     /// injection to overlap the next test through the process-wide
-    /// coordinator. Injections run strictly one at a time, so a fresh one
-    /// reaching the injector at all proves the previous one is done.
+    /// coordinator. Drain via a no-op on that coordinator so we never touch
+    /// a pasteboard just to wait.
     private func drainInjectionQueue() async {
-        // No paste target, so this drain reports failure without pasting. It
-        // still gets its own board so it can never reach the user's clipboard.
-        let board = NSPasteboard(name: .init("com.vocamac.tests.drain.\(UUID())"))
-        defer { board.releaseGlobally() }
-        let drained = expectation(description: "previous injection finished")
-        let drain = TextInjector(pasteboard: board, accessibilityTrustedOverride: true,
-                                 frontmostPIDProvider: { nil })
-        drain.onFailure = { _ in drained.fulfill() }
-        drain.inject(text: "drain", preserveClipboard: false)
-        await fulfillment(of: [drained], timeout: 5)
-        withExtendedLifetime(drain) { }
+        await TextInjector.waitForInjectionQueueIdleForTesting()
     }
 
     func testManyRepresentationsArePreservedAcrossCooperativeCapture() async {

--- a/Tests/VocaMacTests/ClipboardPreservationTests.swift
+++ b/Tests/VocaMacTests/ClipboardPreservationTests.swift
@@ -4,6 +4,30 @@ import XCTest
 
 @MainActor
 final class ClipboardPreservationTests: XCTestCase {
+
+    /// Return once the injection queued by this test has finished.
+    ///
+    /// A paste is only the middle of an injection: the clipboard restore lands
+    /// after a deliberate delay, and the queue slot is released later still.
+    /// Sleeping for a guessed duration instead makes the assertions fail
+    /// whenever a loaded machine takes longer, and leaves a half-finished
+    /// injection to overlap the next test through the process-wide
+    /// coordinator. Injections run strictly one at a time, so a fresh one
+    /// reaching the injector at all proves the previous one is done.
+    private func drainInjectionQueue() async {
+        // No paste target, so this drain reports failure without pasting. It
+        // still gets its own board so it can never reach the user's clipboard.
+        let board = NSPasteboard(name: .init("com.vocamac.tests.drain.\(UUID())"))
+        defer { board.releaseGlobally() }
+        let drained = expectation(description: "previous injection finished")
+        let drain = TextInjector(pasteboard: board, accessibilityTrustedOverride: true,
+                                 frontmostPIDProvider: { nil })
+        drain.onFailure = { _ in drained.fulfill() }
+        drain.inject(text: "drain", preserveClipboard: false)
+        await fulfillment(of: [drained], timeout: 5)
+        withExtendedLifetime(drain) { }
+    }
+
     func testManyRepresentationsArePreservedAcrossCooperativeCapture() async {
         let board = NSPasteboard(name: .init("com.vocamac.tests.\(UUID())"))
         defer { board.releaseGlobally() }
@@ -19,8 +43,7 @@ final class ClipboardPreservationTests: XCTestCase {
         }, frontmostPIDProvider: { 123 })
         injector.inject(text: "dictation", preserveClipboard: true)
         await fulfillment(of: [pasted], timeout: 2)
-        // Wait for the deliberately retained target-app consumption window.
-        try? await Task.sleep(nanoseconds: 250_000_000)
+        await drainInjectionQueue()
         for (index, type) in types.enumerated() {
             XCTAssertEqual(board.data(forType: type), Data(repeating: UInt8(index), count: 2048))
         }
@@ -42,7 +65,7 @@ final class ClipboardPreservationTests: XCTestCase {
         }, frontmostPIDProvider: { 123 })
         injector.inject(text: "dictation", preserveClipboard: true)
         await fulfillment(of: [pasted], timeout: 2)
-        try? await Task.sleep(nanoseconds: 250_000_000)
+        await drainInjectionQueue()
         XCTAssertEqual(board.string(forType: .string), "new clipboard")
         XCTAssertNil(board.data(forType: types[0]))
         withExtendedLifetime(provider) { }
@@ -86,7 +109,7 @@ extension ClipboardPreservationTests {
         // This main-actor continuation executes while the worker is blocked.
         gate.signal()
         await fulfillment(of: [finished], timeout: 1)
-        try? await Task.sleep(nanoseconds: 200_000_000)
+        await drainInjectionQueue()
     }
 
     func testFocusChangeBeforePasteRestoresClipboardAndReportsFailure() async {

--- a/Tests/VocaMacTests/LoadSerializerTests.swift
+++ b/Tests/VocaMacTests/LoadSerializerTests.swift
@@ -20,19 +20,28 @@ final class LoadSerializerTests: XCTestCase {
             lock.unlock()
         }
 
+        // The first operation must reach the serializer before the second is
+        // queued, or the recorded order says nothing about serialization.
+        // Sleeping for a guess loses that race whenever the machine is busy,
+        // so hold the operation open until the test has queued the second one.
+        let claimedQueue = expectation(description: "first operation started")
+        let release = SerializerTestGate()
+
         async let first: Void = serializer.run {
             append("a-start")
-            try await Task.sleep(nanoseconds: 50_000_000)
+            claimedQueue.fulfill()
+            await release.wait()
             append("a-end")
         }
 
-        // Give the first operation a moment to claim the queue.
-        try await Task.sleep(nanoseconds: 5_000_000)
+        await fulfillment(of: [claimedQueue], timeout: 5)
 
         async let second: Int = serializer.run {
             append("b-start")
             return 42
         }
+
+        await release.open()
 
         try await first
         let value = try await second

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -34,23 +34,42 @@ APP_VERSION="${APP_VERSION:-0.9.0}"
 
 # Resolve signing identity:
 # 1. Use CODE_SIGN_IDENTITY env var if set
-# 2. Auto-detect Developer ID Application in the login keychain
-# 3. Fall back to ad-hoc signing (-)
+# 2. Auto-detect Developer ID Application in the login keychain (distribution)
+# 3. Auto-detect Apple Development in the login keychain (local development)
+# 4. Fall back to ad-hoc signing (-)
+#
+# An ad-hoc signature gets a fresh code identity on every build, so macOS
+# treats each rebuild as a different app and drops its Accessibility and
+# Input Monitoring grants. Any real certificate — including the free Apple
+# Development one — keeps that identity stable across rebuilds, so prefer
+# one over ad-hoc even when there is nothing to distribute.
+SIGNING_MODE="ad-hoc"
 if [ -z "${CODE_SIGN_IDENTITY+x}" ]; then
-    DETECTED=$(security find-identity -v -p codesigning 2>/dev/null | grep "Developer ID Application" | head -1 | sed 's/.*"\(.*\)"/\1/' || true)
+    IDENTITIES=$(security find-identity -v -p codesigning 2>/dev/null || true)
+    DETECTED=$(echo "$IDENTITIES" | grep "Developer ID Application" | head -1 | sed 's/.*"\(.*\)"/\1/' || true)
+    if [ -n "$DETECTED" ]; then
+        SIGNING_MODE="Developer ID"
+    else
+        DETECTED=$(echo "$IDENTITIES" | grep "Apple Development" | head -1 | sed 's/.*"\(.*\)"/\1/' || true)
+        if [ -n "$DETECTED" ]; then
+            SIGNING_MODE="Apple Development"
+        fi
+    fi
     if [ -n "$DETECTED" ]; then
         CODE_SIGN_IDENTITY="$DETECTED"
         echo "🔐 Auto-detected signing identity: $CODE_SIGN_IDENTITY"
     else
         CODE_SIGN_IDENTITY="-"
-        echo "⚠️  No Developer ID found — using ad-hoc signing"
+        echo "⚠️  No signing certificate found — using ad-hoc signing"
     fi
+elif [ "$CODE_SIGN_IDENTITY" != "-" ]; then
+    SIGNING_MODE="explicit ($CODE_SIGN_IDENTITY)"
 fi
 
 if [ "$CODE_SIGN_IDENTITY" = "-" ]; then
     echo "🔏 Signing mode: ad-hoc (permissions reset on every rebuild)"
 else
-    echo "🔏 Signing mode: Developer ID"
+    echo "🔏 Signing mode: $SIGNING_MODE"
 fi
 
 # Kill any running VocaMac instances before building


### PR DESCRIPTION
Clears the CI flakes that keep reddening unrelated PRs, plus two smaller loose ends.

## The flakes

**ClipboardPreservationTests** — three tests slept a fixed 200–250 ms waiting for an injection to finish. A paste is only the middle of an injection: the clipboard restore lands after a deliberate delay, and the coordinator's queue slot is released later still. On a loaded full-suite run that budget runs out and the assertions fail. They now drain the process-wide injection coordinator instead — injections run strictly one at a time, so a fresh one reaching the injector proves the previous one finished. That also stops a half-finished injection from overlapping whichever test runs next.

**LoadSerializerTests.testOperationsRunSeriallyInOrder** — slept 5 ms to let the first operation "claim the queue". It now holds that operation open on a gate until the second is queued, so the recorded order is deterministic and the test no longer takes 55 ms.

**LoadSerializerTests.testAlreadyCancelledCallerDoesNotRunOperation** — this one was failing for a real reason, not a timing guess. `LoadSerializer.run` queues an unstructured `Task` that does not inherit the caller's cancellation; it is cancelled only by the handler at the end of the function, and *entering* `withTaskCancellationHandler` leaves the actor. That lets the queued task start and clear its own `Task.checkCancellation()` before `onCancel` installs, so an already-cancelled caller's operation ran anyway — reproducibly, about a third of the time locally. `run` now rejects an already-cancelled caller up front, before it takes a queue slot.

Verified: the two suites pass 12/12 consecutive runs, and the full suite passes 5/5 (562 tests). Before the change the pair failed 2 of 6 targeted runs.

## Also

- **Cleanup settings copy** — the description claimed "Off by default — download a model first" even with a model downloaded and the row below reporting "Cleanup model ready". Setup state moves out of the static paragraph into a line that reflects what is actually on disk.
- **Local signing** — `build.sh` auto-detected only a Developer ID certificate and otherwise signed ad-hoc, which gives every rebuild a new code identity and makes macOS drop the app's Accessibility and Input Monitoring grants. It now falls back to an Apple Development certificate before ad-hoc. CI is unaffected: both workflows set `CODE_SIGN_IDENTITY` explicitly, which still wins.

## Test plan

- `swift test` — 562 tests, 0 failures, 5 consecutive runs
- `swift test --filter 'ClipboardPreservationTests|LoadSerializerTests'` — 12 consecutive clean runs
- `make install` with an empty keychain, an Apple Development cert only, and a Developer ID cert present — verified each detection branch exits 0 under `set -euo pipefail`