### PR TITLE
feat: share stats to X and LinkedIn

### DIFF
--- a/Sources/VocaMac/Models/SettingsSearchIndex.swift
+++ b/Sources/VocaMac/Models/SettingsSearchIndex.swift
@@ -217,7 +217,7 @@ enum SettingsSearchIndex {
             id: "stats",
             page: .stats,
             title: "Usage Stats",
-            keywords: ["streak", "words", "history"]
+            keywords: ["streak", "words", "history", "share", "social", "linkedin"]
         ),
         SettingsSearchEntry(
             id: "logs",

--- a/Sources/VocaMac/Models/StatsShareDestination.swift
+++ b/Sources/VocaMac/Models/StatsShareDestination.swift
@@ -1,0 +1,149 @@
+// StatsShareDestination.swift
+// VocaMac
+//
+// Social destinations for sharing the stats card, plus the post text
+// and composer URL each one gets.
+
+import Foundation
+
+/// A place the user can post their stats card to.
+///
+/// Web share intents cannot carry an attachment, so the flow copies the
+/// rendered card to the clipboard and opens the destination's composer
+/// with prefilled text for the user to paste the image into.
+enum StatsShareDestination: String, CaseIterable, Identifiable {
+    case x
+    case linkedIn
+
+    var id: String { rawValue }
+
+    /// Menu label. X is X, not Twitter.
+    var displayName: String {
+        switch self {
+        case .x: return "X"
+        case .linkedIn: return "LinkedIn"
+        }
+    }
+
+    /// How VocaMac refers to itself on this network, or `nil` where it has no
+    /// account to point at. VocaMac has no LinkedIn page, so a LinkedIn post
+    /// signs off with the site alone rather than a handle that resolves to 404.
+    var handle: String? {
+        switch self {
+        case .x: return "@vocahq"
+        case .linkedIn: return nil
+        }
+    }
+}
+
+/// Builds the post text and composer URL for a stats share.
+enum StatsShareComposer {
+    static let siteURL = "https://vocamac.com"
+
+    /// The post body is hardcoded English, so its numbers and units are pinned
+    /// to English too. Without this a German user posts "2.500 Stunden of
+    /// talking", and the grouping separator varies by locale ("12,500" vs
+    /// "12.500" vs "12 500"). `en_US` rather than `en_US_POSIX`, which drops
+    /// grouping separators entirely ("12500").
+    private static let postLocale = Locale(identifier: "en_US")
+
+    private static let countFormatter: NumberFormatter = {
+        let formatter = NumberFormatter()
+        formatter.numberStyle = .decimal
+        formatter.locale = postLocale
+        return formatter
+    }()
+
+    private static let durationFormatter: DateComponentsFormatter = {
+        let formatter = DateComponentsFormatter()
+        formatter.allowedUnits = [.hour, .minute]
+        formatter.unitsStyle = .full
+        formatter.zeroFormattingBehavior = .dropAll
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.locale = postLocale
+        formatter.calendar = calendar
+        return formatter
+    }()
+
+    /// Shortest duration the post will mention. `.dropAll` does not blank a
+    /// zero duration — it falls back to the smallest allowed unit — so anything
+    /// under a minute has to be filtered out here instead.
+    private static let minimumReportedDuration: Double = 60
+
+    /// The post body. Kept short enough for X's 280-character limit.
+    static func message(for snapshot: StatsShareSnapshot, destination: StatsShareDestination) -> String {
+        var lines = [
+            "🎤 \(pluralized(snapshot.totalWords, "word")) talked into my Mac with VocaMac.",
+            statLine(for: snapshot),
+            "Every model runs on my Mac. Works fully offline, no audio ever leaves it. 🔒",
+            [destination.handle, siteURL].compactMap { $0 }.joined(separator: " · ")
+        ]
+        lines.removeAll { $0.isEmpty }
+        return lines.joined(separator: "\n\n")
+    }
+
+    /// Composer URL with the message prefilled, or `nil` if it cannot be encoded.
+    static func composerURL(for snapshot: StatsShareSnapshot, destination: StatsShareDestination) -> URL? {
+        let text = message(for: snapshot, destination: destination)
+        switch destination {
+        case .x:
+            return url("https://x.com/intent/post", query: [("text", text)])
+        case .linkedIn:
+            // `share-offsite` only accepts a URL; the feed composer is the one
+            // LinkedIn surface that still prefills body text.
+            return url(
+                "https://www.linkedin.com/feed/",
+                query: [("shareActive", "true"), ("text", text)]
+            )
+        }
+    }
+
+    /// Unreserved set from RFC 3986. Everything else in a value is escaped so
+    /// `&`, `+` and `;` inside the post text cannot act as query separators.
+    private static let valueAllowed = CharacterSet(charactersIn:
+        "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-._~")
+
+    static func url(_ base: String, query: [(name: String, value: String)]) -> URL? {
+        guard var components = URLComponents(string: base) else { return nil }
+        let encoded = query.compactMap { item -> String? in
+            guard let value = item.value.addingPercentEncoding(withAllowedCharacters: valueAllowed) else {
+                return nil
+            }
+            return "\(item.name)=\(value)"
+        }
+        guard encoded.count == query.count else { return nil }
+        components.percentEncodedQuery = encoded.joined(separator: "&")
+        return components.url
+    }
+
+    /// The middle line: whichever secondary stats the user actually has.
+    private static func statLine(for snapshot: StatsShareSnapshot) -> String {
+        var parts: [String] = []
+        if snapshot.totalTranscriptions > 0 {
+            parts.append("📊 \(pluralized(snapshot.totalTranscriptions, "session"))")
+        }
+        if snapshot.totalAudioDurationSeconds >= minimumReportedDuration,
+           let duration = durationFormatter.string(from: snapshot.totalAudioDurationSeconds),
+           !duration.isEmpty {
+            parts.append("⏱️ \(duration) of talking")
+        }
+        if snapshot.averageWPM > 0 {
+            parts.append(String(format: "⚡️ %.0f WPM", snapshot.averageWPM))
+        }
+        if snapshot.currentStreak > 0 {
+            parts.append("🔥 \(snapshot.currentStreak)-day streak")
+        }
+        return parts.isEmpty ? "" : parts.joined(separator: " · ")
+    }
+
+    /// "1 session", not "1 sessions" — the post is public.
+    private static func pluralized(_ count: Int, _ noun: String) -> String {
+        "\(formatCount(count)) \(count == 1 ? noun : noun + "s")"
+    }
+
+    /// Grouped count, shared with the card image so the pasted picture and the
+    /// post text never disagree ("12,500" next to "12500").
+    static func formatCount(_ value: Int) -> String {
+        countFormatter.string(from: NSNumber(value: value)) ?? "\(value)"
+    }
+}

--- a/Sources/VocaMac/Views/StatsSettingsTab.swift
+++ b/Sources/VocaMac/Views/StatsSettingsTab.swift
@@ -8,7 +8,21 @@ import SwiftUI
 struct StatsSettingsTab: View {
     @EnvironmentObject var appState: AppState
     @State private var showingResetConfirmation = false
-    @State private var shareCopied = false
+    @State private var shareState: ShareState = .idle
+    /// Bumped on every share state change so a pending reset can only clear the
+    /// state it was scheduled for. Keying the reset on the destination let a
+    /// second share to the same network inherit the first one's countdown.
+    @State private var shareStateToken = 0
+
+    /// One state rather than two independent flags: "Copied!" and "Opening X…"
+    /// are mutually exclusive, and a copy made during an open share window used
+    /// to go unacknowledged.
+    private enum ShareState: Equatable {
+        case idle
+        case copied
+        case opened(StatsShareDestination, cardCopied: Bool)
+        case failed(String)
+    }
 
     private static let durationFormatter: DateComponentsFormatter = {
         let formatter = DateComponentsFormatter()
@@ -43,35 +57,34 @@ struct StatsSettingsTab: View {
                             Label("Lifetime Totals", systemImage: "chart.bar.fill")
                                 .font(.headline)
                             Spacer()
-                            Button {
-                                let snapshot = StatsShareSnapshot.from(appState.statsManager.stats)
-                                if StatsShareExporter.copyImage(toClipboard: snapshot) {
-                                    shareCopied = true
-                                    DispatchQueue.main.asyncAfter(deadline: .now() + 2) {
-                                        shareCopied = false
+                            Menu {
+                                ForEach(StatsShareDestination.allCases) { destination in
+                                    Button("Share on \(destination.displayName)") {
+                                        share(to: destination)
                                     }
                                 }
+                                Divider()
+                                Button("Copy Card Image") { copyCardImage() }
                             } label: {
-                                Label(
-                                    shareCopied ? "Copied!" : "Share",
-                                    systemImage: shareCopied ? "checkmark" : "square.and.arrow.up"
-                                )
+                                Label(shareLabel, systemImage: shareIcon)
                             }
+                            .menuStyle(.borderlessButton)
+                            .fixedSize()
                             .controlSize(.small)
-                            .help("Copy a stats card image to the clipboard")
+                            .help("Post your stats card, or copy it to the clipboard")
                         }
 
                         HStack(spacing: 0) {
                             StatPill(
-                                icon: "text.wordspacing",
+                                icon: "text.word.spacing",
                                 label: "Total Words",
-                                value: "\(appState.statsManager.stats.totalWords)",
+                                value: StatsShareComposer.formatCount(appState.statsManager.stats.totalWords),
                                 color: .blue
                             )
                             StatPill(
                                 icon: "waveform",
                                 label: "Transcriptions",
-                                value: "\(appState.statsManager.stats.totalTranscriptions)",
+                                value: StatsShareComposer.formatCount(appState.statsManager.stats.totalTranscriptions),
                                 color: .purple
                             )
                             StatPill(
@@ -81,7 +94,15 @@ struct StatsSettingsTab: View {
                                 color: .orange
                             )
                         }
+
+                        if let note = shareNote {
+                            Label(note.text, systemImage: note.icon)
+                                .font(.caption)
+                                .foregroundStyle(note.isError ? Color.red : Color.secondary)
+                                .transition(.opacity)
+                        }
                     }
+                    .animation(.easeInOut(duration: 0.2), value: shareState)
                     .padding(8)
                 }
 
@@ -180,6 +201,78 @@ struct StatsSettingsTab: View {
         } message: {
             Text("This permanently deletes all your usage statistics. This action cannot be undone.")
         }
+    }
+
+    private var shareLabel: String {
+        switch shareState {
+        case .idle, .failed: return "Share"
+        case .copied: return "Copied!"
+        case .opened(let destination, _): return "Opening \(destination.displayName)…"
+        }
+    }
+
+    private var shareIcon: String {
+        switch shareState {
+        case .idle: return "square.and.arrow.up"
+        case .copied, .opened: return "checkmark"
+        case .failed: return "exclamationmark.triangle"
+        }
+    }
+
+    /// The line under the pills. Never claims the card is on the clipboard
+    /// unless it is: the user pastes whatever is there into a public post.
+    private var shareNote: (text: String, icon: String, isError: Bool)? {
+        switch shareState {
+        case .idle, .copied:
+            return nil
+        case .opened(let destination, let cardCopied):
+            guard cardCopied else {
+                return (
+                    "Couldn't copy the card image, so your \(destination.displayName) post has the text only.",
+                    "exclamationmark.triangle",
+                    true
+                )
+            }
+            return (
+                "Card copied! Just paste it into your \(destination.displayName) post.",
+                "doc.on.clipboard",
+                false
+            )
+        case .failed(let message):
+            return (message, "exclamationmark.triangle", true)
+        }
+    }
+
+    private func setShareState(_ state: ShareState, clearingAfter seconds: Double) {
+        shareStateToken += 1
+        let token = shareStateToken
+        shareState = state
+        DispatchQueue.main.asyncAfter(deadline: .now() + seconds) {
+            if shareStateToken == token { shareState = .idle }
+        }
+    }
+
+    /// Social composers cannot take an attachment, so the card lands on the
+    /// clipboard and the user pastes it into the prefilled post.
+    private func share(to destination: StatsShareDestination) {
+        let snapshot = StatsShareSnapshot.from(appState.statsManager.stats)
+        switch StatsShareExporter.share(snapshot, to: destination) {
+        case .shared:
+            setShareState(.opened(destination, cardCopied: true), clearingAfter: 4)
+        case .sharedWithoutCard:
+            setShareState(.opened(destination, cardCopied: false), clearingAfter: 6)
+        case .failed:
+            setShareState(.failed("Couldn't open \(destination.displayName)."), clearingAfter: 6)
+        }
+    }
+
+    private func copyCardImage() {
+        let snapshot = StatsShareSnapshot.from(appState.statsManager.stats)
+        guard StatsShareExporter.copyImage(toClipboard: snapshot) else {
+            setShareState(.failed("Couldn't copy the card image."), clearingAfter: 6)
+            return
+        }
+        setShareState(.copied, clearingAfter: 2)
     }
 
     private func formatDuration(_ seconds: Double) -> String {

--- a/Sources/VocaMac/Views/StatsShareCard.swift
+++ b/Sources/VocaMac/Views/StatsShareCard.swift
@@ -1,7 +1,8 @@
 // StatsShareCard.swift
 // VocaMac
 //
-// Branded stats card rendered to an image and copied to the clipboard.
+// Branded stats card rendered to an image, copied to the clipboard and
+// optionally posted to a social composer.
 // Forced dark appearance so clipboard shares match the in-app Stats look.
 
 import AppKit
@@ -40,6 +41,9 @@ struct StatsShareCard: View {
         formatter.allowedUnits = [.hour, .minute]
         formatter.unitsStyle = .abbreviated
         formatter.zeroFormattingBehavior = .dropAll
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.locale = Locale(identifier: "en_US")
+        formatter.calendar = calendar
         return formatter
     }()
 
@@ -59,8 +63,16 @@ struct StatsShareCard: View {
             }
 
             HStack(spacing: 10) {
-                shareMetric(title: "Words", value: "\(snapshot.totalWords)", accent: .blue)
-                shareMetric(title: "Sessions", value: "\(snapshot.totalTranscriptions)", accent: .purple)
+                shareMetric(
+                    title: "Words",
+                    value: StatsShareComposer.formatCount(snapshot.totalWords),
+                    accent: .blue
+                )
+                shareMetric(
+                    title: "Sessions",
+                    value: StatsShareComposer.formatCount(snapshot.totalTranscriptions),
+                    accent: .purple
+                )
                 shareMetric(
                     title: "Time",
                     value: Self.durationFormatter.string(from: snapshot.totalAudioDurationSeconds) ?? "0m",
@@ -123,6 +135,17 @@ struct StatsShareCard: View {
     }
 }
 
+/// What `StatsShareExporter.share` managed to do, so the UI can tell the user
+/// whether the card is actually on the clipboard.
+enum StatsShareOutcome: Equatable {
+    /// Composer opened and the card image is on the clipboard.
+    case shared
+    /// Composer opened, but the card image could not be copied.
+    case sharedWithoutCard
+    /// Nothing opened.
+    case failed
+}
+
 enum StatsShareExporter {
     /// Renders the branded card and copies a PNG to the general pasteboard.
     @MainActor
@@ -140,5 +163,33 @@ enum StatsShareExporter {
         let pasteboard = NSPasteboard.general
         pasteboard.clearContents()
         return pasteboard.setData(png, forType: .png)
+    }
+
+    /// Copies the card image, then opens the destination's composer with the
+    /// post text prefilled so the user can paste the image in.
+    ///
+    /// Web share intents cannot carry an attachment, so the clipboard copy is
+    /// how the image gets there. A failed copy is reported separately rather
+    /// than folded into success: telling the user to paste when the clipboard
+    /// still holds their previous content would put that content in a public
+    /// post.
+    @MainActor
+    static func share(_ snapshot: StatsShareSnapshot, to destination: StatsShareDestination) -> StatsShareOutcome {
+        guard let url = StatsShareComposer.composerURL(for: snapshot, destination: destination) else {
+            VocaLogger.error(.general, "Stats share: could not build a \(destination.displayName) composer URL")
+            return .failed
+        }
+
+        let copiedImage = copyImage(toClipboard: snapshot)
+        if !copiedImage {
+            VocaLogger.warning(.general, "Stats share: card image could not be copied")
+        }
+
+        guard NSWorkspace.shared.open(url) else {
+            VocaLogger.error(.general, "Stats share: could not open the \(destination.displayName) composer")
+            return .failed
+        }
+
+        return copiedImage ? .shared : .sharedWithoutCard
     }
 }

--- a/Tests/VocaMacTests/StatsShareCardTests.swift
+++ b/Tests/VocaMacTests/StatsShareCardTests.swift
@@ -21,4 +21,187 @@ final class StatsShareCardTests: XCTestCase {
         XCTAssertEqual(snapshot.currentStreak, 3)
         XCTAssertEqual(snapshot.bestStreak, 12)
     }
+
+    // MARK: - Share message
+
+    private func makeSnapshot() -> StatsShareSnapshot {
+        StatsShareSnapshot(
+            totalWords: 12_500,
+            totalTranscriptions: 42,
+            totalAudioDurationSeconds: 3600,
+            averageWPM: 138,
+            currentStreak: 7,
+            bestStreak: 12
+        )
+    }
+
+    func testMessageIncludesHeadlineStatsAndHandle() {
+        let message = StatsShareComposer.message(for: makeSnapshot(), destination: .x)
+
+        XCTAssertTrue(message.contains("12,500 words"), message)
+        XCTAssertTrue(message.contains("42 sessions"), message)
+        XCTAssertTrue(message.contains("138 WPM"), message)
+        XCTAssertTrue(message.contains("7-day streak"), message)
+        XCTAssertTrue(message.contains("@vocahq"), message)
+        XCTAssertTrue(message.contains(StatsShareComposer.siteURL), message)
+    }
+
+    /// VocaMac has no LinkedIn account, so a LinkedIn post must not sign off
+    /// with a handle at all rather than one that 404s.
+    func testMessageOmitsHandleWhereThereIsNoAccount() {
+        let message = StatsShareComposer.message(for: makeSnapshot(), destination: .linkedIn)
+
+        XCTAssertFalse(message.contains("@vocahq"), message)
+        XCTAssertFalse(message.lowercased().contains("linkedin.com"), message)
+        XCTAssertTrue(message.hasSuffix(StatsShareComposer.siteURL), message)
+    }
+
+    /// X weighs most emoji as 2 units and normalizes every URL to 23, so
+    /// `String.count` is not the metric X enforces.
+    private func xPostLength(_ message: String) -> Int {
+        let withoutURL = message.replacingOccurrences(of: StatsShareComposer.siteURL, with: "")
+        let weighted = withoutURL.unicodeScalars.reduce(0) { total, scalar in
+            switch scalar.value {
+            case 0...4351, 8192...8205, 8208...8223, 8242...8247:
+                return total + 1
+            default:
+                return total + 2
+            }
+        }
+        return weighted + 23
+    }
+
+    func testMessageFitsWithinXPostLimit() {
+        let snapshot = StatsShareSnapshot(
+            totalWords: 987_654_321,
+            totalTranscriptions: 123_456,
+            totalAudioDurationSeconds: 9_000_000,
+            averageWPM: 999,
+            currentStreak: 4321,
+            bestStreak: 5000
+        )
+
+        let message = StatsShareComposer.message(for: snapshot, destination: .x)
+        XCTAssertLessThanOrEqual(xPostLength(message), 280, message)
+    }
+
+    func testMessageOmitsEmptyStats() {
+        let message = StatsShareComposer.message(for: StatsShareSnapshot.from(UserStats()), destination: .x)
+
+        XCTAssertTrue(message.contains("0 words"), message)
+        XCTAssertFalse(message.contains("sessions"), message)
+        XCTAssertFalse(message.contains("WPM"), message)
+        XCTAssertFalse(message.contains("streak"), message)
+        // `.dropAll` renders a zero duration as "0 minutes", not "", so the
+        // clause has to be filtered out on the value.
+        XCTAssertFalse(message.contains("talking"), message)
+        XCTAssertFalse(message.contains("\n\n\n"), message)
+    }
+
+    func testMessageOmitsDurationUnderOneMinute() {
+        var stats = UserStats()
+        stats.totalWords = 40
+        stats.totalTranscriptions = 1
+        stats.totalAudioDurationSeconds = 30
+
+        let message = StatsShareComposer.message(for: StatsShareSnapshot.from(stats), destination: .x)
+
+        XCTAssertFalse(message.contains("talking"), message)
+        XCTAssertFalse(message.contains("0 minutes"), message)
+        XCTAssertTrue(message.contains("1 session"), message)
+        XCTAssertFalse(message.contains("1 sessions"), message)
+    }
+
+    func testMessageIncludesDurationFromOneMinute() {
+        var stats = UserStats()
+        stats.totalWords = 100
+        stats.totalAudioDurationSeconds = 60
+
+        let message = StatsShareComposer.message(for: StatsShareSnapshot.from(stats), destination: .x)
+
+        XCTAssertTrue(message.contains("1 minute of talking"), message)
+    }
+
+    /// The copy around these numbers is hardcoded English, so the numbers and
+    /// units must not follow the user's locale ("12.500", "2.500 Stunden").
+    func testMessageNumbersDoNotFollowTheUserLocale() {
+        var stats = UserStats()
+        stats.totalWords = 12_500
+        stats.totalAudioDurationSeconds = 9_000
+
+        let message = StatsShareComposer.message(for: StatsShareSnapshot.from(stats), destination: .x)
+
+        XCTAssertTrue(message.contains("12,500 words"), message)
+        XCTAssertTrue(message.contains("2 hours, 30 minutes of talking"), message)
+    }
+
+    // MARK: - Composer URLs
+
+    func testComposerURLForX() throws {
+        let url = try XCTUnwrap(StatsShareComposer.composerURL(for: makeSnapshot(), destination: .x))
+        let components = try XCTUnwrap(URLComponents(url: url, resolvingAgainstBaseURL: false))
+
+        XCTAssertEqual(components.host, "x.com")
+        XCTAssertEqual(components.path, "/intent/post")
+        XCTAssertEqual(
+            components.queryItems?.first(where: { $0.name == "text" })?.value,
+            StatsShareComposer.message(for: makeSnapshot(), destination: .x)
+        )
+    }
+
+    func testComposerURLForLinkedIn() throws {
+        let url = try XCTUnwrap(StatsShareComposer.composerURL(for: makeSnapshot(), destination: .linkedIn))
+        let components = try XCTUnwrap(URLComponents(url: url, resolvingAgainstBaseURL: false))
+
+        XCTAssertEqual(components.host, "www.linkedin.com")
+        XCTAssertEqual(components.path, "/feed/")
+        XCTAssertEqual(components.queryItems?.first(where: { $0.name == "shareActive" })?.value, "true")
+        XCTAssertEqual(
+            components.queryItems?.first(where: { $0.name == "text" })?.value,
+            StatsShareComposer.message(for: makeSnapshot(), destination: .linkedIn)
+        )
+    }
+
+    func testComposerURLPercentEncodesSeparatorsInsideValues() throws {
+        let snapshot = makeSnapshot()
+        let url = try XCTUnwrap(StatsShareComposer.composerURL(for: snapshot, destination: .linkedIn))
+        let components = try XCTUnwrap(URLComponents(url: url, resolvingAgainstBaseURL: false))
+        let query = try XCTUnwrap(components.percentEncodedQuery)
+
+        // One `&` per param boundary, none from the post text itself.
+        XCTAssertEqual(query.filter { $0 == "&" }.count, 1, query)
+        XCTAssertFalse(query.contains("+"), query)
+
+        // Text containing separators still round-trips intact.
+        XCTAssertEqual(
+            components.queryItems?.first(where: { $0.name == "text" })?.value,
+            StatsShareComposer.message(for: snapshot, destination: .linkedIn)
+        )
+    }
+
+    func testEveryDestinationHasLabelAndComposerURL() {
+        for destination in StatsShareDestination.allCases {
+            XCTAssertFalse(destination.displayName.isEmpty)
+            XCTAssertNotEqual(destination.handle, "", "\(destination) has an empty handle; use nil instead")
+            XCTAssertNotNil(StatsShareComposer.composerURL(for: makeSnapshot(), destination: destination))
+        }
+    }
+
+    /// The encoder's actual guarantee, exercised with separators the generated
+    /// post text does not happen to contain.
+    func testEncoderEscapesSeparatorsInsideValues() throws {
+        let hostile = "a&b+c;d=e?f #g"
+        let url = try XCTUnwrap(
+            StatsShareComposer.url("https://x.com/intent/post", query: [("text", hostile), ("via", "vocahq")])
+        )
+        let components = try XCTUnwrap(URLComponents(url: url, resolvingAgainstBaseURL: false))
+        let query = try XCTUnwrap(components.percentEncodedQuery)
+
+        // One `&` per param boundary, none leaking out of the value.
+        XCTAssertEqual(query.filter { $0 == "&" }.count, 1, query)
+        XCTAssertFalse(query.contains("+"), query)
+        XCTAssertFalse(query.contains(";"), query)
+        XCTAssertEqual(components.queryItems?.first(where: { $0.name == "text" })?.value, hostile)
+        XCTAssertEqual(components.queryItems?.first(where: { $0.name == "via" })?.value, "vocahq")
+    }
 }


### PR DESCRIPTION
## What

The Stats tab's **Share** button is now a menu: **Share on X**, **Share on LinkedIn**, and **Copy Card Image** (the old behaviour).

Picking a network copies the rendered stats card to the clipboard and opens that network's composer with a post prefilled, e.g.

> I've spoken 12,500 words into my Mac with VocaMac.
>
> 42 sessions · 1 hour of talking · 138 WPM · a 7-day streak
>
> Fast, private, on-device dictation — no audio ever leaves the machine.
>
> @vocahq · https://vocamac.com

The stat line only lists stats the user actually has, and the whole message stays inside X's 280-character limit even at absurd values (covered by a test).

Web share intents can't carry an attachment, so the clipboard copy is how the image gets there — the tab shows "Card image copied — paste it into your … post." for a few seconds after the composer opens.

Composer endpoints:

- X — `https://x.com/intent/post?text=…`
- LinkedIn — `https://www.linkedin.com/feed/?shareActive=true&text=…` (`share-offsite` only accepts a URL; the feed composer is the one LinkedIn surface that still prefills body text)

Query values are percent-encoded against the RFC 3986 unreserved set, so `&`, `+` and `;` in the post text can't act as separators. A first cut escaped the whole query string and merged LinkedIn's two params into one — the test now pins that.

## Bug fix

The **Total Words** pill rendered with no icon. `text.wordspacing` is not an SF Symbol name, and `Image(systemName:)` draws nothing for an unknown symbol. Fixed to `text.word.spacing`, and `StatPill` now resolves the name through `NSImage(systemSymbolName:)` with a fallback so a bad name can't silently blank a pill again on an older macOS.

## Test plan

- `swift test` — 570 tests, 0 failures
- New `StatsShareCardTests` cases cover message content per destination, the X length limit, omission of empty stats, both composer URLs, and separator encoding