### PR TITLE
fix: mute other audio while dictating instead of lowering the volume

### DIFF
--- a/Sources/VocaMac/Models/AppState.swift
+++ b/Sources/VocaMac/Models/AppState.swift
@@ -92,8 +92,8 @@ final class AppState: ObservableObject {
     /// Every way a recording ends — stop, cancel, force recovery, a failed
     /// start, an input device change, auto-pause — sets this to `false`, so
     /// this is the one place that reliably sees the microphone close. Other
-    /// audio ducked for the recording is restored here rather than at each
-    /// of those exits; `restore()` is a no-op when nothing was ducked.
+    /// audio muted for the recording is restored here rather than at each
+    /// of those exits; `restore()` is a no-op when nothing was muted.
     @Published var isRecording: Bool = false {
         didSet {
             if !isRecording {
@@ -790,7 +790,7 @@ final class AppState: ObservableObject {
             .store(in: &cancellables)
 
         // Quit and Restart call `terminate` without setting `isRecording` to
-        // false, so the didSet restore never runs. Restore ducked volume here
+        // false, so the didSet restore never runs. Unmute other audio here
         // directly. A second restore is a no-op when nothing is pending.
         NotificationCenter.default.publisher(for: NSApplication.willTerminateNotification)
             .sink { [weak self] _ in
@@ -1380,6 +1380,7 @@ final class AppState: ObservableObject {
         }
 
         recordingGeneration = UUID()
+        let generation = recordingGeneration
         recordingInjectsResult = injectResult
         appStatus = .recording
         isRecording = true
@@ -1397,13 +1398,6 @@ final class AppState: ObservableObject {
         // Start recording immediately for instant responsiveness.
         // The start sound is played concurrently — any brief bleed into the
         // mic buffer is negligible and handled well by WhisperKit's noise model.
-        // Lower other audio before the microphone opens, so none of it lands
-        // in the first buffers. Restored from `isRecording`'s observer on
-        // every exit, including a start that fails below.
-        if duckOtherAudioEnabled {
-            audioDucker.duck()
-        }
-
         isStartingAudio = true
         pendingStopDuringStart = nil
         let session = whisperService.startStreaming(language: selectedLanguage == "auto" ? nil : selectedLanguage)
@@ -1452,8 +1446,23 @@ final class AppState: ObservableObject {
 
         // Play start sound after mic is active (fire-and-forget).
         // Off is a stored tone and stays silent even when this switch is on.
+        // Muting other audio would silence the cue too, so when that is on,
+        // let the cue finish first.
         if soundEffectsEnabled && isRecording && appStatus == .recording {
-            soundManager.playStartSound()
+            if duckOtherAudioEnabled {
+                await soundManager.playStartSoundAsync()
+            } else {
+                soundManager.playStartSound()
+            }
+        }
+
+        // Mute other audio once the microphone is live, so a start that never
+        // gets a route leaves playback alone. Undone from `isRecording`'s
+        // observer on every exit. The recording may have ended, or a new one
+        // begun, while the cue played.
+        if duckOtherAudioEnabled && isRecording && appStatus == .recording
+            && recordingGeneration == generation {
+            audioDucker.duck()
         }
     }
 

--- a/Sources/VocaMac/Models/SettingsSearchIndex.swift
+++ b/Sources/VocaMac/Models/SettingsSearchIndex.swift
@@ -208,7 +208,7 @@ enum SettingsSearchIndex {
             id: "other-audio",
             page: .audio,
             title: "Other Audio",
-            subtitle: "Lower music while dictating",
+            subtitle: "Mute music while dictating",
             keywords: ["duck", "mute", "music", "volume", "quiet", "lower", "playback", "youtube"]
         ),
 

--- a/Sources/VocaMac/Services/AudioDucker.swift
+++ b/Sources/VocaMac/Services/AudioDucker.swift
@@ -343,14 +343,7 @@ final class AudioDucker: AudioDucking {
 
     func restore() {
         guard !pending.isEmpty else { return }
-        let restoredAt = now()
-        for var record in undoPending(reason: "recording ended") {
-            record.restoredAt = restoredAt
-            settling[record.deviceUID] = record
-        }
-        persistRecords()
-        guard !settling.isEmpty || !pending.isEmpty else { return }
-        scheduleSettleCheck()
+        undoPendingAndScheduleSettleCheck(reason: "recording ended")
     }
 
     func restoreAfterUnexpectedExit() {
@@ -362,11 +355,24 @@ final class AudioDucker: AudioDucking {
             }
             pending[record.deviceUID] = record
         }
-        undoPending(reason: "previous run ended while muted")
-        persistRecords()
+        // The headset may still be leaving its call profile, so settle here too.
+        undoPendingAndScheduleSettleCheck(reason: "previous run ended while muted")
     }
 
     // MARK: Undo
+
+    /// Undoes the pending records, keeps the finished ones for the settle
+    /// check, and schedules it while anything is left to check or retry.
+    private func undoPendingAndScheduleSettleCheck(reason: String) {
+        let restoredAt = now()
+        for var record in undoPending(reason: reason) {
+            record.restoredAt = restoredAt
+            settling[record.deviceUID] = record
+        }
+        persistRecords()
+        guard !settling.isEmpty || !pending.isEmpty else { return }
+        scheduleSettleCheck()
+    }
 
     /// Undoes every pending record whose device is connected, removing the
     /// ones that are finished. Records whose device is missing or whose

--- a/Sources/VocaMac/Services/AudioDucker.swift
+++ b/Sources/VocaMac/Services/AudioDucker.swift
@@ -209,6 +209,12 @@ final class SystemOutputAudioControl: OutputAudioControlling {
 /// Devices without a mute control get their volume set to zero and put back
 /// to the exact previous level, which, unlike lowering it partway, needs no
 /// tolerance to tell "still where we left it" from "the user moved it".
+///
+/// A mute the user switches off and on again during one recording looks the
+/// same as VocaMac's own and is undone with it. Telling them apart needs a
+/// mute-change listener, and a listener that took a headset's profile switch
+/// for the user unmuting would leave the output muted for good — worse than
+/// the double toggle it guards against.
 final class AudioDucker: AudioDucking {
 
     /// How a device was silenced, which decides how it is undone.
@@ -222,11 +228,14 @@ final class AudioDucker: AudioDucking {
         case zeroedVolume(from: Float)
     }
 
-    /// A device the ducker silenced and has not yet undone.
+    /// A device the ducker silenced.
     struct PendingRestore: Codable, Equatable {
         let deviceUID: String
         let silencing: Silencing
         let date: Date
+        /// When the end-of-recording restore undid it, leaving only the
+        /// settle check; `nil` while the device is still silenced.
+        var restoredAt: Date? = nil
     }
 
     static let pendingRestoreKey = "vocamac.duckOtherAudio.pendingMute"
@@ -246,6 +255,11 @@ final class AudioDucker: AudioDucking {
     /// device has been gone too long to assume its state is still ours.
     static let maxPendingAge: TimeInterval = 24 * 60 * 60
 
+    /// A relaunch this soon after a restore still runs the settle check the
+    /// previous process did not get to. Later, the record is dropped: the
+    /// output was already put back, and any mute since is the user's.
+    static let settleRecoveryWindow: TimeInterval = 60
+
     private let control: OutputAudioControlling
     private let defaults: UserDefaults
     private let now: () -> Date
@@ -254,6 +268,7 @@ final class AudioDucker: AudioDucking {
     /// Silenced and not yet undone, keyed by device UID. Persisted.
     private var pending: [String: PendingRestore] = [:]
     /// Undone at the end of the last recording, awaiting the settle check.
+    /// Persisted, so a quit or crash inside the window is still covered.
     private var settling: [String: PendingRestore] = [:]
     /// Bumped to cancel a scheduled settle check.
     private var settleGeneration = 0
@@ -328,23 +343,27 @@ final class AudioDucker: AudioDucking {
 
     func restore() {
         guard !pending.isEmpty else { return }
-        let undone = undoPending(reason: "recording ended")
-        persistPending()
-        guard !undone.isEmpty || !pending.isEmpty else { return }
-        for record in undone {
+        let restoredAt = now()
+        for var record in undoPending(reason: "recording ended") {
+            record.restoredAt = restoredAt
             settling[record.deviceUID] = record
         }
+        persistRecords()
+        guard !settling.isEmpty || !pending.isEmpty else { return }
         scheduleSettleCheck()
     }
 
     func restoreAfterUnexpectedExit() {
         defaults.removeObject(forKey: Self.legacyPendingRestoreKey)
-        for record in loadPersisted() where pending[record.deviceUID] == nil {
+        for var record in loadPersisted() where pending[record.deviceUID] == nil {
+            if let restoredAt = record.restoredAt {
+                guard now().timeIntervalSince(restoredAt) <= Self.settleRecoveryWindow else { continue }
+                record.restoredAt = nil
+            }
             pending[record.deviceUID] = record
         }
-        guard !pending.isEmpty else { return }
         undoPending(reason: "previous run ended while muted")
-        persistPending()
+        persistRecords()
     }
 
     // MARK: Undo
@@ -389,10 +408,8 @@ final class AudioDucker: AudioDucking {
                 }
                 VocaLogger.info(.audioDucker, "Unmuted device \(deviceID) (\(reason))")
             }
-            if let volume {
-                restoreVolumeIfZeroed(volume, on: deviceID, reason: reason)
-            }
-            return true
+            guard let volume else { return true }
+            return restoreVolumeIfZeroed(volume, on: deviceID, reason: reason)
 
         case .zeroedVolume(let volume):
             guard let current = control.volume(of: deviceID) else {
@@ -410,19 +427,27 @@ final class AudioDucker: AudioDucking {
     }
 
     /// Covers drivers that mute by zeroing the volume and leave it there.
-    private func restoreVolumeIfZeroed(_ volume: Float, on deviceID: AudioDeviceID, reason: String) {
+    /// - Returns: `false` only when the volume is still zero and could not
+    ///   be put back, so the record is kept for a retry.
+    private func restoreVolumeIfZeroed(_ volume: Float, on deviceID: AudioDeviceID, reason: String) -> Bool {
         guard volume > Self.silentVolume,
               let current = control.volume(of: deviceID),
-              current <= Self.silentVolume,
-              control.setVolume(volume, of: deviceID) else { return }
+              current <= Self.silentVolume else { return true }
+        guard control.setVolume(volume, of: deviceID) else {
+            VocaLogger.warning(.audioDucker, "Unmuting left device \(deviceID) at 0% and it could not be restored (\(reason))")
+            return false
+        }
         VocaLogger.info(
             .audioDucker,
             "Unmuting left device \(deviceID) at 0% — restored \(Self.percent(volume)) (\(reason))"
         )
+        return true
     }
 
     // MARK: Settle check
 
+    /// Runs `runSettleCheck` after `settleDelay`, replacing any check
+    /// already scheduled.
     private func scheduleSettleCheck() {
         settleGeneration += 1
         let generation = settleGeneration
@@ -448,30 +473,36 @@ final class AudioDucker: AudioDucking {
             }
             // The device left mid-switch, or the unmute failed: keep the
             // record so the next recording or launch tries again.
-            pending[uid] = pending[uid] ?? record
+            var retry = record
+            retry.restoredAt = nil
+            pending[uid] = pending[uid] ?? retry
         }
-        persistPending()
+        persistRecords()
     }
 
     // MARK: Persistence
 
+    /// Takes ownership of what `duck` just did to `output`, and saves it.
     private func record(_ output: OutputDevice, _ silencing: Silencing) {
         pending[output.uid] = PendingRestore(deviceUID: output.uid, silencing: silencing, date: now())
-        persistPending()
+        persistRecords()
     }
 
-    /// Saves the pending set so a crash mid-dictation can be undone on the
-    /// next launch. An empty set clears the key.
-    private func persistPending() {
-        guard !pending.isEmpty else {
+    /// Saves the pending and settling records so a crash or quit can be
+    /// undone on the next launch. No records clears the key.
+    private func persistRecords() {
+        let records = pending.merging(settling) { pending, _ in pending }
+            .values
+            .sorted { $0.deviceUID < $1.deviceUID }
+        guard !records.isEmpty else {
             defaults.removeObject(forKey: Self.pendingRestoreKey)
             return
         }
-        let records = pending.values.sorted { $0.deviceUID < $1.deviceUID }
         guard let data = try? JSONEncoder().encode(records) else { return }
         defaults.set(data, forKey: Self.pendingRestoreKey)
     }
 
+    /// Records the previous process saved; empty if none or unreadable.
     private func loadPersisted() -> [PendingRestore] {
         guard let data = defaults.data(forKey: Self.pendingRestoreKey) else { return [] }
         return (try? JSONDecoder().decode([PendingRestore].self, from: data)) ?? []

--- a/Sources/VocaMac/Services/AudioDucker.swift
+++ b/Sources/VocaMac/Services/AudioDucker.swift
@@ -1,269 +1,480 @@
 // AudioDucker.swift
 // VocaMac
 //
-// Lowers the system output volume while a recording is open so music or a
-// video does not play at full volume into the microphone, then puts it back
-// the way it was. Apple's own dictation ducks other audio; macOS offers no
-// per-process ducking to third parties, so this drives the default output
-// device's main volume — the same control as the volume keys.
+// Mutes the default output while a recording is open so music or a video
+// does not play into the microphone, then unmutes it — what other dictation
+// apps (Wispr Flow, VoiceInk) do. macOS offers third parties no per-app
+// ducking, and lowering the main volume cannot be undone reliably: Bluetooth
+// headsets keep a separate volume while their microphone is open, so the
+// lowered level can neither be read back nor put back until well after the
+// recording ends. Mute is a single flag that survives that switch.
 
 import AudioToolbox
 import CoreAudio
 import Foundation
 
-// MARK: - OutputVolumeControlling
+// MARK: - OutputAudioControlling
 
-/// The default output device and its main volume in `0...1`.
-struct OutputVolumeSnapshot: Equatable {
-    let deviceID: AudioDeviceID
-    let volume: Float
+/// An output device: its CoreAudio ID for this session, and its UID, which
+/// stays the same across reconnects and relaunches.
+struct OutputDevice: Equatable {
+    let id: AudioDeviceID
+    let uid: String
 }
 
 /// The CoreAudio surface `AudioDucker` depends on, kept behind a protocol so
-/// the ducking policy can be tested without touching real hardware.
-protocol OutputVolumeControlling: AnyObject {
-    /// The default output device with its current main volume, or `nil` when
-    /// that device has no software-settable volume (HDMI and some AirPlay
-    /// outputs) — ducking is then impossible and silently skipped.
-    func defaultOutput() -> OutputVolumeSnapshot?
+/// the policy can be tested without touching real hardware.
+protocol OutputAudioControlling: AnyObject {
+    /// The current default output device, or `nil` if there is none.
+    func defaultOutputDevice() -> OutputDevice?
 
-    /// The main volume of a specific device, or `nil` if the device is gone
-    /// or has no software volume.
+    /// The current ID of the device with `uid`, or `nil` if it is not connected.
+    func deviceID(forUID uid: String) -> AudioDeviceID?
+
+    /// Whether any other process is playing audio right now.
+    func isOtherAudioPlaying(on deviceID: AudioDeviceID) -> Bool
+
+    /// The device's mute state, or `nil` when it has no settable mute control.
+    func isMuted(_ deviceID: AudioDeviceID) -> Bool?
+
+    /// Sets the device's mute state. Returns `false` on failure.
+    @discardableResult
+    func setMuted(_ muted: Bool, on deviceID: AudioDeviceID) -> Bool
+
+    /// The device's main volume in `0...1`, or `nil` when it has no
+    /// software-settable volume.
     func volume(of deviceID: AudioDeviceID) -> Float?
 
-    /// Sets the main volume of a specific device. Returns `false` on failure.
+    /// Sets the device's main volume. Returns `false` on failure.
     @discardableResult
     func setVolume(_ volume: Float, of deviceID: AudioDeviceID) -> Bool
 }
 
-// MARK: - SystemOutputVolumeControl
+// MARK: - SystemOutputAudioControl
 
-/// CoreAudio implementation of `OutputVolumeControlling`. Not unit-tested:
+/// CoreAudio implementation of `OutputAudioControlling`. Not unit-tested:
 /// it is thin, and its behaviour depends on the output device in use.
-final class SystemOutputVolumeControl: OutputVolumeControlling {
+final class SystemOutputAudioControl: OutputAudioControlling {
 
-    private var volumeAddress = AudioObjectPropertyAddress(
-        mSelector: kAudioHardwareServiceDeviceProperty_VirtualMainVolume,
-        mScope: kAudioDevicePropertyScopeOutput,
-        mElement: kAudioObjectPropertyElementMain
-    )
+    private let systemObject = AudioObjectID(kAudioObjectSystemObject)
 
-    func defaultOutput() -> OutputVolumeSnapshot? {
-        var address = AudioObjectPropertyAddress(
-            mSelector: kAudioHardwarePropertyDefaultOutputDevice,
-            mScope: kAudioObjectPropertyScopeGlobal,
-            mElement: kAudioObjectPropertyElementMain
-        )
-        var deviceID = AudioDeviceID(0)
-        var size = UInt32(MemoryLayout<AudioDeviceID>.size)
-        let status = AudioObjectGetPropertyData(
-            AudioObjectID(kAudioObjectSystemObject), &address, 0, nil, &size, &deviceID
-        )
-        guard status == noErr, deviceID != kAudioObjectUnknown else { return nil }
-        guard let volume = volume(of: deviceID) else { return nil }
-        return OutputVolumeSnapshot(deviceID: deviceID, volume: volume)
+    func defaultOutputDevice() -> OutputDevice? {
+        var deviceID = AudioDeviceID(kAudioObjectUnknown)
+        guard read(systemObject, kAudioHardwarePropertyDefaultOutputDevice, into: &deviceID),
+              deviceID != kAudioObjectUnknown,
+              let uid = uid(of: deviceID) else { return nil }
+        return OutputDevice(id: deviceID, uid: uid)
+    }
+
+    func deviceID(forUID uid: String) -> AudioDeviceID? {
+        objectList(kAudioHardwarePropertyDevices).first { self.uid(of: $0) == uid }
+    }
+
+    func isOtherAudioPlaying(on deviceID: AudioDeviceID) -> Bool {
+        // Process objects let VocaMac's own cue be told apart from other
+        // apps' audio. Before macOS 14.2, fall back to whether anything at
+        // all is running on the device.
+        if #available(macOS 14.2, *) {
+            let ownPID = ProcessInfo.processInfo.processIdentifier
+            let processes = objectList(kAudioHardwarePropertyProcessObjectList)
+            if !processes.isEmpty {
+                return processes.contains { process in
+                    var pid: pid_t = 0
+                    var isRunningOutput: UInt32 = 0
+                    return read(process, kAudioProcessPropertyPID, into: &pid)
+                        && pid != ownPID
+                        && read(process, kAudioProcessPropertyIsRunningOutput, into: &isRunningOutput)
+                        && isRunningOutput != 0
+                }
+            }
+        }
+        var isRunning: UInt32 = 0
+        guard read(deviceID, kAudioDevicePropertyDeviceIsRunningSomewhere, into: &isRunning) else {
+            // Unknown: muting something silent is harmless, missing music is not.
+            return true
+        }
+        return isRunning != 0
+    }
+
+    func isMuted(_ deviceID: AudioDeviceID) -> Bool? {
+        guard isSettable(deviceID, kAudioDevicePropertyMute) else { return nil }
+        var muted: UInt32 = 0
+        guard read(deviceID, kAudioDevicePropertyMute, scope: kAudioDevicePropertyScopeOutput, into: &muted) else {
+            return nil
+        }
+        return muted != 0
+    }
+
+    @discardableResult
+    func setMuted(_ muted: Bool, on deviceID: AudioDeviceID) -> Bool {
+        write(deviceID, kAudioDevicePropertyMute, value: UInt32(muted ? 1 : 0))
     }
 
     func volume(of deviceID: AudioDeviceID) -> Float? {
-        guard AudioObjectHasProperty(deviceID, &volumeAddress) else { return nil }
-        var settable: DarwinBoolean = false
-        guard AudioObjectIsPropertySettable(deviceID, &volumeAddress, &settable) == noErr,
-              settable.boolValue else { return nil }
+        guard isSettable(deviceID, kAudioHardwareServiceDeviceProperty_VirtualMainVolume) else { return nil }
         var volume: Float32 = 0
-        var size = UInt32(MemoryLayout<Float32>.size)
-        guard AudioObjectGetPropertyData(deviceID, &volumeAddress, 0, nil, &size, &volume) == noErr else {
-            return nil
-        }
+        guard read(
+            deviceID,
+            kAudioHardwareServiceDeviceProperty_VirtualMainVolume,
+            scope: kAudioDevicePropertyScopeOutput,
+            into: &volume
+        ) else { return nil }
         return volume
     }
 
     @discardableResult
     func setVolume(_ volume: Float, of deviceID: AudioDeviceID) -> Bool {
-        var value = Float32(min(max(volume, 0), 1))
-        let size = UInt32(MemoryLayout<Float32>.size)
-        return AudioObjectSetPropertyData(deviceID, &volumeAddress, 0, nil, size, &value) == noErr
+        write(
+            deviceID,
+            kAudioHardwareServiceDeviceProperty_VirtualMainVolume,
+            value: Float32(min(max(volume, 0), 1))
+        )
+    }
+
+    // MARK: Property access
+
+    private func uid(of deviceID: AudioDeviceID) -> String? {
+        var uid: Unmanaged<CFString>?
+        guard read(deviceID, kAudioDevicePropertyDeviceUID, into: &uid), let uid else { return nil }
+        return uid.takeRetainedValue() as String
+    }
+
+    private func objectList(_ selector: AudioObjectPropertySelector) -> [AudioObjectID] {
+        var address = Self.address(selector, scope: kAudioObjectPropertyScopeGlobal)
+        var size: UInt32 = 0
+        guard AudioObjectGetPropertyDataSize(systemObject, &address, 0, nil, &size) == noErr else { return [] }
+        let stride = MemoryLayout<AudioObjectID>.stride
+        var objects = [AudioObjectID](repeating: 0, count: Int(size) / stride)
+        guard !objects.isEmpty,
+              AudioObjectGetPropertyData(systemObject, &address, 0, nil, &size, &objects) == noErr else { return [] }
+        return Array(objects.prefix(Int(size) / stride))
+    }
+
+    private func isSettable(_ deviceID: AudioDeviceID, _ selector: AudioObjectPropertySelector) -> Bool {
+        var address = Self.address(selector, scope: kAudioDevicePropertyScopeOutput)
+        guard AudioObjectHasProperty(deviceID, &address) else { return false }
+        var settable: DarwinBoolean = false
+        return AudioObjectIsPropertySettable(deviceID, &address, &settable) == noErr && settable.boolValue
+    }
+
+    private func read<Value>(
+        _ object: AudioObjectID,
+        _ selector: AudioObjectPropertySelector,
+        scope: AudioObjectPropertyScope = kAudioObjectPropertyScopeGlobal,
+        into value: inout Value
+    ) -> Bool {
+        var address = Self.address(selector, scope: scope)
+        var size = UInt32(MemoryLayout<Value>.size)
+        return withUnsafeMutablePointer(to: &value) { pointer in
+            AudioObjectGetPropertyData(object, &address, 0, nil, &size, pointer) == noErr
+        }
+    }
+
+    private func write<Value>(
+        _ deviceID: AudioDeviceID,
+        _ selector: AudioObjectPropertySelector,
+        value: Value
+    ) -> Bool {
+        var address = Self.address(selector, scope: kAudioDevicePropertyScopeOutput)
+        let size = UInt32(MemoryLayout<Value>.size)
+        return withUnsafePointer(to: value) { pointer in
+            AudioObjectSetPropertyData(deviceID, &address, 0, nil, size, pointer) == noErr
+        }
+    }
+
+    private static func address(
+        _ selector: AudioObjectPropertySelector,
+        scope: AudioObjectPropertyScope
+    ) -> AudioObjectPropertyAddress {
+        AudioObjectPropertyAddress(mSelector: selector, mScope: scope, mElement: kAudioObjectPropertyElementMain)
     }
 }
 
 // MARK: - AudioDucker
 
-/// Ducks the default output for the duration of a recording and restores it
-/// afterwards. The volume is shared system state, so the rules are
-/// conservative: restore only what was lowered, only on the device it was
-/// lowered on, and only if nobody moved the slider in between.
+/// Mutes the default output for the duration of a recording and unmutes it
+/// afterwards. The output is shared system state, so the rules are
+/// conservative:
 ///
-/// Pending restores are keyed by device so an unresolved restore on one
-/// output does not block ducking a different readable output, and is never
-/// discarded just to start that later duck. They are also persisted, so a
-/// crash mid-dictation does not leave the Mac quiet: the next launch calls
-/// `restoreAfterUnexpectedExit()`.
+/// - Only touch the output when another app is actually playing.
+/// - Never take over a mute the user set; if they unmute during the
+///   recording, do not mute again.
+/// - Undo only on the device that was muted, found by UID so a reconnect or
+///   relaunch still finds it.
+/// - Undoing is idempotent: it acts only while the device is still silenced
+///   the way the ducker left it. That makes it safe to repeat once the output
+///   route has settled — a Bluetooth headset leaves its call profile a couple
+///   of seconds after the microphone closes — and after a crash.
+///
+/// Devices without a mute control get their volume set to zero and put back
+/// to the exact previous level, which, unlike lowering it partway, needs no
+/// tolerance to tell "still where we left it" from "the user moved it".
 final class AudioDucker: AudioDucking {
 
-    /// What `restore()` needs: where the volume was, and where it was put.
-    struct PendingRestore: Codable, Equatable {
-        let deviceID: UInt32
-        let originalVolume: Float
-        let duckedVolume: Float
+    /// How a device was silenced, which decides how it is undone.
+    enum Silencing: Codable, Equatable {
+        /// Muted with the device's mute control. `volume` is the main volume
+        /// at that moment: some USB drivers mute by zeroing it and leave it
+        /// there after unmuting.
+        case muted(volume: Float?)
+        /// The device has no working mute control, so its volume was set to
+        /// zero from `volume`.
+        case zeroedVolume(from: Float)
     }
 
-    static let pendingRestoreKey = "vocamac.duckOtherAudio.pendingRestore"
+    /// A device the ducker silenced and has not yet undone.
+    struct PendingRestore: Codable, Equatable {
+        let deviceUID: String
+        let silencing: Silencing
+        let date: Date
+    }
 
-    /// Fraction of the current volume kept while dictating. Loud enough to
-    /// keep following a video, quiet enough not to reach the microphone.
-    static let duckedFraction: Float = 0.25
+    static let pendingRestoreKey = "vocamac.duckOtherAudio.pendingMute"
+    /// Written by the volume-lowering version of this feature. Its records
+    /// cannot be trusted (see the file header), so they are dropped.
+    static let legacyPendingRestoreKey = "vocamac.duckOtherAudio.pendingRestore"
 
-    /// Volumes closer than this count as untouched. CoreAudio may hand back
-    /// a value that differs from what was set by float rounding.
-    static let volumeTolerance: Float = 0.01
+    /// Volumes at or below this count as silent.
+    static let silentVolume: Float = 0.01
 
-    private let control: OutputVolumeControlling
+    /// How long after a recording ends to check the output once more. A
+    /// Bluetooth headset takes about two seconds to leave its call profile
+    /// after the microphone closes.
+    static let settleDelay: TimeInterval = 3
+
+    /// A pending restore older than this is dropped rather than applied: the
+    /// device has been gone too long to assume its state is still ours.
+    static let maxPendingAge: TimeInterval = 24 * 60 * 60
+
+    private let control: OutputAudioControlling
     private let defaults: UserDefaults
-    /// Unresolved restores keyed by CoreAudio device ID.
-    private var pending: [UInt32: PendingRestore] = [:]
+    private let now: () -> Date
+    private let schedule: (TimeInterval, @escaping () -> Void) -> Void
+
+    /// Silenced and not yet undone, keyed by device UID. Persisted.
+    private var pending: [String: PendingRestore] = [:]
+    /// Undone at the end of the last recording, awaiting the settle check.
+    private var settling: [String: PendingRestore] = [:]
+    /// Bumped to cancel a scheduled settle check.
+    private var settleGeneration = 0
 
     init(
-        control: OutputVolumeControlling = SystemOutputVolumeControl(),
-        defaults: UserDefaults = .standard
+        control: OutputAudioControlling = SystemOutputAudioControl(),
+        defaults: UserDefaults = .standard,
+        now: @escaping () -> Date = Date.init,
+        schedule: @escaping (TimeInterval, @escaping () -> Void) -> Void = { delay, work in
+            DispatchQueue.main.asyncAfter(deadline: .now() + delay, execute: work)
+        }
     ) {
         self.control = control
         self.defaults = defaults
+        self.now = now
+        self.schedule = schedule
     }
 
     // MARK: AudioDucking
 
     func duck() {
-        guard let output = control.defaultOutput() else {
-            VocaLogger.info(.audioDucker, "Default output has no software volume — not ducking")
+        // Run a settle check still waiting on the last recording now, so a
+        // device it would have unmuted is not mistaken for a user's mute.
+        settleGeneration += 1
+        runSettleCheck(reason: "before a new recording")
+
+        guard let output = control.defaultOutputDevice() else {
+            VocaLogger.info(.audioDucker, "No default output device — not muting")
             return
         }
-        guard pending[output.deviceID] == nil else {
-            VocaLogger.debug(.audioDucker, "Already ducked — ignoring second duck")
+        guard pending[output.uid] == nil else {
+            VocaLogger.debug(.audioDucker, "Output is still muted from an earlier recording — leaving it")
+            return
+        }
+        guard control.isOtherAudioPlaying(on: output.id) else {
+            VocaLogger.debug(.audioDucker, "Nothing else is playing — leaving the output alone")
             return
         }
 
-        let hadPending = !pending.isEmpty
-        attemptRestore(except: output.deviceID, reason: "before ducking another device")
+        let volume = control.volume(of: output.id)
+        if let isMuted = control.isMuted(output.id) {
+            if isMuted {
+                VocaLogger.info(.audioDucker, "Output is already muted — leaving it as the user set it")
+                return
+            }
+            if control.setMuted(true, on: output.id), control.isMuted(output.id) == true {
+                record(output, .muted(volume: volume))
+                VocaLogger.info(.audioDucker, "Muted device \(output.id) while dictating")
+                return
+            }
+            // Some drivers acknowledge the write and do nothing. Put the flag
+            // back in case it half-applied, then use the volume instead.
+            control.setMuted(false, on: output.id)
+            VocaLogger.warning(.audioDucker, "Mute did not take on device \(output.id) — using the volume instead")
+        }
 
-        let target = output.volume * Self.duckedFraction
-        guard output.volume - target > Self.volumeTolerance else {
-            VocaLogger.debug(.audioDucker, "Output already at \(Self.percent(output.volume)) — nothing to duck")
-            if hadPending { persistPending() }
+        guard let volume else {
+            VocaLogger.info(.audioDucker, "Output has no mute or software volume (e.g. HDMI) — not muting")
             return
         }
-        guard control.setVolume(target, of: output.deviceID) else {
-            VocaLogger.warning(.audioDucker, "Could not set volume on device \(output.deviceID)")
-            if hadPending { persistPending() }
+        guard volume > Self.silentVolume else {
+            VocaLogger.debug(.audioDucker, "Output volume is already at zero — nothing to mute")
             return
         }
-        let record = PendingRestore(
-            deviceID: output.deviceID,
-            originalVolume: output.volume,
-            duckedVolume: target
-        )
-        pending[output.deviceID] = record
-        persistPending()
-        VocaLogger.info(
-            .audioDucker,
-            "Ducked device \(output.deviceID): \(Self.percent(output.volume)) → \(Self.percent(target))"
-        )
+        guard control.setVolume(0, of: output.id) else {
+            VocaLogger.warning(.audioDucker, "Could not set the volume on device \(output.id)")
+            return
+        }
+        record(output, .zeroedVolume(from: volume))
+        VocaLogger.info(.audioDucker, "Set device \(output.id) to 0% while dictating (was \(Self.percent(volume)))")
     }
 
     func restore() {
         guard !pending.isEmpty else { return }
-        attemptRestore(reason: "recording ended")
+        let undone = undoPending(reason: "recording ended")
         persistPending()
+        guard !undone.isEmpty || !pending.isEmpty else { return }
+        for record in undone {
+            settling[record.deviceUID] = record
+        }
+        scheduleSettleCheck()
     }
 
     func restoreAfterUnexpectedExit() {
-        if pending.isEmpty {
-            pending = loadPersisted()
+        defaults.removeObject(forKey: Self.legacyPendingRestoreKey)
+        for record in loadPersisted() where pending[record.deviceUID] == nil {
+            pending[record.deviceUID] = record
         }
         guard !pending.isEmpty else { return }
-        attemptRestore(reason: "previous run ended while ducked")
+        undoPending(reason: "previous run ended while muted")
         persistPending()
     }
 
-    // MARK: Restore policy
+    // MARK: Undo
 
-    /// Applies the restore policy for `record`.
-    /// - Returns: `true` when the pending record may be discarded, `false` when
-    ///   it must be kept so a later retry can still restore the original volume.
-    ///
-    /// Discard (`true`) when the restore write succeeded, or the user moved
-    /// the volume outside ducked tolerance.
-    /// Keep (`false`) when `setVolume` failed while still at the ducked volume,
-    /// or `volume(of:)` returned nil (device unreadability / transient failure).
-    private func finishRestore(_ record: PendingRestore, reason: String) -> Bool {
-        guard let current = control.volume(of: record.deviceID) else {
-            VocaLogger.warning(
-                .audioDucker,
-                "Could not read volume on device \(record.deviceID) — keeping pending restore for retry (\(reason))"
-            )
-            return false
+    /// Undoes every pending record whose device is connected, removing the
+    /// ones that are finished. Records whose device is missing or whose
+    /// write failed stay pending for a later retry; stale ones are dropped.
+    /// - Returns: the records that were removed because they are finished.
+    @discardableResult
+    private func undoPending(reason: String) -> [PendingRestore] {
+        var finished: [PendingRestore] = []
+        for (uid, record) in pending {
+            if now().timeIntervalSince(record.date) > Self.maxPendingAge {
+                VocaLogger.info(.audioDucker, "Dropping a mute too old to undo safely")
+                pending.removeValue(forKey: uid)
+                continue
+            }
+            guard let deviceID = control.deviceID(forUID: uid) else {
+                VocaLogger.info(.audioDucker, "The muted output is not connected — will unmute it when it is (\(reason))")
+                continue
+            }
+            if undo(record, on: deviceID, reason: reason) {
+                pending.removeValue(forKey: uid)
+                finished.append(record)
+            }
         }
-        guard abs(current - record.duckedVolume) <= Self.volumeTolerance else {
-            VocaLogger.info(
-                .audioDucker,
-                "Volume moved to \(Self.percent(current)) while ducked — leaving it alone (\(reason))"
-            )
+        return finished
+    }
+
+    /// Puts `deviceID` back if it is still silenced the way `record` says.
+    /// Idempotent: a device that is no longer silenced — already undone, or
+    /// changed by the user — is left alone.
+    /// - Returns: `true` when finished, `false` when a write failed and a
+    ///   retry may still help.
+    private func undo(_ record: PendingRestore, on deviceID: AudioDeviceID, reason: String) -> Bool {
+        switch record.silencing {
+        case .muted(let volume):
+            if control.isMuted(deviceID) == true {
+                guard control.setMuted(false, on: deviceID) else {
+                    VocaLogger.warning(.audioDucker, "Could not unmute device \(deviceID) (\(reason))")
+                    return false
+                }
+                VocaLogger.info(.audioDucker, "Unmuted device \(deviceID) (\(reason))")
+            }
+            if let volume {
+                restoreVolumeIfZeroed(volume, on: deviceID, reason: reason)
+            }
             return true
-        }
-        if control.setVolume(record.originalVolume, of: record.deviceID) {
-            VocaLogger.info(
-                .audioDucker,
-                "Restored device \(record.deviceID) to \(Self.percent(record.originalVolume)) (\(reason))"
-            )
+
+        case .zeroedVolume(let volume):
+            guard let current = control.volume(of: deviceID) else {
+                VocaLogger.warning(.audioDucker, "Could not read the volume on device \(deviceID) (\(reason))")
+                return false
+            }
+            guard current <= Self.silentVolume else { return true }
+            guard control.setVolume(volume, of: deviceID) else {
+                VocaLogger.warning(.audioDucker, "Could not restore the volume on device \(deviceID) (\(reason))")
+                return false
+            }
+            VocaLogger.info(.audioDucker, "Restored device \(deviceID) to \(Self.percent(volume)) (\(reason))")
             return true
-        } else {
-            VocaLogger.warning(.audioDucker, "Could not restore volume on device \(record.deviceID) (\(reason))")
-            return false
         }
     }
 
-    // MARK: Pending set
+    /// Covers drivers that mute by zeroing the volume and leave it there.
+    private func restoreVolumeIfZeroed(_ volume: Float, on deviceID: AudioDeviceID, reason: String) {
+        guard volume > Self.silentVolume,
+              let current = control.volume(of: deviceID),
+              current <= Self.silentVolume,
+              control.setVolume(volume, of: deviceID) else { return }
+        VocaLogger.info(
+            .audioDucker,
+            "Unmuting left device \(deviceID) at 0% — restored \(Self.percent(volume)) (\(reason))"
+        )
+    }
 
-    /// Runs `finishRestore` for every pending record except `excludedDeviceID`.
-    /// Removes only records that finish successfully; unreadable and failed-write
-    /// pendings stay so a later retry can still restore them.
-    private func attemptRestore(except excludedDeviceID: UInt32? = nil, reason: String) {
-        let deviceIDs = pending.keys.filter { $0 != excludedDeviceID }
-        for deviceID in deviceIDs {
-            guard let record = pending[deviceID] else { continue }
-            if finishRestore(record, reason: reason) {
-                pending.removeValue(forKey: deviceID)
-            }
+    // MARK: Settle check
+
+    private func scheduleSettleCheck() {
+        settleGeneration += 1
+        let generation = settleGeneration
+        schedule(Self.settleDelay) { [weak self] in
+            guard let self, self.settleGeneration == generation else { return }
+            self.runSettleCheck(reason: "output settled")
         }
+    }
+
+    /// Undoes once more what the last recording's restore undid, in case the
+    /// output route switched back to a silenced state, and retries anything
+    /// still pending.
+    private func runSettleCheck(reason: String) {
+        if !pending.isEmpty {
+            undoPending(reason: reason)
+        }
+        let records = settling
+        settling = [:]
+        for (uid, record) in records {
+            if let deviceID = control.deviceID(forUID: uid),
+               undo(record, on: deviceID, reason: reason) {
+                continue
+            }
+            // The device left mid-switch, or the unmute failed: keep the
+            // record so the next recording or launch tries again.
+            pending[uid] = pending[uid] ?? record
+        }
+        persistPending()
     }
 
     // MARK: Persistence
 
-    /// Encodes the full pending set so a crash mid-dictation can restore later.
-    /// An empty set clears the key rather than leaving a stale record.
+    private func record(_ output: OutputDevice, _ silencing: Silencing) {
+        pending[output.uid] = PendingRestore(deviceUID: output.uid, silencing: silencing, date: now())
+        persistPending()
+    }
+
+    /// Saves the pending set so a crash mid-dictation can be undone on the
+    /// next launch. An empty set clears the key.
     private func persistPending() {
         guard !pending.isEmpty else {
             defaults.removeObject(forKey: Self.pendingRestoreKey)
             return
         }
-        let records = pending.values.sorted { $0.deviceID < $1.deviceID }
+        let records = pending.values.sorted { $0.deviceUID < $1.deviceUID }
         guard let data = try? JSONEncoder().encode(records) else { return }
         defaults.set(data, forKey: Self.pendingRestoreKey)
     }
 
-    /// Reads pending restores left by a previous run. Accepts both the current
-    /// array encoding and a legacy single `PendingRestore` object.
-    private func loadPersisted() -> [UInt32: PendingRestore] {
-        guard let data = defaults.data(forKey: Self.pendingRestoreKey) else { return [:] }
-        if let records = try? JSONDecoder().decode([PendingRestore].self, from: data) {
-            var map: [UInt32: PendingRestore] = [:]
-            for record in records {
-                map[record.deviceID] = record
-            }
-            return map
-        }
-        if let record = try? JSONDecoder().decode(PendingRestore.self, from: data) {
-            return [record.deviceID: record]
-        }
-        return [:]
+    private func loadPersisted() -> [PendingRestore] {
+        guard let data = defaults.data(forKey: Self.pendingRestoreKey) else { return [] }
+        return (try? JSONDecoder().decode([PendingRestore].self, from: data)) ?? []
     }
 
     /// Formats `volume` as a whole-number percent for log lines.

--- a/Sources/VocaMac/Services/ServiceProtocols.swift
+++ b/Sources/VocaMac/Services/ServiceProtocols.swift
@@ -62,13 +62,13 @@ extension SoundPlaying {
 
 // MARK: - AudioDucking
 
-/// Lowers other audio while a recording is open and puts it back afterwards.
+/// Silences other audio while a recording is open and brings it back afterwards.
 protocol AudioDucking: AnyObject {
-    /// Lower the default output volume. A second call on the same already-ducked device is ignored.
+    /// Mute the default output if another app is playing and the user has not muted it already.
     func duck()
-    /// Put the volume back if it is still where `duck` left it.
+    /// Unmute what `duck` muted, if it is still muted.
     func restore()
-    /// Undo a duck the previous process did not get to restore (crash, kill).
+    /// Undo a mute the previous process did not get to restore (crash, kill).
     func restoreAfterUnexpectedExit()
 }
 

--- a/Sources/VocaMac/Views/SettingsView.swift
+++ b/Sources/VocaMac/Views/SettingsView.swift
@@ -1392,9 +1392,9 @@ struct AudioSettingsTab: View {
             }
 
             Section("Other Audio") {
-                Toggle("Lower other audio while dictating", isOn: $appState.duckOtherAudioEnabled)
+                Toggle("Mute other audio while dictating", isOn: $appState.duckOtherAudioEnabled)
 
-                Text("Turns the system volume down while the microphone is open — like the built-in dictation — and back up when you stop. Speakers only: it does not affect outputs without a software volume, such as HDMI.")
+                Text("Mutes your speakers or headphones while the microphone is open, then unmutes them when you stop. Only kicks in when something is playing, and leaves a mute you set yourself alone.")
                     .font(.caption)
                     .foregroundStyle(.secondary)
             }

--- a/Tests/VocaMacTests/AppStateDuckingTests.swift
+++ b/Tests/VocaMacTests/AppStateDuckingTests.swift
@@ -1,7 +1,7 @@
 // AppStateDuckingTests.swift
 // VocaMac Tests
 //
-// Other audio is lowered when the microphone opens and restored on every way
+// Other audio is muted once the microphone is live and restored on every way
 // a recording can end — not only the happy path.
 
 import AppKit
@@ -13,6 +13,7 @@ final class AppStateDuckingTests: XCTestCase {
 
     override func tearDown() {
         UserDefaults.standard.removeObject(forKey: PreferenceKey.duckOtherAudioEnabled)
+        UserDefaults.standard.removeObject(forKey: "vocamac.soundEffectsEnabled")
         super.tearDown()
     }
 
@@ -42,6 +43,39 @@ final class AppStateDuckingTests: XCTestCase {
         await appState.stopRecordingAndTranscribe()
 
         XCTAssertEqual(mocks.audioDucker.duckCallCount, 0)
+    }
+
+    func testStartCueFinishesBeforeOtherAudioIsMuted() async {
+        let (appState, mocks) = makeDuckingState()
+        appState.soundEffectsEnabled = true
+        var cuesPlayedBeforeMute: [MockSoundManager.PlayEvent] = []
+        mocks.audioDucker.onDuck = { cuesPlayedBeforeMute = mocks.soundManager.playLog }
+
+        await appState.startRecording()
+
+        XCTAssertEqual(cuesPlayedBeforeMute, [.startAsync], "Muting first would silence the cue")
+        XCTAssertEqual(mocks.soundManager.startSoundCallCount, 0)
+    }
+
+    func testCueStaysFireAndForgetWhenMutingIsOff() async {
+        let (appState, mocks) = makeDuckingState()
+        appState.duckOtherAudioEnabled = false
+        appState.soundEffectsEnabled = true
+
+        await appState.startRecording()
+
+        XCTAssertEqual(mocks.soundManager.playLog, [.start])
+    }
+
+    func testRecordingThatEndsDuringTheCueIsNeverMuted() async {
+        let (appState, mocks) = makeDuckingState()
+        appState.soundEffectsEnabled = true
+        mocks.soundManager.whileStartSoundAsyncPlays = { await appState.cancelRecording() }
+
+        await appState.startRecording()
+
+        XCTAssertFalse(appState.isRecording)
+        XCTAssertEqual(mocks.audioDucker.duckCallCount, 0, "Muting after the recording ended would strand the mute")
     }
 
     func testDeniedMicrophoneNeverDucks() async {
@@ -82,14 +116,14 @@ final class AppStateDuckingTests: XCTestCase {
         XCTAssertEqual(mocks.audioDucker.restoreCallCount, 1)
     }
 
-    func testFailedAudioEngineStartRestores() async {
+    func testFailedAudioEngineStartNeverMutes() async {
         let (appState, mocks) = makeDuckingState()
         mocks.audioEngine.startRecordingResult = false
 
         await appState.startRecording()
 
-        XCTAssertEqual(mocks.audioDucker.duckCallCount, 1, "Ducked before the engine was asked to start")
-        XCTAssertEqual(mocks.audioDucker.restoreCallCount, 1, "…and undone when the start failed")
+        XCTAssertEqual(mocks.audioDucker.duckCallCount, 0, "No live microphone, so playback is left alone")
+        XCTAssertFalse(appState.isRecording)
     }
 
     func testInputDeviceChangeMidRecordingRestores() async {

--- a/Tests/VocaMacTests/AudioDuckerTests.swift
+++ b/Tests/VocaMacTests/AudioDuckerTests.swift
@@ -1,35 +1,86 @@
 // AudioDuckerTests.swift
 // VocaMac Tests
 //
-// The ducking policy against a fake output device. The volume is shared
-// system state, so most of these pin down when the ducker must *not* touch it.
+// The mute-while-dictating policy against a fake output device. The output
+// is shared system state, so most of these pin down when the ducker must
+// *not* touch it, and that whatever it did touch always comes back.
 
+import CoreAudio
 import XCTest
 @testable import VocaMac
 
 // MARK: - Fake output
 
-final class FakeOutputVolumeControl: OutputVolumeControlling {
-    /// Volumes by device. A device missing here "has no software volume".
-    var volumes: [UInt32: Float] = [:]
-    var defaultDeviceID: UInt32? = 1
-    var setCalls: [(deviceID: UInt32, volume: Float)] = []
-    var setShouldFail = false
-
-    func defaultOutput() -> OutputVolumeSnapshot? {
-        guard let id = defaultDeviceID, let volume = volumes[id] else { return nil }
-        return OutputVolumeSnapshot(deviceID: id, volume: volume)
+final class FakeOutputAudioControl: OutputAudioControlling {
+    struct Device {
+        var id: AudioDeviceID
+        /// `nil`: the device has no mute control.
+        var muted: Bool?
+        /// `nil`: the device has no software volume.
+        var volume: Float?
+        var isOtherAudioPlaying = true
     }
 
-    func volume(of deviceID: UInt32) -> Float? {
-        volumes[deviceID]
+    /// Devices by UID. A device missing here is not connected.
+    var devices: [String: Device] = [:]
+    var defaultUID: String? = "speakers"
+
+    var setMutedShouldFail = false
+    /// Drivers that acknowledge a mute write and do nothing.
+    var muteWritesAreIgnored = false
+    /// Drivers that mute by zeroing the volume, and leave it at zero on unmute.
+    var muteZeroesVolume = false
+    var setVolumeShouldFail = false
+
+    private(set) var muteWrites: [(uid: String, muted: Bool)] = []
+    private(set) var volumeWrites: [(uid: String, volume: Float)] = []
+
+    var writeCount: Int { muteWrites.count + volumeWrites.count }
+
+    private func uid(of deviceID: AudioDeviceID) -> String? {
+        devices.first { $0.value.id == deviceID }?.key
+    }
+
+    func defaultOutputDevice() -> OutputDevice? {
+        guard let uid = defaultUID, let device = devices[uid] else { return nil }
+        return OutputDevice(id: device.id, uid: uid)
+    }
+
+    func deviceID(forUID uid: String) -> AudioDeviceID? {
+        devices[uid]?.id
+    }
+
+    func isOtherAudioPlaying(on deviceID: AudioDeviceID) -> Bool {
+        uid(of: deviceID).flatMap { devices[$0]?.isOtherAudioPlaying } ?? false
+    }
+
+    func isMuted(_ deviceID: AudioDeviceID) -> Bool? {
+        uid(of: deviceID).flatMap { devices[$0]?.muted }
     }
 
     @discardableResult
-    func setVolume(_ volume: Float, of deviceID: UInt32) -> Bool {
-        setCalls.append((deviceID, volume))
-        guard !setShouldFail, volumes[deviceID] != nil else { return false }
-        volumes[deviceID] = volume
+    func setMuted(_ muted: Bool, on deviceID: AudioDeviceID) -> Bool {
+        guard let uid = uid(of: deviceID), devices[uid]?.muted != nil else { return false }
+        muteWrites.append((uid, muted))
+        guard !setMutedShouldFail else { return false }
+        guard !muteWritesAreIgnored else { return true }
+        devices[uid]?.muted = muted
+        if muted && muteZeroesVolume {
+            devices[uid]?.volume = 0
+        }
+        return true
+    }
+
+    func volume(of deviceID: AudioDeviceID) -> Float? {
+        uid(of: deviceID).flatMap { devices[$0]?.volume }
+    }
+
+    @discardableResult
+    func setVolume(_ volume: Float, of deviceID: AudioDeviceID) -> Bool {
+        guard let uid = uid(of: deviceID), devices[uid]?.volume != nil else { return false }
+        volumeWrites.append((uid, volume))
+        guard !setVolumeShouldFail else { return false }
+        devices[uid]?.volume = volume
         return true
     }
 }
@@ -40,288 +91,387 @@ final class AudioDuckerTests: XCTestCase {
 
     private var defaults: UserDefaults!
     private var suiteName: String!
-    private var control: FakeOutputVolumeControl!
+    private var control: FakeOutputAudioControl!
+    private var clock = Date(timeIntervalSince1970: 1_800_000_000)
+    private var scheduled: [(delay: TimeInterval, work: () -> Void)] = []
 
     override func setUp() {
         super.setUp()
         suiteName = "AudioDuckerTests.\(UUID().uuidString)"
         defaults = UserDefaults(suiteName: suiteName)
-        control = FakeOutputVolumeControl()
-        control.volumes = [1: 0.8]
+        control = FakeOutputAudioControl()
+        control.devices = ["speakers": .init(id: 10, muted: false, volume: 0.8)]
+        scheduled = []
     }
 
     override func tearDown() {
         defaults.removePersistentDomain(forName: suiteName)
         defaults = nil
+        control = nil
         super.tearDown()
     }
 
     private func makeDucker() -> AudioDucker {
-        AudioDucker(control: control, defaults: defaults)
+        AudioDucker(
+            control: control,
+            defaults: defaults,
+            now: { [unowned self] in self.clock },
+            schedule: { [unowned self] delay, work in self.scheduled.append((delay, work)) }
+        )
     }
 
-    /// Production persists an array of records; older builds stored one object.
-    private func persistedRecords() -> [AudioDucker.PendingRestore]? {
-        guard let data = defaults.data(forKey: AudioDucker.pendingRestoreKey) else { return nil }
-        if let records = try? JSONDecoder().decode([AudioDucker.PendingRestore].self, from: data) {
-            return records
-        }
-        if let record = try? JSONDecoder().decode(AudioDucker.PendingRestore.self, from: data) {
-            return [record]
-        }
-        return nil
+    /// Runs the settle check the ducker scheduled, as if its delay had passed.
+    private func runScheduled() {
+        let work = scheduled
+        scheduled = []
+        work.forEach { $0.work() }
+    }
+
+    private func persistedRecords() -> [AudioDucker.PendingRestore] {
+        guard let data = defaults.data(forKey: AudioDucker.pendingRestoreKey) else { return [] }
+        return (try? JSONDecoder().decode([AudioDucker.PendingRestore].self, from: data)) ?? []
+    }
+
+    private func speakers() -> FakeOutputAudioControl.Device? {
+        control.devices["speakers"]
     }
 
     // MARK: Happy path
 
-    func testDuckLowersToAQuarterAndRestoreBringsItBack() {
+    func testMutesWhileDictatingAndUnmutesAfterwards() {
         let ducker = makeDucker()
 
         ducker.duck()
-        XCTAssertEqual(control.volumes[1]!, 0.2, accuracy: 0.001)
+        XCTAssertEqual(speakers()?.muted, true)
 
         ducker.restore()
-        XCTAssertEqual(control.volumes[1]!, 0.8, accuracy: 0.001)
+        XCTAssertEqual(speakers()?.muted, false)
+        XCTAssertEqual(speakers()?.volume, 0.8, "Muting never touches the volume")
+        XCTAssertTrue(control.volumeWrites.isEmpty)
     }
 
-    // MARK: Leave the volume alone when…
+    func testRestoreSchedulesOneSettleCheck() {
+        let ducker = makeDucker()
+        ducker.duck()
+        ducker.restore()
 
-    func testNoSoftwareVolumeMeansNothingHappens() {
-        control.volumes = [:]
+        XCTAssertEqual(scheduled.count, 1)
+        XCTAssertEqual(scheduled.first?.delay, AudioDucker.settleDelay)
+
+        runScheduled()
+        XCTAssertEqual(speakers()?.muted, false)
+        XCTAssertEqual(control.muteWrites.count, 2, "Mute, unmute — the settle check finds nothing left to do")
+    }
+
+    // MARK: Leave the output alone when…
+
+    func testNothingPlayingMeansTheOutputIsNotTouched() {
+        control.devices["speakers"]?.isOtherAudioPlaying = false
         let ducker = makeDucker()
 
         ducker.duck()
         ducker.restore()
 
-        XCTAssertTrue(control.setCalls.isEmpty)
+        XCTAssertEqual(control.writeCount, 0)
+        XCTAssertTrue(scheduled.isEmpty)
         XCTAssertNil(defaults.data(forKey: AudioDucker.pendingRestoreKey))
     }
 
-    func testAlreadyQuietOutputIsNotTouched() {
-        control.volumes = [1: 0.0]
+    func testAMuteTheUserSetStaysTheirs() {
+        control.devices["speakers"]?.muted = true
         let ducker = makeDucker()
 
         ducker.duck()
         ducker.restore()
+        runScheduled()
 
-        XCTAssertTrue(control.setCalls.isEmpty, "Ducking silence would only record a pointless restore")
+        XCTAssertEqual(speakers()?.muted, true, "VocaMac did not mute it, so it must not unmute it")
+        XCTAssertEqual(control.writeCount, 0)
     }
 
-    func testUserMovingTheSliderWhileDuckedWinsOverRestore() {
+    func testUnmutingMidDictationIsRespected() {
         let ducker = makeDucker()
         ducker.duck()
 
-        control.volumes[1] = 0.6  // the user turned it up mid-dictation
+        control.devices["speakers"]?.muted = false  // volume key mid-dictation
 
         ducker.restore()
-        XCTAssertEqual(control.volumes[1]!, 0.6, accuracy: 0.001, "Their choice stands")
-        XCTAssertNil(defaults.data(forKey: AudioDucker.pendingRestoreKey), "User-moved volume is terminal; drop the record")
+        runScheduled()
+
+        XCTAssertEqual(speakers()?.muted, false)
+        XCTAssertEqual(control.muteWrites.count, 1, "Only the original mute — nothing re-muted or re-unmuted")
     }
 
-    func testRestoreTargetsTheDeviceThatWasDuckedNotTheNewDefault() {
-        control.volumes = [1: 0.8, 2: 0.5]
+    func testNoDefaultOutputMeansNothingHappens() {
+        control.defaultUID = nil
         let ducker = makeDucker()
+
         ducker.duck()
-
-        control.defaultDeviceID = 2  // headphones plugged in mid-dictation
-
         ducker.restore()
-        XCTAssertEqual(control.volumes[1]!, 0.8, accuracy: 0.001, "The speakers get their volume back")
-        XCTAssertEqual(control.volumes[2]!, 0.5, accuracy: 0.001, "The headphones were never touched")
+
+        XCTAssertEqual(control.writeCount, 0)
     }
 
-    func testDeviceGoneAtRestoreIsLeftAlone() {
+    func testOutputWithNeitherMuteNorVolumeIsSkipped() {
+        control.devices["speakers"] = .init(id: 10, muted: nil, volume: nil)
         let ducker = makeDucker()
+
         ducker.duck()
-
-        control.volumes = [:]
-        let callsBefore = control.setCalls.count
-
         ducker.restore()
-        XCTAssertEqual(control.setCalls.count, callsBefore, "No device to restore on")
-        XCTAssertNotNil(
-            defaults.data(forKey: AudioDucker.pendingRestoreKey),
-            "Nil volume read is not terminal; keep the record for retry"
-        )
-    }
 
-    func testNilVolumeReadKeepsPendingUntilALaterRestoreSucceeds() {
-        let ducker = makeDucker()
-        ducker.duck()
-        XCTAssertEqual(control.volumes[1]!, 0.2, accuracy: 0.001)
-
-        control.volumes = [:]
-        ducker.restore()
-        XCTAssertNotNil(
-            defaults.data(forKey: AudioDucker.pendingRestoreKey),
-            "Nil read keeps persistence so restore can retry"
-        )
-
-        control.volumes = [1: 0.2]
-        ducker.restore()
-        XCTAssertEqual(control.volumes[1]!, 0.8, accuracy: 0.001)
+        XCTAssertEqual(control.writeCount, 0)
         XCTAssertNil(defaults.data(forKey: AudioDucker.pendingRestoreKey))
     }
 
-    func testUnreadablePendingAllowsASecondDuckOnADifferentDevice() {
+    // MARK: Bluetooth headsets (the reported bug)
+
+    /// AirPods report a separate volume while their microphone is open, and
+    /// return to the music-mode volume a couple of seconds after it closes.
+    /// The volume-lowering version read the call-mode volume at restore,
+    /// decided the user had moved the slider, and left music quiet; every
+    /// dictation then lowered it further until it was silent.
+    func testHeadsetVolumeSwitchingProfilesDoesNotStrandTheMute() {
+        control.devices = ["airpods": .init(id: 88, muted: false, volume: 0.69)]
+        control.defaultUID = "airpods"
         let ducker = makeDucker()
-        ducker.duck()
-        XCTAssertEqual(control.volumes[1]!, 0.2, accuracy: 0.001)
 
-        control.volumes = [:]
+        ducker.duck()
+        control.devices["airpods"]?.volume = 0.73  // mic open: call-mode volume
+
         ducker.restore()
-        XCTAssertNotNil(
-            defaults.data(forKey: AudioDucker.pendingRestoreKey),
-            "Nil volume read keeps the original pending restore"
-        )
+        control.devices["airpods"]?.volume = 0.69  // mic closed: music volume is back
+        runScheduled()
 
-        control.volumes = [2: 0.8]
-        control.defaultDeviceID = 2
-        ducker.duck()
+        XCTAssertEqual(control.devices["airpods"]?.muted, false)
+        XCTAssertEqual(control.devices["airpods"]?.volume, 0.69)
+        XCTAssertTrue(control.volumeWrites.isEmpty)
+    }
 
-        XCTAssertEqual(control.volumes[2]!, 0.2, accuracy: 0.001, "The new default output is ducked")
-        guard let records = persistedRecords() else {
-            XCTFail("Expected pending restores to remain persisted")
-            return
+    func testRepeatedDictationsNeverCompound() {
+        let ducker = makeDucker()
+
+        for _ in 0..<10 {
+            ducker.duck()
+            ducker.restore()
+            runScheduled()
         }
-        let byDevice = Dictionary(uniqueKeysWithValues: records.map { ($0.deviceID, $0) })
-        XCTAssertEqual(records.count, 2, "Ducking B must not discard A's unresolved pending")
-        XCTAssertEqual(byDevice[1]!.originalVolume, 0.8, accuracy: 0.001)
-        XCTAssertEqual(byDevice[1]!.duckedVolume, 0.2, accuracy: 0.001)
-        XCTAssertEqual(byDevice[2]!.originalVolume, 0.8, accuracy: 0.001)
-        XCTAssertEqual(byDevice[2]!.duckedVolume, 0.2, accuracy: 0.001)
 
-        control.volumes[1] = 0.2
-        ducker.restore()
-        XCTAssertEqual(control.volumes[1]!, 0.8, accuracy: 0.001, "A is restored once it is readable again")
-        XCTAssertEqual(control.volumes[2]!, 0.8, accuracy: 0.001, "B is restored with A")
+        XCTAssertEqual(speakers()?.muted, false)
+        XCTAssertEqual(speakers()?.volume, 0.8)
         XCTAssertNil(defaults.data(forKey: AudioDucker.pendingRestoreKey))
     }
 
-    func testSecondDuckWhileDuckedIsIgnored() {
+    func testSettleCheckUnmutesIfTheRouteSwitchMutesAgain() {
         let ducker = makeDucker()
         ducker.duck()
-        XCTAssertEqual(control.volumes[1]!, 0.2, accuracy: 0.001)
-        XCTAssertEqual(control.setCalls.count, 1, "First duck writes the ducked volume once")
-        XCTAssertEqual(control.setCalls[0].volume, 0.2, accuracy: 0.001)
-
-        ducker.duck()
-        XCTAssertEqual(
-            control.setCalls.count, 1,
-            "A second duck must not restore then re-duck while volume is still readable"
-        )
-        XCTAssertEqual(control.volumes[1]!, 0.2, accuracy: 0.001)
-        XCTAssertNotNil(defaults.data(forKey: AudioDucker.pendingRestoreKey))
-
         ducker.restore()
-        XCTAssertEqual(control.volumes[1]!, 0.8, accuracy: 0.001)
-        XCTAssertNil(defaults.data(forKey: AudioDucker.pendingRestoreKey))
+
+        control.devices["speakers"]?.muted = true  // profile switch brought the muted state back
+
+        runScheduled()
+        XCTAssertEqual(speakers()?.muted, false)
     }
 
-    func testRestoreWithoutDuckIsANoOp() {
-        let ducker = makeDucker()
-        ducker.restore()
-        XCTAssertTrue(control.setCalls.isEmpty)
-    }
-
-    func testSetFailureRecordsNothingToRestore() {
-        control.setShouldFail = true
-        let ducker = makeDucker()
-
-        ducker.duck()
-
-        XCTAssertNil(defaults.data(forKey: AudioDucker.pendingRestoreKey))
-        control.setShouldFail = false
-        ducker.restore()
-        XCTAssertEqual(control.setCalls.count, 1, "Only the failed duck attempt, no restore")
-    }
-
-    // MARK: Surviving a crash
-
-    func testPendingRestoreIsPersistedWhileDucked() {
+    func testSettleCheckThatCannotUnmuteKeepsTheRecordForRelaunch() {
         let ducker = makeDucker()
         ducker.duck()
-        XCTAssertNotNil(defaults.data(forKey: AudioDucker.pendingRestoreKey))
-
         ducker.restore()
-        XCTAssertNil(defaults.data(forKey: AudioDucker.pendingRestoreKey))
-    }
+        XCTAssertTrue(persistedRecords().isEmpty)
 
-    func testNextLaunchRestoresAVolumeTheCrashedRunLeftLow() {
-        makeDucker().duck()
-        // Process dies here. `control.volumes[1]` is still 0.2.
+        control.devices["speakers"]?.muted = true
+        control.setMutedShouldFail = true
+        runScheduled()
+        XCTAssertEqual(persistedRecords().map(\.deviceUID), ["speakers"])
 
-        let relaunched = makeDucker()
-        relaunched.restoreAfterUnexpectedExit()
-
-        XCTAssertEqual(control.volumes[1]!, 0.8, accuracy: 0.001)
-        XCTAssertNil(defaults.data(forKey: AudioDucker.pendingRestoreKey))
-    }
-
-    func testNextLaunchLeavesAVolumeTheUserAlreadyFixed() {
-        makeDucker().duck()
-        control.volumes[1] = 0.5  // they turned it back up themselves
-
-        let relaunched = makeDucker()
-        relaunched.restoreAfterUnexpectedExit()
-
-        XCTAssertEqual(control.volumes[1]!, 0.5, accuracy: 0.001)
-        XCTAssertNil(defaults.data(forKey: AudioDucker.pendingRestoreKey), "Stale record is cleared either way")
-    }
-
-    func testNextLaunchWithNothingPendingDoesNothing() {
+        control.setMutedShouldFail = false
         makeDucker().restoreAfterUnexpectedExit()
-        XCTAssertTrue(control.setCalls.isEmpty)
+        XCTAssertEqual(speakers()?.muted, false)
     }
 
-    func testLegacySinglePendingRestoreStillLoadsOnRelaunch() {
-        let legacy = AudioDucker.PendingRestore(deviceID: 1, originalVolume: 0.8, duckedVolume: 0.2)
-        guard let data = try? JSONEncoder().encode(legacy) else {
-            XCTFail("Failed to encode a legacy single pending restore")
-            return
-        }
-        defaults.set(data, forKey: AudioDucker.pendingRestoreKey)
-        control.volumes = [1: 0.2]
-
-        let relaunched = makeDucker()
-        relaunched.restoreAfterUnexpectedExit()
-
-        XCTAssertEqual(control.volumes[1]!, 0.8, accuracy: 0.001)
-        XCTAssertNil(defaults.data(forKey: AudioDucker.pendingRestoreKey))
-    }
-
-    // MARK: Failed restore keeps the record for retry
-
-    func testFailedRestoreKeepsPendingSoARetryCanSucceed() {
+    func testANewRecordingRunsTheWaitingSettleCheckFirst() {
         let ducker = makeDucker()
         ducker.duck()
-        XCTAssertEqual(control.volumes[1]!, 0.2, accuracy: 0.001)
-
-        control.setShouldFail = true
         ducker.restore()
 
-        XCTAssertEqual(control.volumes[1]!, 0.2, accuracy: 0.001, "Volume stays ducked when the write fails")
-        XCTAssertNotNil(defaults.data(forKey: AudioDucker.pendingRestoreKey), "Record stays so restore can retry")
+        control.devices["speakers"]?.muted = true  // route switch re-muted it
+        ducker.duck()  // next dictation, before the settle check fires
 
-        control.setShouldFail = false
+        XCTAssertEqual(speakers()?.muted, true)
+        XCTAssertEqual(persistedRecords().map(\.deviceUID), ["speakers"], "Muted by VocaMac, not the user")
         ducker.restore()
-        XCTAssertEqual(control.volumes[1]!, 0.8, accuracy: 0.001)
+        XCTAssertEqual(speakers()?.muted, false)
+    }
+
+    func testANewRecordingCancelsThePendingSettleCheck() {
+        let ducker = makeDucker()
+        ducker.duck()
+        ducker.restore()
+
+        ducker.duck()  // next dictation, before the settle check fires
+        XCTAssertEqual(speakers()?.muted, true)
+
+        runScheduled()
+        XCTAssertEqual(speakers()?.muted, true, "The stale check must not unmute the new recording")
+    }
+
+    // MARK: Devices without a working mute
+
+    func testNoMuteControlZeroesTheVolumeAndPutsTheExactLevelBack() {
+        control.devices["speakers"] = .init(id: 10, muted: nil, volume: 0.57)
+        let ducker = makeDucker()
+
+        ducker.duck()
+        XCTAssertEqual(speakers()?.volume, 0)
+
+        ducker.restore()
+        XCTAssertEqual(speakers()?.volume, 0.57)
+    }
+
+    func testZeroedVolumeTheUserTurnsUpIsLeftAlone() {
+        control.devices["speakers"] = .init(id: 10, muted: nil, volume: 0.57)
+        let ducker = makeDucker()
+        ducker.duck()
+
+        control.devices["speakers"]?.volume = 0.3
+
+        ducker.restore()
+        runScheduled()
+        XCTAssertEqual(speakers()?.volume, 0.3)
+    }
+
+    func testAlreadySilentOutputWithoutMuteIsNotTouched() {
+        control.devices["speakers"] = .init(id: 10, muted: nil, volume: 0)
+        let ducker = makeDucker()
+
+        ducker.duck()
+        ducker.restore()
+
+        XCTAssertEqual(control.writeCount, 0)
+    }
+
+    func testIgnoredMuteFallsBackToTheVolume() {
+        control.muteWritesAreIgnored = true
+        let ducker = makeDucker()
+
+        ducker.duck()
+        XCTAssertEqual(speakers()?.volume, 0)
+        XCTAssertEqual(control.muteWrites.map(\.muted), [true, false], "Tried, then put the flag back")
+
+        ducker.restore()
+        XCTAssertEqual(speakers()?.volume, 0.8)
+    }
+
+    func testDriverThatMutesByZeroingTheVolumeGetsItsVolumeBack() {
+        control.muteZeroesVolume = true
+        let ducker = makeDucker()
+
+        ducker.duck()
+        XCTAssertEqual(speakers()?.volume, 0)
+
+        ducker.restore()
+        XCTAssertEqual(speakers()?.muted, false)
+        XCTAssertEqual(speakers()?.volume, 0.8)
+    }
+
+    // MARK: Device changes
+
+    func testRestoresTheDeviceItMutedEvenAfterTheDefaultChanged() {
+        control.devices["headphones"] = .init(id: 20, muted: false, volume: 0.5)
+        let ducker = makeDucker()
+        ducker.duck()
+
+        control.defaultUID = "headphones"  // headphones connected mid-dictation
+
+        ducker.restore()
+        XCTAssertEqual(speakers()?.muted, false)
+        XCTAssertEqual(control.devices["headphones"]?.muted, false)
+        XCTAssertFalse(control.muteWrites.contains { $0.uid == "headphones" })
+    }
+
+    func testDisconnectedDeviceIsUnmutedWhenItComesBackUnderANewID() {
+        control.devices = ["airpods": .init(id: 88, muted: false, volume: 0.7)]
+        control.defaultUID = "airpods"
+        let ducker = makeDucker()
+        ducker.duck()
+
+        let airpods = control.devices.removeValue(forKey: "airpods")
+        ducker.restore()
+        XCTAssertEqual(persistedRecords().map(\.deviceUID), ["airpods"], "Kept for when it returns")
+
+        control.devices["airpods"] = airpods.map { .init(id: 131, muted: $0.muted, volume: $0.volume) }
+        runScheduled()
+
+        XCTAssertEqual(control.devices["airpods"]?.muted, false)
+        XCTAssertTrue(persistedRecords().isEmpty)
+    }
+
+    func testFailedUnmuteIsRetriedAtTheSettleCheck() {
+        let ducker = makeDucker()
+        ducker.duck()
+
+        control.setMutedShouldFail = true
+        ducker.restore()
+        XCTAssertEqual(speakers()?.muted, true)
+        XCTAssertEqual(persistedRecords().count, 1)
+
+        control.setMutedShouldFail = false
+        runScheduled()
+        XCTAssertEqual(speakers()?.muted, false)
+        XCTAssertTrue(persistedRecords().isEmpty)
+    }
+
+    // MARK: Persistence and relaunch
+
+    func testMuteIsPersistedWhileActiveAndClearedAfterRestore() {
+        let ducker = makeDucker()
+
+        ducker.duck()
+        XCTAssertEqual(persistedRecords().map(\.deviceUID), ["speakers"])
+
+        ducker.restore()
         XCTAssertNil(defaults.data(forKey: AudioDucker.pendingRestoreKey))
     }
 
-    func testFailedCrashRecoveryKeepsPersistedRecordForRetry() {
-        makeDucker().duck()
+    func testRelaunchUnmutesWhatACrashLeftMuted() {
+        makeDucker().duck()  // process dies here
 
-        control.setShouldFail = true
-        let relaunched = makeDucker()
-        relaunched.restoreAfterUnexpectedExit()
+        makeDucker().restoreAfterUnexpectedExit()
 
-        XCTAssertEqual(control.volumes[1]!, 0.2, accuracy: 0.001)
-        XCTAssertNotNil(defaults.data(forKey: AudioDucker.pendingRestoreKey))
-
-        control.setShouldFail = false
-        relaunched.restore()
-        XCTAssertEqual(control.volumes[1]!, 0.8, accuracy: 0.001)
+        XCTAssertEqual(speakers()?.muted, false)
         XCTAssertNil(defaults.data(forKey: AudioDucker.pendingRestoreKey))
+    }
+
+    func testRelaunchLeavesAnOutputTheUserAlreadyUnmuted() {
+        makeDucker().duck()
+        control.devices["speakers"]?.muted = false
+        let writes = control.writeCount
+
+        makeDucker().restoreAfterUnexpectedExit()
+
+        XCTAssertEqual(control.writeCount, writes)
+    }
+
+    func testRelaunchDropsAMuteTooOldToTrust() {
+        makeDucker().duck()
+        clock += AudioDucker.maxPendingAge + 60
+
+        makeDucker().restoreAfterUnexpectedExit()
+
+        XCTAssertEqual(speakers()?.muted, true)
+        XCTAssertNil(defaults.data(forKey: AudioDucker.pendingRestoreKey))
+    }
+
+    func testRelaunchWithNothingPendingDoesNothing() {
+        makeDucker().restoreAfterUnexpectedExit()
+        XCTAssertEqual(control.writeCount, 0)
+    }
+
+    func testRelaunchDiscardsTheOldVolumeRecord() {
+        defaults.set(Data("[{\"deviceID\":88}]".utf8), forKey: AudioDucker.legacyPendingRestoreKey)
+
+        makeDucker().restoreAfterUnexpectedExit()
+
+        XCTAssertNil(defaults.data(forKey: AudioDucker.legacyPendingRestoreKey))
+        XCTAssertEqual(control.writeCount, 0)
     }
 }

--- a/Tests/VocaMacTests/AudioDuckerTests.swift
+++ b/Tests/VocaMacTests/AudioDuckerTests.swift
@@ -462,8 +462,13 @@ final class AudioDuckerTests: XCTestCase {
         control.devices["speakers"]?.muted = true  // route switch re-muted it
         clock += 5
 
-        makeDucker().restoreAfterUnexpectedExit()
+        let relaunched = makeDucker()
+        relaunched.restoreAfterUnexpectedExit()
         XCTAssertEqual(speakers()?.muted, false)
+
+        control.devices["speakers"]?.muted = true  // the switch finishes after launch
+        runScheduled()
+        XCTAssertEqual(speakers()?.muted, false, "Startup schedules its own settle check")
         XCTAssertNil(defaults.data(forKey: AudioDucker.pendingRestoreKey))
     }
 
@@ -485,9 +490,11 @@ final class AudioDuckerTests: XCTestCase {
     func testRelaunchUnmutesWhatACrashLeftMuted() {
         makeDucker().duck()  // process dies here
 
-        makeDucker().restoreAfterUnexpectedExit()
-
+        let relaunched = makeDucker()
+        relaunched.restoreAfterUnexpectedExit()
         XCTAssertEqual(speakers()?.muted, false)
+
+        runScheduled()
         XCTAssertNil(defaults.data(forKey: AudioDucker.pendingRestoreKey))
     }
 

--- a/Tests/VocaMacTests/AudioDuckerTests.swift
+++ b/Tests/VocaMacTests/AudioDuckerTests.swift
@@ -276,12 +276,13 @@ final class AudioDuckerTests: XCTestCase {
         let ducker = makeDucker()
         ducker.duck()
         ducker.restore()
-        XCTAssertTrue(persistedRecords().isEmpty)
 
         control.devices["speakers"]?.muted = true
         control.setMutedShouldFail = true
         runScheduled()
         XCTAssertEqual(persistedRecords().map(\.deviceUID), ["speakers"])
+        XCTAssertNil(persistedRecords().first?.restoredAt, "Back to an ordinary pending mute, not a settle record")
+        clock += AudioDucker.settleRecoveryWindow * 10
 
         control.setMutedShouldFail = false
         makeDucker().restoreAfterUnexpectedExit()
@@ -361,6 +362,23 @@ final class AudioDuckerTests: XCTestCase {
         XCTAssertEqual(speakers()?.volume, 0.8)
     }
 
+    func testFailedVolumeRestoreAfterUnmuteIsRetried() {
+        control.muteZeroesVolume = true
+        let ducker = makeDucker()
+        ducker.duck()
+
+        control.setVolumeShouldFail = true
+        ducker.restore()
+        XCTAssertEqual(speakers()?.muted, false)
+        XCTAssertEqual(speakers()?.volume, 0)
+        XCTAssertNil(persistedRecords().first?.restoredAt, "Still owed a volume restore")
+
+        control.setVolumeShouldFail = false
+        runScheduled()
+        XCTAssertEqual(speakers()?.volume, 0.8)
+        XCTAssertTrue(persistedRecords().isEmpty)
+    }
+
     func testDriverThatMutesByZeroingTheVolumeGetsItsVolumeBack() {
         control.muteZeroesVolume = true
         let ducker = makeDucker()
@@ -422,13 +440,45 @@ final class AudioDuckerTests: XCTestCase {
 
     // MARK: Persistence and relaunch
 
-    func testMuteIsPersistedWhileActiveAndClearedAfterRestore() {
+    func testMuteIsPersistedUntilTheSettleCheckFinishes() {
         let ducker = makeDucker()
 
         ducker.duck()
         XCTAssertEqual(persistedRecords().map(\.deviceUID), ["speakers"])
+        XCTAssertNil(persistedRecords().first?.restoredAt)
 
         ducker.restore()
+        XCTAssertEqual(persistedRecords().first?.restoredAt, clock, "Kept, marked restored, for the settle check")
+
+        runScheduled()
+        XCTAssertNil(defaults.data(forKey: AudioDucker.pendingRestoreKey))
+    }
+
+    func testQuitDuringTheSettleWindowIsCoveredByAQuickRelaunch() {
+        let ducker = makeDucker()
+        ducker.duck()
+        ducker.restore()  // willTerminate; the settle check never runs
+
+        control.devices["speakers"]?.muted = true  // route switch re-muted it
+        clock += 5
+
+        makeDucker().restoreAfterUnexpectedExit()
+        XCTAssertEqual(speakers()?.muted, false)
+        XCTAssertNil(defaults.data(forKey: AudioDucker.pendingRestoreKey))
+    }
+
+    func testSettleRecordIsIgnoredByALateRelaunch() {
+        let ducker = makeDucker()
+        ducker.duck()
+        ducker.restore()
+
+        control.devices["speakers"]?.muted = true  // the user muted it later
+        clock += AudioDucker.settleRecoveryWindow + 1
+        let writes = control.writeCount
+
+        makeDucker().restoreAfterUnexpectedExit()
+        XCTAssertEqual(speakers()?.muted, true, "Already put back once; this mute is the user's")
+        XCTAssertEqual(control.writeCount, writes)
         XCTAssertNil(defaults.data(forKey: AudioDucker.pendingRestoreKey))
     }
 

--- a/Tests/VocaMacTests/Mocks/MockServices.swift
+++ b/Tests/VocaMacTests/Mocks/MockServices.swift
@@ -116,6 +116,8 @@ final class MockSoundManager: SoundPlaying {
     var startSoundAsyncCallCount = 0
     var stopSoundAsyncCallCount = 0
     var playLog: [PlayEvent] = []
+    /// Runs while the awaited start cue "plays", to act mid-cue.
+    var whileStartSoundAsyncPlays: (() async -> Void)?
 
     func playStartSound() {
         startSoundCallCount += 1
@@ -125,6 +127,7 @@ final class MockSoundManager: SoundPlaying {
     func playStartSoundAsync() async {
         startSoundAsyncCallCount += 1
         playLog.append(.startAsync)
+        await whileStartSoundAsyncPlays?()
     }
 
     func playStopSound() {
@@ -144,9 +147,11 @@ final class MockAudioDucker: AudioDucking {
     var duckCallCount = 0
     var restoreCallCount = 0
     var restoreAfterUnexpectedExitCallCount = 0
+    var onDuck: (() -> Void)?
 
     func duck() {
         duckCallCount += 1
+        onDuck?()
     }
 
     func restore() {


### PR DESCRIPTION
## Why

"Lower other audio while dictating" (#263) is unreliable on Bluetooth headsets. It can leave music quiet after dictating, and after a few dictations it goes silent.

AirPods keep a separate volume while their microphone is open. The volume control reads the call-mode level from the moment the mic opens until about 2 s after it closes. Reproduced outside VocaMac: music at 81% reads 69% while the mic is open, and 81% again once it closes.

The old restore compared the current volume with the level it had set, within 1%. On AirPods it read the call-mode level (73%), concluded the user had moved the slider, and restored nothing. Once the headset switched back, music was still at the lowered level. The next dictation lowered it again from there. From a real log:

```
Ducked device 88: 69% → 17%
Volume moved to 73% while ducked — leaving it alone (recording ended)
Ducked device 88: 17% → 4%
Volume moved to 73% while ducked — leaving it alone (recording ended)
Ducked device 88: 4% → 1%
…
Ducked device 88: 2% → 0%
```

## What

Mute the default output instead of lowering it: Wispr Flow's "Mute music while dictating" and VoiceInk's "Mute audio while recording" both do this. Mute stays set when the headset switches modes. On AirPods, muting in music mode stays muted in call mode, and unmuting during call mode carries back to music mode. The setting is now **Audio → Other Audio → "Mute other audio while dictating"**, same preference key.

## How

`AudioDucker` keeps its role and `AudioDucking` protocol; the policy is new:

- **Only when something is playing.** It checks CoreAudio process objects for another process with running output (macOS 14.2+), which ignores VocaMac's own cue. Older versions fall back to `kAudioDevicePropertyDeviceIsRunningSomewhere`. Most dictations never touch the output.
- **Leaves the user's mute alone.** An output already muted stays muted. If the user unmutes during the dictation, it isn't muted again.
- **Idempotent undo.** Undo acts only while the device is still silenced the way the ducker left it. That makes it safe to repeat: once when the recording ends, again 3 s later after the Bluetooth switch, and on launch after a crash. A new dictation runs a waiting check first, so a re-muted device isn't mistaken for a user mute. Records waiting on the settle check are persisted too: a relaunch within 60 s (quit or crash inside the window) still runs it, and a later one drops them. Startup restores schedule their own settle check.
- **Devices tracked by UID**, not `AudioDeviceID`, so a reconnect or relaunch finds the device it muted. Records older than a day are dropped.
- **Devices without a working mute.** When there's no mute control, or a driver acknowledges the write and does nothing, the volume goes to 0 and comes back to the exact level. Checking for zero needs no tolerance. Drivers that mute by zeroing the volume get their level back on unmute (the VoiceInk #640 failure); if that write fails, the record stays for a retry.
- **Mutes after the mic is live and after the start cue.** Muting first would silence the cue, and a start that never gets a route now leaves playback alone. `AppState` awaits the cue only when the setting is on, and skips the mute if the recording ended or restarted while the cue played.
- Pending records from the volume version are discarded on launch.
- Logs use the CoreAudio device ID, not the UID. Bluetooth UIDs contain the device's MAC address.

## Not done / trade-offs

- Mute is all-or-nothing; there's no partial duck. The per-mode volume is why partial ducking can't be undone reliably on Bluetooth headsets.
- Audio that starts after the recording begins isn't muted (same as Wispr Flow).
- If the user mutes within the 3 s after a dictation ends, the settle check unmutes it.
- If the user unmutes and then mutes again during one recording, that mute is undone with VocaMac's. Telling them apart needs a mute-change listener, and one that mistook a headset's profile switch for the user unmuting would leave the output muted for good.

## Tests

`swift test`: 903 tests, 4 skipped, 0 failures.

- `AudioDuckerTests` (30, against `FakeOutputAudioControl`):
  - Mute and unmute; nothing playing; user mute kept; unmute mid-dictation respected.
  - **Headset profile switch** (the reported bug); ten cycles never compound.
  - Settle check re-unmutes; a failed settle check survives to relaunch; a new recording runs the waiting check.
  - No mute control, ignored mute, and mute-by-zeroing drivers.
  - Default output changed; disconnected device returns under a new ID; failed unmute retried.
  - Persistence, relaunch, stale and legacy records; a quit inside the settle window recovered by a quick relaunch (including a re-mute after launch) and ignored by a late one; a failed volume restore after unmute retried.
- `AppStateDuckingTests` (15): cue plays before the mute; cue stays fire-and-forget when the setting is off; a recording that ends during the cue is never muted; a failed engine start never mutes; every exit restores.

Checked on hardware (MacBook Pro, macOS 26, AirPods as both mic and output, Brave playing): I ran the real `SystemOutputAudioControl` + `AudioDucker` with the AirPods mic opened for real, 3 cycles. The output was muted during each recording and unmuted after, and nothing was left pending. The volume read jumped between 66%, 81%, and unreadable while the mic opened and closed, but was never written. Same check on the built-in speakers.
