### PR TITLE
fix: harden usage statistics

### DIFF
--- a/Sources/VocaMac/Models/AppState.swift
+++ b/Sources/VocaMac/Models/AppState.swift
@@ -795,6 +795,21 @@ final class AppState: ObservableObject {
         NotificationCenter.default.publisher(for: NSApplication.willTerminateNotification)
             .sink { [weak self] _ in
                 self?.audioDucker.restore()
+                self?.statsManager.flushPendingSaves()
+            }
+            .store(in: &cancellables)
+
+        // `currentStreak` is a cached, persisted value. Refresh it when the
+        // local calendar context changes so an inactive streak does not stay visible.
+        NotificationCenter.default.publisher(for: .NSCalendarDayChanged)
+            .sink { [weak self] _ in
+                self?.statsManager.refreshCurrentStreak()
+            }
+            .store(in: &cancellables)
+
+        NotificationCenter.default.publisher(for: .NSSystemTimeZoneDidChange)
+            .sink { [weak self] _ in
+                self?.statsManager.refreshCurrentStreak()
             }
             .store(in: &cancellables)
 

--- a/Sources/VocaMac/Models/StatsShareDestination.swift
+++ b/Sources/VocaMac/Models/StatsShareDestination.swift
@@ -137,7 +137,7 @@ enum StatsShareComposer {
     }
 
     /// "1 session", not "1 sessions" — the post is public.
-    private static func pluralized(_ count: Int, _ noun: String) -> String {
+    static func pluralized(_ count: Int, _ noun: String) -> String {
         "\(formatCount(count)) \(count == 1 ? noun : noun + "s")"
     }
 

--- a/Sources/VocaMac/Models/UserStats.swift
+++ b/Sources/VocaMac/Models/UserStats.swift
@@ -28,6 +28,15 @@ struct UserStats: Codable, Equatable {
     /// Key is date string in "yyyy-MM-dd" format
     var dailyWordCounts: [String: Int] = [:]
 
+    /// Daily successful-transcription counts used to distinguish activity from
+    /// a corrupt or legitimately zero-word daily bucket.
+    /// Key is date string in "yyyy-MM-dd" format.
+    var dailyTranscriptionCounts: [String: Int] = [:]
+
+    /// Time-zone identifier used to create and interpret daily buckets.
+    /// Keeping this stable prevents travel from reinterpreting historical keys.
+    var timeZoneIdentifier: String?
+
     /// Calculated average Words Per Minute (WPM).
     /// Note: This is "words-per-minute-of-audio", dividing total words by total audio duration.
     var averageWPM: Double {
@@ -73,6 +82,14 @@ extension UserStats {
             forKey: .dailyWordCounts
         ) ?? dailyWordCounts
         dailyWordCounts = decodedDailyCounts.mapValues { max(0, $0) }
+
+        let decodedDailyTranscriptionCounts = container.decodeLossily(
+            [String: Int].self,
+            forKey: .dailyTranscriptionCounts
+        ) ?? dailyTranscriptionCounts
+        dailyTranscriptionCounts = decodedDailyTranscriptionCounts.mapValues { max(0, $0) }
+
+        timeZoneIdentifier = container.decodeLossily(String.self, forKey: .timeZoneIdentifier)
     }
 }
 

--- a/Sources/VocaMac/Models/UserStats.swift
+++ b/Sources/VocaMac/Models/UserStats.swift
@@ -81,7 +81,9 @@ extension UserStats {
             [String: Int].self,
             forKey: .dailyWordCounts
         ) ?? dailyWordCounts
-        dailyWordCounts = decodedDailyCounts.mapValues { max(0, $0) }
+        // Negative buckets are corrupt, not zero-word activity. Drop them so
+        // the legacy migration can safely treat retained zero buckets as real.
+        dailyWordCounts = decodedDailyCounts.filter { $0.value >= 0 }
 
         let decodedDailyTranscriptionCounts = container.decodeLossily(
             [String: Int].self,

--- a/Sources/VocaMac/Models/UserStats.swift
+++ b/Sources/VocaMac/Models/UserStats.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-struct UserStats: Codable {
+struct UserStats: Codable, Equatable {
     /// Total number of words transcribed across all sessions
     var totalWords: Int = 0
 
@@ -31,9 +31,12 @@ struct UserStats: Codable {
     /// Calculated average Words Per Minute (WPM).
     /// Note: This is "words-per-minute-of-audio", dividing total words by total audio duration.
     var averageWPM: Double {
-        guard totalAudioDurationSeconds > 0 else { return 0 }
+        guard totalWords > 0,
+              totalAudioDurationSeconds.isFinite,
+              totalAudioDurationSeconds > 0 else { return 0 }
         let minutes = totalAudioDurationSeconds / 60.0
-        return Double(totalWords) / minutes
+        let wordsPerMinute = Double(totalWords) / minutes
+        return wordsPerMinute.isFinite ? wordsPerMinute : 0
     }
 }
 
@@ -46,12 +49,36 @@ extension UserStats {
     init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         self.init()
-        totalWords = try container.decodeIfPresent(Int.self, forKey: .totalWords) ?? totalWords
-        totalTranscriptions = try container.decodeIfPresent(Int.self, forKey: .totalTranscriptions) ?? totalTranscriptions
-        totalAudioDurationSeconds = try container.decodeIfPresent(Double.self, forKey: .totalAudioDurationSeconds) ?? totalAudioDurationSeconds
-        lastUsageDate = try container.decodeIfPresent(Date.self, forKey: .lastUsageDate)
-        currentStreak = try container.decodeIfPresent(Int.self, forKey: .currentStreak) ?? currentStreak
-        bestStreak = try container.decodeIfPresent(Int.self, forKey: .bestStreak) ?? bestStreak
-        dailyWordCounts = try container.decodeIfPresent([String: Int].self, forKey: .dailyWordCounts) ?? dailyWordCounts
+        totalWords = max(0, container.decodeLossily(Int.self, forKey: .totalWords) ?? totalWords)
+        totalTranscriptions = max(
+            0,
+            container.decodeLossily(Int.self, forKey: .totalTranscriptions) ?? totalTranscriptions
+        )
+
+        let decodedDuration = container.decodeLossily(
+            Double.self,
+            forKey: .totalAudioDurationSeconds
+        ) ?? totalAudioDurationSeconds
+        totalAudioDurationSeconds = decodedDuration.isFinite && decodedDuration > 0 ? decodedDuration : 0
+
+        lastUsageDate = container.decodeLossily(Date.self, forKey: .lastUsageDate)
+        currentStreak = max(0, container.decodeLossily(Int.self, forKey: .currentStreak) ?? currentStreak)
+        bestStreak = max(
+            currentStreak,
+            max(0, container.decodeLossily(Int.self, forKey: .bestStreak) ?? bestStreak)
+        )
+
+        let decodedDailyCounts = container.decodeLossily(
+            [String: Int].self,
+            forKey: .dailyWordCounts
+        ) ?? dailyWordCounts
+        dailyWordCounts = decodedDailyCounts.mapValues { max(0, $0) }
+    }
+}
+
+private extension KeyedDecodingContainer {
+    /// A malformed field must not make every other valid statistic unreadable.
+    func decodeLossily<Value: Decodable>(_ type: Value.Type, forKey key: Key) -> Value? {
+        try? decode(Value.self, forKey: key)
     }
 }

--- a/Sources/VocaMac/Services/ServiceProtocols.swift
+++ b/Sources/VocaMac/Services/ServiceProtocols.swift
@@ -235,7 +235,14 @@ protocol StatsManaging: AnyObject {
     var stats: UserStats { get }
     var objectWillChangePublisher: AnyPublisher<Void, Never> { get }
     func recordTranscription(_ transcription: VocaTranscription)
+    func refreshCurrentStreak()
+    func flushPendingSaves()
     func resetStats()
+}
+
+extension StatsManaging {
+    func refreshCurrentStreak() {}
+    func flushPendingSaves() {}
 }
 
 // MARK: - SnippetExpanding

--- a/Sources/VocaMac/Services/StatsManager.swift
+++ b/Sources/VocaMac/Services/StatsManager.swift
@@ -58,6 +58,16 @@ class StatsManager: StatsManaging, ObservableObject {
                 let data = try Data(contentsOf: statsFileURL)
                 let decodedStats = try JSONDecoder().decode(UserStats.self, from: data)
                 var loadedStats = decodedStats
+                if loadedStats.timeZoneIdentifier == nil {
+                    // Before per-day transcription counts existed, a retained
+                    // zero-word bucket was the only evidence of a successful
+                    // emoji/punctuation-only transcription. Negative buckets
+                    // have already been removed by decoding, so migrate every
+                    // remaining zero bucket into explicit activity.
+                    for (key, count) in loadedStats.dailyWordCounts where count == 0 {
+                        loadedStats.dailyTranscriptionCounts[key] = 1
+                    }
+                }
                 if let identifier = loadedStats.timeZoneIdentifier,
                    let persistedTimeZone = TimeZone(identifier: identifier) {
                     statisticsTimeZone = persistedTimeZone

--- a/Sources/VocaMac/Services/StatsManager.swift
+++ b/Sources/VocaMac/Services/StatsManager.swift
@@ -16,12 +16,12 @@ class StatsManager: StatsManaging, ObservableObject {
 
     private let fileManager = FileManager.default
     private let statsFileURL: URL
-    private let calendarSource: Calendar
+    private var statisticsTimeZone: TimeZone
     private let now: () -> Date
 
     private var calendar: Calendar {
         var localGregorianCalendar = Calendar(identifier: .gregorian)
-        localGregorianCalendar.timeZone = calendarSource.timeZone
+        localGregorianCalendar.timeZone = statisticsTimeZone
         return localGregorianCalendar
     }
 
@@ -43,11 +43,11 @@ class StatsManager: StatsManaging, ObservableObject {
             self.statsFileURL = vMacDir.appendingPathComponent("stats.json")
         }
 
-        // Day keys are a documented Gregorian `yyyy-MM-dd` format. Preserve
-        // the caller's local time zone without letting a non-Gregorian system
-        // calendar produce keys the Stats view cannot parse or sort. The
-        // production default keeps following time-zone changes while running.
-        self.calendarSource = calendar
+        // Day keys are a documented Gregorian `yyyy-MM-dd` format. Capture the
+        // caller's time zone without letting a non-Gregorian system calendar
+        // produce keys the Stats view cannot parse or sort. Once persisted,
+        // this zone stays stable so travel cannot reinterpret historical keys.
+        self.statisticsTimeZone = calendar.timeZone
         self.now = now
         loadStats()
     }
@@ -56,9 +56,16 @@ class StatsManager: StatsManaging, ObservableObject {
         do {
             if fileManager.fileExists(atPath: statsFileURL.path) {
                 let data = try Data(contentsOf: statsFileURL)
-                let loadedStats = try JSONDecoder().decode(UserStats.self, from: data)
+                let decodedStats = try JSONDecoder().decode(UserStats.self, from: data)
+                var loadedStats = decodedStats
+                if let identifier = loadedStats.timeZoneIdentifier,
+                   let persistedTimeZone = TimeZone(identifier: identifier) {
+                    statisticsTimeZone = persistedTimeZone
+                } else {
+                    loadedStats.timeZoneIdentifier = statisticsTimeZone.identifier
+                }
                 stats = recalculatingStreaks(in: loadedStats, asOf: now())
-                if stats != loadedStats {
+                if stats != decodedStats {
                     saveStats()
                 }
                 VocaLogger.debug(.general, "User stats loaded from disk")
@@ -124,6 +131,11 @@ class StatsManager: StatsManaging, ObservableObject {
             updatedStats.dailyWordCounts[dateKey, default: 0],
             words
         )
+        updatedStats.dailyTranscriptionCounts[dateKey] = addingWithoutOverflow(
+            updatedStats.dailyTranscriptionCounts[dateKey, default: 0],
+            1
+        )
+        updatedStats.timeZoneIdentifier = statisticsTimeZone.identifier
 
         if updatedStats.lastUsageDate.map({ transcription.timestamp > $0 }) ?? true {
             updatedStats.lastUsageDate = transcription.timestamp
@@ -152,10 +164,11 @@ class StatsManager: StatsManaging, ObservableObject {
     }
 
     func resetStats() {
-        stats = UserStats()
+        stats = UserStats(timeZoneIdentifier: statisticsTimeZone.identifier)
         saveStats()
     }
 
+    /// Formats an instant as the persisted statistics calendar's Gregorian day key.
     private func dayKey(for date: Date) -> String {
         let components = calendar.dateComponents([.year, .month, .day], from: date)
         guard let year = components.year, let month = components.month, let day = components.day else {
@@ -164,6 +177,7 @@ class StatsManager: StatsManaging, ObservableObject {
         return String(format: "%04d-%02d-%02d", year, month, day)
     }
 
+    /// Parses a strict Gregorian day key in the persisted statistics time zone.
     private func date(fromDayKey key: String) -> Date? {
         let parts = key.split(separator: "-", omittingEmptySubsequences: false)
         guard parts.count == 3,
@@ -180,22 +194,41 @@ class StatsManager: StatsManaging, ObservableObject {
         return date
     }
 
+    /// Rebuilds cached streaks from genuine, non-future activity days.
+    ///
+    /// Positive daily word counts support files from the previous schema, while
+    /// daily transcription counts preserve valid activity that produced no words.
+    /// Future buckets remain stored but do not affect streaks until their day arrives.
     private func recalculatingStreaks(in original: UserStats, asOf referenceDate: Date) -> UserStats {
         var updated = original
-        let activityDays = Set(original.dailyWordCounts.keys.compactMap(date(fromDayKey:))).sorted()
+        let referenceDay = calendar.startOfDay(for: referenceDate)
+        let wordActivityKeys = original.dailyWordCounts.compactMap { key, count in
+            count > 0 ? key : nil
+        }
+        let transcriptionActivityKeys = original.dailyTranscriptionCounts.compactMap { key, count in
+            count > 0 ? key : nil
+        }
+        let activityDays = Set(wordActivityKeys + transcriptionActivityKeys)
+            .compactMap(date(fromDayKey:))
+            .filter { $0 <= referenceDay }
+            .sorted()
 
         guard let latestDay = activityDays.last else {
-            guard let lastUsageDate = original.lastUsageDate else {
-                updated.currentStreak = 0
-                return updated
-            }
+            updated.currentStreak = 0
+            // Files from the oldest schema may have a last-use instant but no
+            // daily buckets. Preserve their cached streak only while that
+            // instant is today or yesterday. A present-but-invalid, zero, or
+            // future bucket is not evidence of activity.
+            guard original.dailyWordCounts.isEmpty,
+                  original.dailyTranscriptionCounts.isEmpty,
+                  let lastUsageDate = original.lastUsageDate else { return updated }
             let gap = calendar.dateComponents(
                 [.day],
                 from: calendar.startOfDay(for: lastUsageDate),
-                to: calendar.startOfDay(for: referenceDate)
+                to: referenceDay
             ).day
-            if gap != 0 && gap != 1 {
-                updated.currentStreak = 0
+            if gap == 0 || gap == 1 {
+                updated.currentStreak = original.currentStreak
             }
             return updated
         }
@@ -213,7 +246,7 @@ class StatsManager: StatsManaging, ObservableObject {
         let daysSinceLatestUsage = calendar.dateComponents(
             [.day],
             from: latestDay,
-            to: calendar.startOfDay(for: referenceDate)
+            to: referenceDay
         ).day
         updated.currentStreak = daysSinceLatestUsage == 0 || daysSinceLatestUsage == 1 ? latestRun : 0
         // Preserve a historical best from an older schema that may not have
@@ -222,11 +255,13 @@ class StatsManager: StatsManaging, ObservableObject {
         return updated
     }
 
+    /// Adds non-negative counters and saturates at `Int.max` on overflow.
     private func addingWithoutOverflow(_ lhs: Int, _ rhs: Int) -> Int {
         let (sum, overflowed) = max(0, lhs).addingReportingOverflow(max(0, rhs))
         return overflowed ? Int.max : sum
     }
 
+    /// Adds a valid positive duration while repairing invalid totals and overflow.
     private func addingDuration(_ duration: TimeInterval, to total: TimeInterval) -> TimeInterval {
         let safeTotal = total.isFinite && total > 0 ? total : 0
         guard duration.isFinite, duration > 0 else { return safeTotal }

--- a/Sources/VocaMac/Services/StatsManager.swift
+++ b/Sources/VocaMac/Services/StatsManager.swift
@@ -16,12 +16,23 @@ class StatsManager: StatsManaging, ObservableObject {
 
     private let fileManager = FileManager.default
     private let statsFileURL: URL
-    private let calendar: Calendar
+    private let calendarSource: Calendar
+    private let now: () -> Date
+
+    private var calendar: Calendar {
+        var localGregorianCalendar = Calendar(identifier: .gregorian)
+        localGregorianCalendar.timeZone = calendarSource.timeZone
+        return localGregorianCalendar
+    }
 
     /// Serial queue for off-main disk writes so recording never blocks the UI.
     private let saveQueue = DispatchQueue(label: "com.vocamac.stats.save", qos: .utility)
 
-    init(statsFileURL: URL? = nil, calendar: Calendar = .current) {
+    init(
+        statsFileURL: URL? = nil,
+        calendar: Calendar = .autoupdatingCurrent,
+        now: @escaping () -> Date = Date.init
+    ) {
         if let statsFileURL {
             self.statsFileURL = statsFileURL
         } else {
@@ -29,13 +40,15 @@ class StatsManager: StatsManaging, ObservableObject {
                 ?? FileManager.default.temporaryDirectory
             let vMacDir = appSupport.appendingPathComponent("VocaMac", isDirectory: true)
 
-            // Ensure directory exists
-            if !FileManager.default.fileExists(atPath: vMacDir.path) {
-                try? FileManager.default.createDirectory(at: vMacDir, withIntermediateDirectories: true)
-            }
             self.statsFileURL = vMacDir.appendingPathComponent("stats.json")
         }
-        self.calendar = calendar
+
+        // Day keys are a documented Gregorian `yyyy-MM-dd` format. Preserve
+        // the caller's local time zone without letting a non-Gregorian system
+        // calendar produce keys the Stats view cannot parse or sort. The
+        // production default keeps following time-zone changes while running.
+        self.calendarSource = calendar
+        self.now = now
         loadStats()
     }
 
@@ -43,7 +56,11 @@ class StatsManager: StatsManaging, ObservableObject {
         do {
             if fileManager.fileExists(atPath: statsFileURL.path) {
                 let data = try Data(contentsOf: statsFileURL)
-                stats = try JSONDecoder().decode(UserStats.self, from: data)
+                let loadedStats = try JSONDecoder().decode(UserStats.self, from: data)
+                stats = recalculatingStreaks(in: loadedStats, asOf: now())
+                if stats != loadedStats {
+                    saveStats()
+                }
                 VocaLogger.debug(.general, "User stats loaded from disk")
             } else {
                 VocaLogger.info(.general, "No stats file found, starting fresh")
@@ -66,6 +83,10 @@ class StatsManager: StatsManaging, ObservableObject {
         let url = statsFileURL
         saveQueue.async {
             do {
+                try FileManager.default.createDirectory(
+                    at: url.deletingLastPathComponent(),
+                    withIntermediateDirectories: true
+                )
                 try data.write(to: url, options: .atomic)
                 VocaLogger.debug(.general, "User stats saved to disk")
             } catch {
@@ -87,20 +108,47 @@ class StatsManager: StatsManaging, ObservableObject {
 
         let dateKey = dayKey(for: transcription.timestamp)
 
-        // Update basic counts
-        stats.totalWords += words
-        stats.totalTranscriptions += 1
-        stats.totalAudioDurationSeconds += transcription.audioLengthSeconds
+        var updatedStats = stats
+
+        // Update basic counts without allowing corrupt imported values or an
+        // invalid engine duration to overflow/poison future JSON saves.
+        updatedStats.totalWords = addingWithoutOverflow(updatedStats.totalWords, words)
+        updatedStats.totalTranscriptions = addingWithoutOverflow(updatedStats.totalTranscriptions, 1)
+        updatedStats.totalAudioDurationSeconds = addingDuration(
+            transcription.audioLengthSeconds,
+            to: updatedStats.totalAudioDurationSeconds
+        )
 
         // Update daily stats
-        stats.dailyWordCounts[dateKey, default: 0] += words
+        updatedStats.dailyWordCounts[dateKey] = addingWithoutOverflow(
+            updatedStats.dailyWordCounts[dateKey, default: 0],
+            words
+        )
 
-        // Update streaks
-        updateStreaks(currentDate: transcription.timestamp)
+        if updatedStats.lastUsageDate.map({ transcription.timestamp > $0 }) ?? true {
+            updatedStats.lastUsageDate = transcription.timestamp
+        }
 
-        stats.lastUsageDate = transcription.timestamp
+        // Deriving streaks from daily activity makes late/out-of-order results
+        // deterministic instead of resetting the user's current streak.
+        stats = recalculatingStreaks(in: updatedStats, asOf: now())
 
         saveStats()
+    }
+
+    /// Refresh the cached streak when the calendar day changes without a new
+    /// transcription. A streak stays active through the day after last use.
+    func refreshCurrentStreak() {
+        let refreshedStats = recalculatingStreaks(in: stats, asOf: now())
+        guard refreshedStats != stats else { return }
+        stats = refreshedStats
+        saveStats()
+    }
+
+    /// Finish queued writes before application termination. Normal recording
+    /// stays non-blocking; quitting cannot drop the most recent tiny snapshot.
+    func flushPendingSaves() {
+        saveQueue.sync {}
     }
 
     func resetStats() {
@@ -116,32 +164,73 @@ class StatsManager: StatsManaging, ObservableObject {
         return String(format: "%04d-%02d-%02d", year, month, day)
     }
 
-    private func updateStreaks(currentDate: Date) {
-        guard let lastDate = stats.lastUsageDate else {
-            // First time usage
-            stats.currentStreak = 1
-            stats.bestStreak = 1
-            return
+    private func date(fromDayKey key: String) -> Date? {
+        let parts = key.split(separator: "-", omittingEmptySubsequences: false)
+        guard parts.count == 3,
+              parts[0].count == 4,
+              parts[1].count == 2,
+              parts[2].count == 2,
+              let year = Int(parts[0]),
+              let month = Int(parts[1]),
+              let day = Int(parts[2]),
+              let date = calendar.date(from: DateComponents(year: year, month: month, day: day)),
+              dayKey(for: date) == key else {
+            return nil
+        }
+        return date
+    }
+
+    private func recalculatingStreaks(in original: UserStats, asOf referenceDate: Date) -> UserStats {
+        var updated = original
+        let activityDays = Set(original.dailyWordCounts.keys.compactMap(date(fromDayKey:))).sorted()
+
+        guard let latestDay = activityDays.last else {
+            guard let lastUsageDate = original.lastUsageDate else {
+                updated.currentStreak = 0
+                return updated
+            }
+            let gap = calendar.dateComponents(
+                [.day],
+                from: calendar.startOfDay(for: lastUsageDate),
+                to: calendar.startOfDay(for: referenceDate)
+            ).day
+            if gap != 0 && gap != 1 {
+                updated.currentStreak = 0
+            }
+            return updated
         }
 
-        let lastDay = calendar.startOfDay(for: lastDate)
-        let currentDay = calendar.startOfDay(for: currentDate)
-        let daysBetween = calendar.dateComponents([.day], from: lastDay, to: currentDay).day
-
-        switch daysBetween {
-        case 0:
-            // Already used on this calendar day, streak remains same
-            break
-        case 1:
-            // Continuation of streak
-            stats.currentStreak += 1
-        default:
-            // Streak broken or older transcription recorded out of order
-            stats.currentStreak = 1
+        var run = 1
+        var latestRun = 1
+        var computedBest = 1
+        for (previous, next) in zip(activityDays, activityDays.dropFirst()) {
+            let gap = calendar.dateComponents([.day], from: previous, to: next).day
+            run = gap == 1 ? run + 1 : 1
+            latestRun = run
+            computedBest = max(computedBest, run)
         }
 
-        if stats.currentStreak > stats.bestStreak {
-            stats.bestStreak = stats.currentStreak
-        }
+        let daysSinceLatestUsage = calendar.dateComponents(
+            [.day],
+            from: latestDay,
+            to: calendar.startOfDay(for: referenceDate)
+        ).day
+        updated.currentStreak = daysSinceLatestUsage == 0 || daysSinceLatestUsage == 1 ? latestRun : 0
+        // Preserve a historical best from an older schema that may not have
+        // complete daily buckets, while still repairing understated values.
+        updated.bestStreak = max(original.bestStreak, computedBest)
+        return updated
+    }
+
+    private func addingWithoutOverflow(_ lhs: Int, _ rhs: Int) -> Int {
+        let (sum, overflowed) = max(0, lhs).addingReportingOverflow(max(0, rhs))
+        return overflowed ? Int.max : sum
+    }
+
+    private func addingDuration(_ duration: TimeInterval, to total: TimeInterval) -> TimeInterval {
+        let safeTotal = total.isFinite && total > 0 ? total : 0
+        guard duration.isFinite, duration > 0 else { return safeTotal }
+        let sum = safeTotal + duration
+        return sum.isFinite ? sum : Double.greatestFiniteMagnitude
     }
 }

--- a/Sources/VocaMac/Views/StatsSettingsTab.swift
+++ b/Sources/VocaMac/Views/StatsSettingsTab.swift
@@ -34,15 +34,19 @@ struct StatsSettingsTab: View {
 
     private static let dateFormatter: DateFormatter = {
         let formatter = DateFormatter()
-        formatter.dateFormat = "yyyy-MM-dd"
         // Fixed locale so the "yyyy-MM-dd" keys (written with a Gregorian calendar)
         // parse back correctly regardless of the user's default calendar/locale.
         formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.calendar = Calendar(identifier: .gregorian)
+        formatter.timeZone = .autoupdatingCurrent
+        formatter.dateFormat = "yyyy-MM-dd"
+        formatter.isLenient = false
         return formatter
     }()
 
     private static let displayDateFormatter: DateFormatter = {
         let formatter = DateFormatter()
+        formatter.timeZone = .autoupdatingCurrent
         formatter.dateFormat = "MMM d, yyyy"
         return formatter
     }()
@@ -69,6 +73,7 @@ struct StatsSettingsTab: View {
                         .menuStyle(.borderlessButton)
                         .fixedSize()
                         .controlSize(.small)
+                        .disabled(!hasStats)
                         .help("Post your stats card, or copy it to the clipboard")
                         .padding(.trailing, 8)
                     }
@@ -117,11 +122,19 @@ struct StatsSettingsTab: View {
                     }
 
                     VocaSettingsGroup("Streak") {
-                        Text("\(appState.statsManager.stats.currentStreak)")
+                        let currentStreak = appState.statsManager.stats.currentStreak
+                        Text(StatsShareComposer.formatCount(currentStreak))
                             .font(.system(size: 32, weight: .bold, design: .rounded))
-                        + Text(" days").font(.headline).foregroundColor(.secondary)
+                        + Text(currentStreak == 1 ? " day" : " days")
+                            .font(.headline)
+                            .foregroundColor(.secondary)
 
-                        Text("Best: \(appState.statsManager.stats.bestStreak) days")
+                        Text(
+                            "Best: " + StatsShareComposer.pluralized(
+                                appState.statsManager.stats.bestStreak,
+                                "day"
+                            )
+                        )
                             .font(.caption)
                             .foregroundStyle(.secondary)
                     }
@@ -143,7 +156,12 @@ struct StatsSettingsTab: View {
                                     Text(formatDateString(day))
                                         .font(.subheadline)
                                     Spacer()
-                                    Text("\(appState.statsManager.stats.dailyWordCounts[day] ?? 0) words")
+                                    Text(
+                                        StatsShareComposer.pluralized(
+                                            appState.statsManager.stats.dailyWordCounts[day] ?? 0,
+                                            "word"
+                                        )
+                                    )
                                         .font(.subheadline)
                                         .fontWeight(.medium)
                                 }
@@ -162,6 +180,7 @@ struct StatsSettingsTab: View {
                     Label("Reset All Statistics", systemImage: "trash")
                 }
                 .controlSize(.small)
+                .disabled(!hasStats)
                 .padding(.top, 8)
             }
             .padding()
@@ -169,10 +188,14 @@ struct StatsSettingsTab: View {
         .alert("Reset All Statistics?", isPresented: $showingResetConfirmation) {
             Button("Reset", role: .destructive) {
                 appState.statsManager.resetStats()
+                clearShareState()
             }
             Button("Cancel", role: .cancel) {}
         } message: {
             Text("This permanently deletes all your usage statistics. This action cannot be undone.")
+        }
+        .onAppear {
+            appState.statsManager.refreshCurrentStreak()
         }
     }
 
@@ -225,6 +248,11 @@ struct StatsSettingsTab: View {
         }
     }
 
+    private func clearShareState() {
+        shareStateToken += 1
+        shareState = .idle
+    }
+
     /// Social composers cannot take an attachment, so the card lands on the
     /// clipboard and the user pastes it into the prefilled post.
     private func share(to destination: StatsShareDestination) {
@@ -249,12 +277,25 @@ struct StatsSettingsTab: View {
     }
 
     private func formatDuration(_ seconds: Double) -> String {
-        return Self.durationFormatter.string(from: seconds) ?? "\(Int(seconds))s"
+        guard seconds.isFinite, seconds > 0 else { return "0s" }
+        return Self.durationFormatter.string(from: seconds) ?? String(format: "%.0fs", seconds)
     }
 
     private func recentDays() -> [String] {
         let keys = Array(appState.statsManager.stats.dailyWordCounts.keys)
-        return keys.sorted(by: >).prefix(7).map { String($0) }
+        return keys
+            .filter { Self.dateFormatter.date(from: $0) != nil }
+            .sorted(by: >)
+            .prefix(7)
+            .map { String($0) }
+    }
+
+    private var hasStats: Bool {
+        let stats = appState.statsManager.stats
+        return stats.totalTranscriptions > 0
+            || stats.totalWords > 0
+            || stats.totalAudioDurationSeconds > 0
+            || !stats.dailyWordCounts.isEmpty
     }
 
     private func formatDateString(_ dateString: String) -> String {

--- a/Sources/VocaMac/Views/StatsShareCard.swift
+++ b/Sources/VocaMac/Views/StatsShareCard.swift
@@ -161,8 +161,8 @@ enum StatsShareExporter {
         return pasteboard.setData(png, forType: .png)
     }
 
-    /// Copies the card image, then opens the destination's composer with the
-    /// post text prefilled so the user can paste the image in.
+    /// Opens the destination's composer with prefilled text, then copies the
+    /// card image so the user can paste it in.
     ///
     /// Web share intents cannot carry an attachment, so the clipboard copy is
     /// how the image gets there. A failed copy is reported separately rather
@@ -170,20 +170,41 @@ enum StatsShareExporter {
     /// still holds their previous content would put that content in a public
     /// post.
     @MainActor
-    static func share(_ snapshot: StatsShareSnapshot, to destination: StatsShareDestination) -> StatsShareOutcome {
+    static func share(
+        _ snapshot: StatsShareSnapshot,
+        to destination: StatsShareDestination
+    ) -> StatsShareOutcome {
+        share(
+            snapshot,
+            to: destination,
+            openURL: { NSWorkspace.shared.open($0) },
+            copyCard: { copyImage(toClipboard: $0) }
+        )
+    }
+
+    @MainActor
+    static func share(
+        _ snapshot: StatsShareSnapshot,
+        to destination: StatsShareDestination,
+        openURL: (URL) -> Bool,
+        copyCard: (StatsShareSnapshot) -> Bool
+    ) -> StatsShareOutcome {
         guard let url = StatsShareComposer.composerURL(for: snapshot, destination: destination) else {
             VocaLogger.error(.general, "Stats share: could not build a \(destination.displayName) composer URL")
             return .failed
         }
 
-        let copiedImage = copyImage(toClipboard: snapshot)
-        if !copiedImage {
-            VocaLogger.warning(.general, "Stats share: card image could not be copied")
-        }
-
-        guard NSWorkspace.shared.open(url) else {
+        // Do not overwrite the clipboard when the destination cannot open.
+        // Copy immediately after a successful open request, before the user can
+        // reach the composer and paste.
+        guard openURL(url) else {
             VocaLogger.error(.general, "Stats share: could not open the \(destination.displayName) composer")
             return .failed
+        }
+
+        let copiedImage = copyCard(snapshot)
+        if !copiedImage {
+            VocaLogger.warning(.general, "Stats share: card image could not be copied")
         }
 
         return copiedImage ? .shared : .sharedWithoutCard

--- a/Tests/VocaMacTests/AppStateDuckingTests.swift
+++ b/Tests/VocaMacTests/AppStateDuckingTests.swift
@@ -139,6 +139,18 @@ final class AppStateDuckingTests: XCTestCase {
         NotificationCenter.default.post(name: NSApplication.willTerminateNotification, object: nil)
 
         XCTAssertEqual(mocks.audioDucker.restoreCallCount, 1)
+        XCTAssertEqual(mocks.statsManager.flushPendingSavesCallCount, 1)
         XCTAssertTrue(appState.isRecording, "Quit does not flip isRecording; restore runs from willTerminate")
+    }
+
+    func testCalendarChangesRefreshStatsStreak() {
+        let (appState, mocks) = makeDuckingState()
+
+        withExtendedLifetime(appState) {
+            NotificationCenter.default.post(name: .NSCalendarDayChanged, object: nil)
+            NotificationCenter.default.post(name: .NSSystemTimeZoneDidChange, object: nil)
+        }
+
+        XCTAssertEqual(mocks.statsManager.refreshCurrentStreakCallCount, 2)
     }
 }

--- a/Tests/VocaMacTests/Mocks/MockServices.swift
+++ b/Tests/VocaMacTests/Mocks/MockServices.swift
@@ -560,6 +560,8 @@ final class MockStatsManager: StatsManaging, ObservableObject {
 
     var recordCallCount = 0
     var resetCallCount = 0
+    var refreshCurrentStreakCallCount = 0
+    var flushPendingSavesCallCount = 0
 
     var objectWillChangePublisher: AnyPublisher<Void, Never> {
         objectWillChange.eraseToAnyPublisher()
@@ -567,6 +569,14 @@ final class MockStatsManager: StatsManaging, ObservableObject {
 
     func recordTranscription(_ transcription: VocaTranscription) {
         recordCallCount += 1
+    }
+
+    func refreshCurrentStreak() {
+        refreshCurrentStreakCallCount += 1
+    }
+
+    func flushPendingSaves() {
+        flushPendingSavesCallCount += 1
     }
 
     func resetStats() {

--- a/Tests/VocaMacTests/StatsManagerTests.swift
+++ b/Tests/VocaMacTests/StatsManagerTests.swift
@@ -290,6 +290,56 @@ final class StatsManagerTests: XCTestCase {
     }
 
     @MainActor
+    func testZeroWordBucketWithoutTranscriptionActivityDoesNotInflateStreak() throws {
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = TimeZone(secondsFromGMT: 0)!
+        let thirdDay = try XCTUnwrap(calendar.date(
+            from: DateComponents(year: 2026, month: 9, day: 3)
+        ))
+        var savedStats = UserStats()
+        savedStats.dailyWordCounts = [
+            "2026-09-01": 2,
+            "2026-09-02": -8,
+            "2026-09-03": 2
+        ]
+        try JSONEncoder().encode(savedStats).write(to: tempFileURL)
+
+        statsManager = StatsManager(
+            statsFileURL: tempFileURL,
+            calendar: calendar,
+            now: { thirdDay }
+        )
+
+        XCTAssertEqual(statsManager.stats.dailyWordCounts["2026-09-02"], 0)
+        XCTAssertEqual(statsManager.stats.currentStreak, 1)
+        XCTAssertEqual(statsManager.stats.bestStreak, 1)
+    }
+
+    @MainActor
+    func testZeroWordTranscriptionStillCountsAsActivity() throws {
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = TimeZone(secondsFromGMT: 0)!
+        let date = try XCTUnwrap(calendar.date(
+            from: DateComponents(year: 2026, month: 9, day: 10)
+        ))
+        statsManager = StatsManager(statsFileURL: tempFileURL, calendar: calendar, now: { date })
+
+        statsManager.recordTranscription(VocaTranscription(
+            text: "🙂",
+            duration: 1,
+            detectedLanguage: "und",
+            audioLengthSeconds: 1,
+            modelUsed: .tiny,
+            timestamp: date
+        ))
+
+        XCTAssertEqual(statsManager.stats.dailyWordCounts["2026-09-10"], 0)
+        XCTAssertEqual(statsManager.stats.dailyTranscriptionCounts["2026-09-10"], 1)
+        XCTAssertEqual(statsManager.stats.currentStreak, 1)
+        XCTAssertEqual(statsManager.stats.bestStreak, 1)
+    }
+
+    @MainActor
     func testNonGregorianSystemCalendarStillWritesGregorianDayKeys() {
         var calendar = Calendar(identifier: .buddhist)
         calendar.timeZone = TimeZone(secondsFromGMT: 0)!
@@ -361,6 +411,67 @@ final class StatsManagerTests: XCTestCase {
 
         XCTAssertEqual(statsManager.stats.currentStreak, 0)
         XCTAssertEqual(statsManager.stats.bestStreak, 2)
+    }
+
+    @MainActor
+    func testFutureBucketsDoNotSuppressOrInflateStreaks() throws {
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = TimeZone(secondsFromGMT: 0)!
+        let currentDate = try XCTUnwrap(calendar.date(
+            from: DateComponents(year: 2026, month: 9, day: 2)
+        ))
+        var savedStats = UserStats()
+        savedStats.dailyWordCounts = [
+            "2026-09-01": 2,
+            "2026-09-02": 2,
+            "2026-09-10": 2,
+            "2026-09-11": 2,
+            "2026-09-12": 2
+        ]
+        try JSONEncoder().encode(savedStats).write(to: tempFileURL)
+
+        statsManager = StatsManager(
+            statsFileURL: tempFileURL,
+            calendar: calendar,
+            now: { currentDate }
+        )
+
+        XCTAssertEqual(statsManager.stats.currentStreak, 2)
+        XCTAssertEqual(statsManager.stats.bestStreak, 2)
+    }
+
+    @MainActor
+    func testReloadKeepsPersistedStatisticsTimeZone() throws {
+        var originCalendar = Calendar(identifier: .gregorian)
+        originCalendar.timeZone = try XCTUnwrap(TimeZone(identifier: "Pacific/Kiritimati"))
+        let usageDate = Date(timeIntervalSince1970: 1_788_949_800) // 2026-09-09 10:30:00 UTC
+        let referenceDate = Date(timeIntervalSince1970: 1_788_951_600) // 2026-09-09 11:00:00 UTC
+        statsManager = StatsManager(
+            statsFileURL: tempFileURL,
+            calendar: originCalendar,
+            now: { referenceDate }
+        )
+        statsManager.recordTranscription(VocaTranscription(
+            text: "near midnight",
+            duration: 1,
+            detectedLanguage: "en",
+            audioLengthSeconds: 1,
+            modelUsed: .tiny,
+            timestamp: usageDate
+        ))
+        statsManager.flushPendingSaves()
+
+        var destinationCalendar = Calendar(identifier: .gregorian)
+        destinationCalendar.timeZone = try XCTUnwrap(TimeZone(identifier: "Etc/GMT+12"))
+        statsManager = StatsManager(
+            statsFileURL: tempFileURL,
+            calendar: destinationCalendar,
+            now: { referenceDate }
+        )
+
+        XCTAssertEqual(statsManager.stats.timeZoneIdentifier, originCalendar.timeZone.identifier)
+        XCTAssertEqual(statsManager.stats.dailyWordCounts["2026-09-10"], 2)
+        XCTAssertEqual(statsManager.stats.currentStreak, 1)
     }
 
     @MainActor

--- a/Tests/VocaMacTests/StatsManagerTests.swift
+++ b/Tests/VocaMacTests/StatsManagerTests.swift
@@ -286,7 +286,7 @@ final class StatsManagerTests: XCTestCase {
         XCTAssertEqual(decoded.totalAudioDurationSeconds, 0)
         XCTAssertEqual(decoded.currentStreak, 0)
         XCTAssertEqual(decoded.bestStreak, 4)
-        XCTAssertEqual(decoded.dailyWordCounts["2026-09-10"], 0)
+        XCTAssertNil(decoded.dailyWordCounts["2026-09-10"])
     }
 
     @MainActor
@@ -310,9 +310,36 @@ final class StatsManagerTests: XCTestCase {
             now: { thirdDay }
         )
 
-        XCTAssertEqual(statsManager.stats.dailyWordCounts["2026-09-02"], 0)
+        XCTAssertNil(statsManager.stats.dailyWordCounts["2026-09-02"])
         XCTAssertEqual(statsManager.stats.currentStreak, 1)
         XCTAssertEqual(statsManager.stats.bestStreak, 1)
+    }
+
+    @MainActor
+    func testLegacyZeroWordBucketMigratesToExplicitActivity() throws {
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = TimeZone(secondsFromGMT: 0)!
+        let date = try XCTUnwrap(calendar.date(
+            from: DateComponents(year: 2026, month: 9, day: 10)
+        ))
+        var savedStats = UserStats()
+        savedStats.totalTranscriptions = 1
+        savedStats.lastUsageDate = date
+        savedStats.currentStreak = 1
+        savedStats.bestStreak = 1
+        savedStats.dailyWordCounts = ["2026-09-10": 0]
+        try JSONEncoder().encode(savedStats).write(to: tempFileURL)
+
+        statsManager = StatsManager(statsFileURL: tempFileURL, calendar: calendar, now: { date })
+        statsManager.flushPendingSaves()
+
+        XCTAssertEqual(statsManager.stats.dailyTranscriptionCounts["2026-09-10"], 1)
+        XCTAssertEqual(statsManager.stats.currentStreak, 1)
+        let persistedStats = try JSONDecoder().decode(
+            UserStats.self,
+            from: Data(contentsOf: tempFileURL)
+        )
+        XCTAssertEqual(persistedStats.dailyTranscriptionCounts["2026-09-10"], 1)
     }
 
     @MainActor

--- a/Tests/VocaMacTests/StatsManagerTests.swift
+++ b/Tests/VocaMacTests/StatsManagerTests.swift
@@ -20,7 +20,9 @@ final class StatsManagerTests: XCTestCase {
         cancellables = []
     }
 
+    @MainActor
     override func tearDown() {
+        statsManager?.flushPendingSaves()
         try? FileManager.default.removeItem(at: tempFileURL)
         super.tearDown()
     }
@@ -102,6 +104,12 @@ final class StatsManagerTests: XCTestCase {
         let calendar = Calendar.current
         let today = Date()
         let threeDaysAgo = calendar.date(byAdding: .day, value: -3, to: today)!
+        var currentDate = threeDaysAgo
+        statsManager = StatsManager(
+            statsFileURL: tempFileURL,
+            calendar: calendar,
+            now: { currentDate }
+        )
 
         // 1. Record for 3 days ago
         let t1 = VocaTranscription(
@@ -116,6 +124,7 @@ final class StatsManagerTests: XCTestCase {
         XCTAssertEqual(statsManager.stats.currentStreak, 1)
 
         // 2. Record for today (2 day gap)
+        currentDate = today
         let t2 = VocaTranscription(
             text: "Today transcription",
             duration: 1.0,
@@ -154,10 +163,14 @@ final class StatsManagerTests: XCTestCase {
     func testStreakUsesTranscriptionDateRatherThanCurrentDate() {
         var calendar = Calendar(identifier: .gregorian)
         calendar.timeZone = TimeZone(secondsFromGMT: 0)!
-        statsManager = StatsManager(statsFileURL: tempFileURL, calendar: calendar)
 
         let firstDay = Date(timeIntervalSince1970: 946_684_800) // 2000-01-01 00:00:00 UTC
         let secondDay = Date(timeIntervalSince1970: 946_771_200) // 2000-01-02 00:00:00 UTC
+        statsManager = StatsManager(
+            statsFileURL: tempFileURL,
+            calendar: calendar,
+            now: { secondDay }
+        )
 
         statsManager.recordTranscription(VocaTranscription(
             text: "first day",
@@ -184,10 +197,10 @@ final class StatsManagerTests: XCTestCase {
     func testSameDayTranscriptionsDoNotIncrementStreak() {
         var calendar = Calendar(identifier: .gregorian)
         calendar.timeZone = TimeZone(secondsFromGMT: 0)!
-        statsManager = StatsManager(statsFileURL: tempFileURL, calendar: calendar)
 
         let first = Date(timeIntervalSince1970: 946_684_800) // 2000-01-01 00:00:00 UTC
         let second = Date(timeIntervalSince1970: 946_728_000) // 2000-01-01 12:00:00 UTC
+        statsManager = StatsManager(statsFileURL: tempFileURL, calendar: calendar, now: { second })
 
         statsManager.recordTranscription(VocaTranscription(
             text: "morning words",
@@ -252,5 +265,169 @@ final class StatsManagerTests: XCTestCase {
         XCTAssertEqual(decoded.currentStreak, 0)
         XCTAssertNil(decoded.lastUsageDate)
         XCTAssertTrue(decoded.dailyWordCounts.isEmpty)
+    }
+
+    func testStatsDecodeSalvagesValidFieldsAndRepairsInvalidValues() throws {
+        let json = Data("""
+        {
+          "totalWords": 42,
+          "totalTranscriptions": "broken",
+          "totalAudioDurationSeconds": -10,
+          "currentStreak": -3,
+          "bestStreak": 4,
+          "dailyWordCounts": {"2026-09-10": -8}
+        }
+        """.utf8)
+
+        let decoded = try JSONDecoder().decode(UserStats.self, from: json)
+
+        XCTAssertEqual(decoded.totalWords, 42)
+        XCTAssertEqual(decoded.totalTranscriptions, 0)
+        XCTAssertEqual(decoded.totalAudioDurationSeconds, 0)
+        XCTAssertEqual(decoded.currentStreak, 0)
+        XCTAssertEqual(decoded.bestStreak, 4)
+        XCTAssertEqual(decoded.dailyWordCounts["2026-09-10"], 0)
+    }
+
+    @MainActor
+    func testNonGregorianSystemCalendarStillWritesGregorianDayKeys() {
+        var calendar = Calendar(identifier: .buddhist)
+        calendar.timeZone = TimeZone(secondsFromGMT: 0)!
+        let date = Date(timeIntervalSince1970: 1_704_067_200) // 2024-01-01 00:00:00 UTC
+        statsManager = StatsManager(statsFileURL: tempFileURL, calendar: calendar, now: { date })
+
+        statsManager.recordTranscription(VocaTranscription(
+            text: "calendar test",
+            duration: 1,
+            detectedLanguage: "en",
+            audioLengthSeconds: 1,
+            modelUsed: .tiny,
+            timestamp: date
+        ))
+
+        XCTAssertEqual(statsManager.stats.dailyWordCounts["2024-01-01"], 2)
+        XCTAssertNil(statsManager.stats.dailyWordCounts["2567-01-01"])
+    }
+
+    @MainActor
+    func testOutOfOrderTranscriptionsRebuildStreakWithoutRegressingLastUsage() throws {
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = TimeZone(secondsFromGMT: 0)!
+        let firstDay = try XCTUnwrap(calendar.date(from: DateComponents(year: 2026, month: 9, day: 8)))
+        let secondDay = try XCTUnwrap(calendar.date(byAdding: .day, value: 1, to: firstDay))
+        let thirdDay = try XCTUnwrap(calendar.date(byAdding: .day, value: 2, to: firstDay))
+        statsManager = StatsManager(statsFileURL: tempFileURL, calendar: calendar, now: { thirdDay })
+
+        for date in [firstDay, thirdDay, secondDay] {
+            statsManager.recordTranscription(VocaTranscription(
+                text: "out of order",
+                duration: 1,
+                detectedLanguage: "en",
+                audioLengthSeconds: 1,
+                modelUsed: .tiny,
+                timestamp: date
+            ))
+        }
+
+        XCTAssertEqual(statsManager.stats.currentStreak, 3)
+        XCTAssertEqual(statsManager.stats.bestStreak, 3)
+        XCTAssertEqual(statsManager.stats.lastUsageDate, thirdDay)
+    }
+
+    @MainActor
+    func testRefreshingStreakExpiresItButPreservesBest() throws {
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = TimeZone(secondsFromGMT: 0)!
+        let firstDay = try XCTUnwrap(calendar.date(from: DateComponents(year: 2026, month: 9, day: 1)))
+        let secondDay = try XCTUnwrap(calendar.date(byAdding: .day, value: 1, to: firstDay))
+        let fifthDay = try XCTUnwrap(calendar.date(byAdding: .day, value: 4, to: firstDay))
+        var currentDate = secondDay
+        statsManager = StatsManager(statsFileURL: tempFileURL, calendar: calendar, now: { currentDate })
+
+        for date in [firstDay, secondDay] {
+            statsManager.recordTranscription(VocaTranscription(
+                text: "streak words",
+                duration: 1,
+                detectedLanguage: "en",
+                audioLengthSeconds: 1,
+                modelUsed: .tiny,
+                timestamp: date
+            ))
+        }
+        XCTAssertEqual(statsManager.stats.currentStreak, 2)
+
+        currentDate = fifthDay
+        statsManager.refreshCurrentStreak()
+
+        XCTAssertEqual(statsManager.stats.currentStreak, 0)
+        XCTAssertEqual(statsManager.stats.bestStreak, 2)
+    }
+
+    @MainActor
+    func testInvalidAudioDurationsDoNotPoisonTotalsOrPersistence() {
+        let transcription = VocaTranscription(
+            text: "valid words",
+            duration: 1,
+            detectedLanguage: "en",
+            audioLengthSeconds: .nan,
+            modelUsed: .tiny
+        )
+
+        statsManager.recordTranscription(transcription)
+        statsManager.flushPendingSaves()
+
+        XCTAssertEqual(statsManager.stats.totalAudioDurationSeconds, 0)
+        XCTAssertEqual(statsManager.stats.averageWPM, 0)
+        XCTAssertNoThrow(try Data(contentsOf: tempFileURL))
+
+        let reloaded = StatsManager(statsFileURL: tempFileURL)
+        XCTAssertEqual(reloaded.stats.totalTranscriptions, 1)
+        XCTAssertEqual(reloaded.stats.totalWords, 2)
+        XCTAssertEqual(reloaded.stats.totalAudioDurationSeconds, 0)
+    }
+
+    @MainActor
+    func testSaveCreatesMissingParentDirectory() throws {
+        let parent = FileManager.default.temporaryDirectory
+            .appendingPathComponent("stats_test_dir_\(UUID().uuidString)", isDirectory: true)
+        let nestedURL = parent.appendingPathComponent("nested/stats.json")
+        defer { try? FileManager.default.removeItem(at: parent) }
+        statsManager = StatsManager(statsFileURL: nestedURL)
+
+        statsManager.recordTranscription(VocaTranscription(
+            text: "persist me",
+            duration: 1,
+            detectedLanguage: "en",
+            audioLengthSeconds: 1,
+            modelUsed: .tiny
+        ))
+        statsManager.flushPendingSaves()
+
+        XCTAssertTrue(FileManager.default.fileExists(atPath: nestedURL.path))
+        let decoded = try JSONDecoder().decode(UserStats.self, from: Data(contentsOf: nestedURL))
+        XCTAssertEqual(decoded.totalTranscriptions, 1)
+    }
+
+    @MainActor
+    func testCountsSaturateInsteadOfOverflowing() throws {
+        let date = Date(timeIntervalSince1970: 1_789_000_000)
+        var savedStats = UserStats()
+        savedStats.totalWords = Int.max
+        savedStats.totalTranscriptions = Int.max
+        savedStats.dailyWordCounts = ["2026-09-10": Int.max]
+        try JSONEncoder().encode(savedStats).write(to: tempFileURL)
+        statsManager = StatsManager(statsFileURL: tempFileURL, now: { date })
+
+        statsManager.recordTranscription(VocaTranscription(
+            text: "one more",
+            duration: 1,
+            detectedLanguage: "en",
+            audioLengthSeconds: 1,
+            modelUsed: .tiny,
+            timestamp: date
+        ))
+
+        XCTAssertEqual(statsManager.stats.totalWords, Int.max)
+        XCTAssertEqual(statsManager.stats.totalTranscriptions, Int.max)
     }
 }

--- a/Tests/VocaMacTests/StatsShareCardTests.swift
+++ b/Tests/VocaMacTests/StatsShareCardTests.swift
@@ -187,6 +187,62 @@ final class StatsShareCardTests: XCTestCase {
         }
     }
 
+    func testPluralizedCountsUseSingularAndGroupedPluralForms() {
+        XCTAssertEqual(StatsShareComposer.pluralized(1, "day"), "1 day")
+        XCTAssertEqual(StatsShareComposer.pluralized(12_500, "word"), "12,500 words")
+    }
+
+    @MainActor
+    func testFailedComposerOpenDoesNotAttemptToReplaceClipboard() {
+        var copied = false
+
+        let outcome = StatsShareExporter.share(
+            makeSnapshot(),
+            to: .x,
+            openURL: { _ in false },
+            copyCard: { _ in
+                copied = true
+                return true
+            }
+        )
+
+        XCTAssertEqual(outcome, .failed)
+        XCTAssertFalse(copied)
+    }
+
+    @MainActor
+    func testSuccessfulComposerOpenCopiesCardAfterOpening() {
+        var events: [String] = []
+
+        let outcome = StatsShareExporter.share(
+            makeSnapshot(),
+            to: .linkedIn,
+            openURL: { _ in
+                events.append("opened")
+                return true
+            },
+            copyCard: { _ in
+                events.append("copied")
+                return true
+            }
+        )
+
+        XCTAssertEqual(outcome, .shared)
+        XCTAssertEqual(events, ["opened", "copied"])
+    }
+
+    @MainActor
+    func testOpenComposerReportsWhenCardCopyFails() {
+        let outcome = StatsShareExporter.share(
+            makeSnapshot(),
+            to: .x,
+            openURL: { _ in true },
+            copyCard: { _ in false }
+        )
+
+        XCTAssertEqual(outcome, .sharedWithoutCard)
+    }
+
     /// The encoder's actual guarantee, exercised with separators the generated
     /// post text does not happen to contain.
     func testEncoderEscapesSeparatorsInsideValues() throws {


### PR DESCRIPTION
## Problem

Usage statistics could show a stale or incorrect streak after missed days, backfilled results, non-Gregorian calendars, or time-zone changes. Malformed saved values and invalid engine durations could also discard otherwise valid history, break JSON persistence, or overflow counters. The final asynchronous save was not flushed at quit, and a failed social composer launch could still replace the clipboard.

## Summary

- derive current and best streaks from recorded daily activity and refresh them on calendar changes
- persist the statistics time zone so travel cannot reinterpret historical day keys
- distinguish real zero-word transcriptions from corrupt negative buckets, migrate legacy zero-word activity, and ignore future buckets during streak reconstruction
- keep day keys Gregorian while honoring the statistics time zone
- salvage valid saved fields, normalize invalid values, and saturate unsafe counters and durations
- create missing persistence directories and flush queued snapshots at application termination
- open social composers before replacing the clipboard and cover each outcome with injected tests
- fix singular labels, filter invalid recent-day keys, and disable Share and Reset when there is no data

## Verification

- `swift test`: 888 passed, 4 environment-dependent skips, 0 failures
- `VOCAMAC_KEEP_RUNNING=1 CODE_SIGN_IDENTITY=- ./scripts/build.sh debug`
- `codesign --verify --deep --strict --verbose=2 VocaMac.app`
- `git diff --check`
- rebased onto upstream `main` at `e31bfe3`; intervening changes only touched `README.md` and `web/`
