### PR TITLE
feat: share the stats card with other apps through the system picker

### DIFF
--- a/Sources/VocaMac/Models/StatsShareDestination.swift
+++ b/Sources/VocaMac/Models/StatsShareDestination.swift
@@ -72,11 +72,17 @@ enum StatsShareComposer {
 
     /// The post body. Kept short enough for X's 280-character limit.
     static func message(for snapshot: StatsShareSnapshot, destination: StatsShareDestination) -> String {
+        message(for: snapshot, handle: destination.handle)
+    }
+
+    /// The post body for the system share picker. The destination app is
+    /// unknown there, so it signs off with the site alone.
+    static func message(for snapshot: StatsShareSnapshot, handle: String? = nil) -> String {
         var lines = [
             "🎤 \(pluralized(snapshot.totalWords, "word")) talked into my Mac with VocaMac.",
             statLine(for: snapshot),
             "Every model runs on my Mac. Works fully offline, no audio ever leaves it. 🔒",
-            [destination.handle, siteURL].compactMap { $0 }.joined(separator: " · ")
+            [handle, siteURL].compactMap { $0 }.joined(separator: " · ")
         ]
         lines.removeAll { $0.isEmpty }
         return lines.joined(separator: "\n\n")

--- a/Sources/VocaMac/Views/StatsSettingsTab.swift
+++ b/Sources/VocaMac/Views/StatsSettingsTab.swift
@@ -3,6 +3,7 @@
 //
 // View for displaying user usage statistics.
 
+import AppKit
 import SwiftUI
 
 struct StatsSettingsTab: View {
@@ -13,6 +14,7 @@ struct StatsSettingsTab: View {
     /// state it was scheduled for. Keying the reset on the destination let a
     /// second share to the same network inherit the first one's countdown.
     @State private var shareStateToken = 0
+    @State private var sharePickerAnchor = SharePickerAnchor()
 
     /// One state rather than two independent flags: "Copied!" and "Opening X…"
     /// are mutually exclusive, and a copy made during an open share window used
@@ -65,6 +67,7 @@ struct StatsSettingsTab: View {
                                     share(to: destination)
                                 }
                             }
+                            Button("Share with Other Apps…") { showSharePicker() }
                             Divider()
                             Button("Copy Card Image") { copyCardImage() }
                         } label: {
@@ -73,8 +76,9 @@ struct StatsSettingsTab: View {
                         .menuStyle(.borderlessButton)
                         .fixedSize()
                         .controlSize(.small)
+                        .background(SharePickerAnchorView(anchor: sharePickerAnchor))
                         .disabled(!hasStats)
-                        .help("Post your stats card, or copy it to the clipboard")
+                        .help("Post your stats card, send it to another app, or copy it to the clipboard")
                         .padding(.trailing, 8)
                     }
 
@@ -267,6 +271,21 @@ struct StatsSettingsTab: View {
         }
     }
 
+    /// For apps with no composer URL of their own. The picker pops up from the
+    /// Share menu's button.
+    private func showSharePicker() {
+        guard let view = sharePickerAnchor.view else {
+            setShareState(.failed("Couldn't open the share picker."), clearingAfter: 6)
+            return
+        }
+        let snapshot = StatsShareSnapshot.from(appState.statsManager.stats)
+        // The menu is still closing when its action runs, and a picker shown
+        // during that would be dismissed along with it.
+        DispatchQueue.main.async {
+            StatsShareExporter.showSharePicker(for: snapshot, relativeTo: view)
+        }
+    }
+
     private func copyCardImage() {
         let snapshot = StatsShareSnapshot.from(appState.statsManager.stats)
         guard StatsShareExporter.copyImage(toClipboard: snapshot) else {
@@ -305,6 +324,26 @@ struct StatsSettingsTab: View {
         if Calendar.current.isDateInYesterday(date) { return "Yesterday" }
 
         return Self.displayDateFormatter.string(from: date)
+    }
+}
+
+/// Holds the AppKit view the share picker pops up from. SwiftUI's `Menu` has
+/// no view of its own to anchor an `NSSharingServicePicker` to.
+final class SharePickerAnchor {
+    weak var view: NSView?
+}
+
+private struct SharePickerAnchorView: NSViewRepresentable {
+    let anchor: SharePickerAnchor
+
+    func makeNSView(context: Context) -> NSView {
+        let view = NSView()
+        anchor.view = view
+        return view
+    }
+
+    func updateNSView(_ nsView: NSView, context: Context) {
+        anchor.view = nsView
     }
 }
 

--- a/Sources/VocaMac/Views/StatsShareCard.swift
+++ b/Sources/VocaMac/Views/StatsShareCard.swift
@@ -164,13 +164,19 @@ enum StatsShareExporter {
     /// The card as a PNG file, then the post text. A file rather than an
     /// `NSImage` so Mail and AirDrop send a named PNG instead of a TIFF. If the
     /// card cannot be written, the text still goes on its own.
+    ///
+    /// Each share gets its own directory. A service can still be reading an
+    /// earlier share's file (a Mail draft, a pending AirDrop) when the next one
+    /// starts, and a shared path would swap that card for the newer one.
     @MainActor
     static func sharingItems(for snapshot: StatsShareSnapshot) -> [Any] {
         var items: [Any] = []
         if let png = renderPNG(snapshot) {
-            let url = FileManager.default.temporaryDirectory
-                .appendingPathComponent("VocaMac Stats.png")
+            let directory = FileManager.default.temporaryDirectory
+                .appendingPathComponent("VocaMac Share \(UUID().uuidString)", isDirectory: true)
+            let url = directory.appendingPathComponent("VocaMac Stats.png")
             do {
+                try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
                 try png.write(to: url, options: .atomic)
                 items.append(url)
             } catch {

--- a/Sources/VocaMac/Views/StatsShareCard.swift
+++ b/Sources/VocaMac/Views/StatsShareCard.swift
@@ -1,8 +1,8 @@
 // StatsShareCard.swift
 // VocaMac
 //
-// Branded stats card rendered to an image, copied to the clipboard and
-// optionally posted to a social composer.
+// Branded stats card rendered to an image, copied to the clipboard,
+// posted to a social composer, or handed to the system share picker.
 // Forced dark appearance so clipboard shares match the in-app Stats look.
 
 import AppKit
@@ -146,19 +146,51 @@ enum StatsShareExporter {
     /// Renders the branded card and copies a PNG to the general pasteboard.
     @MainActor
     static func copyImage(toClipboard snapshot: StatsShareSnapshot) -> Bool {
-        let card = StatsShareCard(snapshot: snapshot)
-        let renderer = ImageRenderer(content: card)
-        renderer.scale = 2
-        guard let nsImage = renderer.nsImage,
-              let tiff = nsImage.tiffRepresentation,
-              let rep = NSBitmapImageRep(data: tiff),
-              let png = rep.representation(using: .png, properties: [:]) else {
-            return false
-        }
+        guard let png = renderPNG(snapshot) else { return false }
 
         let pasteboard = NSPasteboard.general
         pasteboard.clearContents()
         return pasteboard.setData(png, forType: .png)
+    }
+
+    /// Opens the system share picker (Messages, Mail, AirDrop, Notes, …) with
+    /// the card and post text, anchored to `view`.
+    @MainActor
+    static func showSharePicker(for snapshot: StatsShareSnapshot, relativeTo view: NSView) {
+        let picker = NSSharingServicePicker(items: sharingItems(for: snapshot))
+        picker.show(relativeTo: view.bounds, of: view, preferredEdge: .minY)
+    }
+
+    /// The card as a PNG file, then the post text. A file rather than an
+    /// `NSImage` so Mail and AirDrop send a named PNG instead of a TIFF. If the
+    /// card cannot be written, the text still goes on its own.
+    @MainActor
+    static func sharingItems(for snapshot: StatsShareSnapshot) -> [Any] {
+        var items: [Any] = []
+        if let png = renderPNG(snapshot) {
+            let url = FileManager.default.temporaryDirectory
+                .appendingPathComponent("VocaMac Stats.png")
+            do {
+                try png.write(to: url, options: .atomic)
+                items.append(url)
+            } catch {
+                VocaLogger.warning(.general, "Stats share: could not write the card image: \(error.localizedDescription)")
+            }
+        }
+        items.append(StatsShareComposer.message(for: snapshot))
+        return items
+    }
+
+    @MainActor
+    private static func renderPNG(_ snapshot: StatsShareSnapshot) -> Data? {
+        let renderer = ImageRenderer(content: StatsShareCard(snapshot: snapshot))
+        renderer.scale = 2
+        guard let nsImage = renderer.nsImage,
+              let tiff = nsImage.tiffRepresentation,
+              let rep = NSBitmapImageRep(data: tiff) else {
+            return nil
+        }
+        return rep.representation(using: .png, properties: [:])
     }
 
     /// Opens the destination's composer with prefilled text, then copies the

--- a/Tests/VocaMacTests/StatsShareCardTests.swift
+++ b/Tests/VocaMacTests/StatsShareCardTests.swift
@@ -75,6 +75,21 @@ final class StatsShareCardTests: XCTestCase {
         XCTAssertTrue(FileManager.default.fileExists(atPath: card.path))
     }
 
+    /// A later share must not overwrite a card an earlier share still holds.
+    @MainActor
+    func testEachShareWritesItsOwnCardFile() throws {
+        let first = try XCTUnwrap(StatsShareExporter.sharingItems(for: makeSnapshot()).first as? URL)
+        let firstPNG = try Data(contentsOf: first)
+
+        var later = makeSnapshot()
+        later.totalWords = 99_999
+        let second = try XCTUnwrap(StatsShareExporter.sharingItems(for: later).first as? URL)
+
+        XCTAssertNotEqual(first, second)
+        XCTAssertEqual(second.lastPathComponent, "VocaMac Stats.png")
+        XCTAssertEqual(try Data(contentsOf: first), firstPNG)
+    }
+
     /// X weighs most emoji as 2 units and normalizes every URL to 23, so
     /// `String.count` is not the metric X enforces.
     private func xPostLength(_ message: String) -> Int {

--- a/Tests/VocaMacTests/StatsShareCardTests.swift
+++ b/Tests/VocaMacTests/StatsShareCardTests.swift
@@ -56,6 +56,25 @@ final class StatsShareCardTests: XCTestCase {
         XCTAssertTrue(message.hasSuffix(StatsShareComposer.siteURL), message)
     }
 
+    /// The share picker's destination is unknown, so the post has no handle.
+    func testSharePickerMessageOmitsHandle() {
+        let message = StatsShareComposer.message(for: makeSnapshot())
+
+        XCTAssertFalse(message.contains("@vocahq"), message)
+        XCTAssertTrue(message.contains("12,500 words"), message)
+        XCTAssertTrue(message.hasSuffix(StatsShareComposer.siteURL), message)
+    }
+
+    @MainActor
+    func testSharingItemsAreTheCardFileThenThePostText() throws {
+        let items = StatsShareExporter.sharingItems(for: makeSnapshot())
+
+        XCTAssertEqual(items.last as? String, StatsShareComposer.message(for: makeSnapshot()))
+        let card = try XCTUnwrap(items.first as? URL)
+        XCTAssertEqual(card.pathExtension, "png")
+        XCTAssertTrue(FileManager.default.fileExists(atPath: card.path))
+    }
+
     /// X weighs most emoji as 2 units and normalizes every URL to 23, so
     /// `String.count` is not the metric X enforces.
     private func xPostLength(_ message: String) -> Int {


### PR DESCRIPTION
## Why

The Stats **Share** menu only reached X and LinkedIn. There was no way to send the card to Messages, Mail, AirDrop, Notes or any other app. This matches the Share button added to VocaPhone's Stats screen on iOS and Android.

## Summary

- Adds **Share with Other Apps…** to the Stats Share menu. It opens `NSSharingServicePicker` from the menu's button with the card and the post text.
- The card goes as a PNG file in the temporary directory (`VocaMac Stats.png`) rather than an `NSImage`, so Mail and AirDrop send a named PNG instead of a TIFF. If the file cannot be written, the text is shared on its own.
- The picker's destination is unknown, so its post text signs off with the site and no `@vocahq` handle (new `StatsShareComposer.message(for:handle:)`; the per-destination overload now calls it).
- SwiftUI's `Menu` has no view to anchor the picker to, so a small `NSViewRepresentable` in the menu's background provides one. The picker is shown on the next run-loop turn so the closing menu doesn't dismiss it.
- Card rendering moves into one `renderPNG` helper shared by the clipboard copy and the picker.
- X and LinkedIn are unchanged. LinkedIn's `feed/?shareActive=true&text=` prefill works on the desktop site, which is what the Mac opens.

## Testing

- `swift test`: 905 tests, 0 failures (4 skipped).
- New `testSharePickerMessageOmitsHandle` and `testSharingItemsAreTheCardFileThenThePostText`.
- Not yet clicked through in a running build.
