### PR TITLE
ci: split the app job into three parallel jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,13 +38,19 @@ jobs:
             web:
               - 'web/**'
 
-  # Build and test Swift app (only when app source changes)
-  build-and-test:
-    name: Build & Test App
+  # ── App jobs ────────────────────────────────────────────────────────────────
+  #
+  # These three ran as one 20-minute serial job. They share no output with each
+  # other — SPM debug, SPM release and the xcodebuild app bundle each compile
+  # into their own directory — so running them on separate runners cuts the
+  # wall clock to the slowest one without losing any coverage.
+
+  test:
+    name: Test (Debug)
     needs: changes
     if: needs.changes.outputs.app == 'true'
     runs-on: macos-15
-    timeout-minutes: 30
+    timeout-minutes: 25
 
     steps:
       - name: Checkout
@@ -54,9 +60,9 @@ jobs:
         uses: actions/cache@v5
         with:
           path: .build
-          key: spm-${{ runner.os }}-${{ hashFiles('Package.resolved') }}
+          key: spm-debug-${{ runner.os }}-${{ hashFiles('Package.swift') }}
           restore-keys: |
-            spm-${{ runner.os }}-
+            spm-debug-${{ runner.os }}-
 
       - name: Select Xcode 26
         run: ./scripts/select-xcode-26.sh
@@ -67,8 +73,52 @@ jobs:
       - name: Test
         run: swift test
 
+  release-build:
+    name: Build (Release)
+    needs: changes
+    if: needs.changes.outputs.app == 'true'
+    runs-on: macos-15
+    timeout-minutes: 25
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Cache SPM dependencies
+        uses: actions/cache@v5
+        with:
+          path: .build
+          key: spm-release-${{ runner.os }}-${{ hashFiles('Package.swift') }}
+          restore-keys: |
+            spm-release-${{ runner.os }}-
+
+      - name: Select Xcode 26
+        run: ./scripts/select-xcode-26.sh
+
       - name: Build (Release)
         run: swift build -c release
+
+  app-bundle:
+    name: Verify App Bundle
+    needs: changes
+    if: needs.changes.outputs.app == 'true'
+    runs-on: macos-15
+    timeout-minutes: 30
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Cache Xcode build
+        uses: actions/cache@v5
+        with:
+          path: .xcode-build/SourcePackages
+          key: xcode-deps-${{ runner.os }}-${{ hashFiles('Package.swift') }}
+          restore-keys: |
+            xcode-deps-${{ runner.os }}-
+
+      - name: Select Xcode 26
+        run: ./scripts/select-xcode-26.sh
 
       - name: Initialize Xcode tools
         run: sudo xcodebuild -runFirstLaunch
@@ -110,3 +160,24 @@ jobs:
       - name: Validate CSS
         working-directory: web
         run: npx --yes stylelint static/style.css
+
+  # Single pass/fail signal for the whole workflow. A path-filtered job that
+  # did not run reports "skipped", which is a pass — only a real failure or a
+  # cancellation fails the gate. Point branch protection at this one check
+  # instead of tracking each job above.
+  ci:
+    name: CI
+    needs: [changes, test, release-build, app-bundle, build-website]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check job results
+        env:
+          RESULTS: ${{ toJSON(needs) }}
+        run: |
+          echo "$RESULTS"
+          if echo "$RESULTS" | grep -qE '"result"[[:space:]]*:[[:space:]]*"(failure|cancelled)"'; then
+            echo "❌ At least one job did not pass."
+            exit 1
+          fi
+          echo "✅ All jobs passed or were skipped."

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,8 +35,14 @@ jobs:
               - 'scripts/**'
               - 'Makefile'
               - 'VocaMac.entitlements'
+              # A change to this workflow must exercise the jobs it defines,
+              # or a CI edit merges having proven nothing. Scoped to this file
+              # so editing an unrelated workflow does not book three macOS
+              # runners.
+              - '.github/workflows/ci.yml'
             web:
               - 'web/**'
+              - '.github/workflows/ci.yml'
 
   # ── App jobs ────────────────────────────────────────────────────────────────
   #


### PR DESCRIPTION
`Build & Test App` did four things in one serial job. Measured on the last green run on `main` ([34266468713](https://github.com/VocaHQ/vocamac/actions/runs/34266468713)), that job took **20m45s**:

| Step | Time |
|---|---|
| Build (Debug) | 3m58s |
| Test | 57s |
| Build (Release) | 6m51s |
| Verify app bundle | 8m28s |
| setup / checkout / cache / Xcode select | 19s |

Nothing in that chain consumes the previous step's output. SPM debug builds into `.build`, SPM release builds into `.build` under a different config, and `scripts/build.sh` drives **xcodebuild** into `.xcode-build` — three independent compiles that happened to share a runner. Splitting them means the workflow finishes with the slowest job rather than the sum.

## Jobs

| Job | Runner | Was | Now |
|---|---|---|---|
| `Test (Debug)` | macos-15 | part of the 20m job | ~5m |
| `Build (Release)` | macos-15 | part of the 20m job | ~7m |
| `Verify App Bundle` | macos-15 | part of the 20m job | ~9m |
| `Build Website` | ubuntu | 29s | 29s (unchanged) |
| `CI` | ubuntu | — | aggregate gate |

**Wall clock: ~20m45s → ~9m.** Total runner minutes are roughly unchanged — the same compiles happen, just concurrently, plus about a minute of extra per-job setup. No coverage is dropped: every command that ran before still runs.

## Two bugs found on the way

**The SPM cache has been frozen since it was first written.** The key was `spm-${{ runner.os }}-${{ hashFiles('Package.resolved') }}`, but `Package.resolved` is gitignored and not committed, so `hashFiles` returns an empty string and every run has shared the constant key `spm-macOS-`. `actions/cache` only writes on a miss, so after the very first run the cache could never be updated — the repo currently holds exactly one 0.29 GB entry, keyed `spm-macOS-`, which has never refreshed and cannot pick up a dependency change. The key now hashes `Package.swift`, where versions are actually pinned (per the comment in `build.sh`), and each job gets its own prefix so the three don't collide.

**`Initialize Xcode tools` ran after both Swift builds**, which is fine but only matters for `xcodebuild`; it now sits in the bundle job where it's actually needed.

## The `CI` gate job

With path filtering, a job that correctly skips reports `skipped`, which reads as "missing" to branch protection. The `CI` job aggregates the results — skipped is a pass, only `failure`/`cancelled` fail. `main` is not currently protected, so nothing breaks today; if protection is added later, point it at this single check rather than five.

## Test plan

- `actionlint .github/workflows/ci.yml` — clean
- YAML parses; job graph is `changes → {test, release-build, app-bundle, build-website} → ci`
- Gate logic exercised against five `needs` payloads: all-success, web-skipped, app-jobs-skipped, one-failure, one-cancelled — passes the first three, fails the last two
- `scripts/build.sh release` confirmed independent of `.build` (it drives xcodebuild into `.xcode-build`), so the bundle job needs no prior `swift build`

Timings above are from the referenced run; the real numbers will show on this PR.