### PR TITLE
feat: add dictation history, extra shortcuts, and a personal dictionary

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,9 @@
 - **⌨️ System-Wide Text Injection** - Transcribed text is typed wherever your cursor is: browsers, Slack, VS Code, spreadsheets, terminals - everywhere.
 - **🎯 Push-to-Talk** - Hold a hotkey (default: Right Option) to record. Release to transcribe.
 - **👆 Double-Tap Toggle** - Double-tap the hotkey to start/stop recording.
+- **🕘 Dictation History** - Search, copy, replay, and retry past dictations. Audio is saved before transcription, so a crash or failed decode never loses what you said. Press ⌃⌘V to paste your last dictation again. History is local, with 1-day to forever retention, and can be turned off.
+- **⌨️ More Ways to Dictate** - Press Escape to cancel. A separate hands-free shortcut starts and stops dictation without holding a key. A middle or side mouse button works like the hotkey. Sessions can run up to 20 minutes.
+- **📖 Personal Dictionary** - Vocabulary and replacements work with every speech engine (“voca mac” → VocaMac, “get hub” → GitHub). VocaMac suggests words you corrected after dictating, and can spell names and code identifiers the way they appear on screen. All of this happens on your Mac.
 - **🧠 Engine and Model Choice** - Choose the local speech engine and model that fit your language, speed, and memory needs. VocaMac recommends compatible options for your Apple Silicon Mac.
 - **⚡ Native Apple Acceleration** - CoreML + Metal + Neural Engine acceleration on Apple Silicon. No manual setup.
 - **📊 Visual Feedback** - Menu bar icon changes color during recording and processing. Audio level indicator shows input.

--- a/Sources/VocaMac/Models/AppState.swift
+++ b/Sources/VocaMac/Models/AppState.swift
@@ -895,6 +895,7 @@ final class AppState: ObservableObject {
             .sink { [weak self] _ in
                 self?.audioDucker.restore()
                 self?.statsManager.flushPendingSaves()
+                self?.historyStore.saveIfNeeded()
             }
             .store(in: &cancellables)
 

--- a/Sources/VocaMac/Models/AppState.swift
+++ b/Sources/VocaMac/Models/AppState.swift
@@ -1655,8 +1655,13 @@ final class AppState: ObservableObject {
         let contextTask = screenContextTask
         screenContextTask = nil
         // Saved before transcribing, so a crash or failure can't lose it.
-        let historyID = injectResult ? beginHistoryEntry(audio: audioData) : nil
+        let historyID = injectResult ? await beginHistoryEntry(audio: audioData) : nil
         activeHistoryEntryID = historyID
+        guard generation == recordingGeneration else {
+            // Escape arrived while the audio was being saved.
+            if let historyID { historyStore.markCancelled(historyID) }
+            return
+        }
 
         do {
             let language = selectedLanguage == "auto" ? nil : selectedLanguage
@@ -2479,11 +2484,11 @@ extension AppState {
 
     /// Record a dictation in history before it is transcribed. Returns nil
     /// when history is off.
-    fileprivate func beginHistoryEntry(audio: [Float]) -> UUID? {
+    fileprivate func beginHistoryEntry(audio: [Float]) async -> UUID? {
         guard historyEnabled else { return nil }
         historyStore.applyRetention(historyRetention)
         let modelID = currentModel?.size.rawValue ?? selectedModelSize
-        return historyStore.begin(
+        return await historyStore.begin(
             audio: audio,
             target: frontmostAppResolver.currentFrontmostApp() ?? pendingTargetApp,
             modelID: modelID,

--- a/Sources/VocaMac/Models/AppState.swift
+++ b/Sources/VocaMac/Models/AppState.swift
@@ -100,6 +100,7 @@ final class AppState: ObservableObject {
                 audioEngine.onAudioSamples = nil
                 recordingTranscription?.cancel()
                 recordingTranscription = nil
+                isHandsFreeSession = false
             }
             if oldValue && !isRecording {
                 audioDucker.restore()
@@ -184,6 +185,17 @@ final class AppState: ObservableObject {
     @AppStorage(PreferenceKey.transcriptCleanupEnabled) var transcriptCleanupEnabled: Bool = false
     @AppStorage(PreferenceKey.transcriptCleanupModel) var transcriptCleanupModel: String = CleanupModelKind.defaultKind.rawValue
     @AppStorage(PreferenceKey.transcriptCleanupPrompt) var transcriptCleanupPrompt: String = ""
+    @AppStorage(PreferenceKey.historyEnabled) var historyEnabled: Bool = true
+    @AppStorage(PreferenceKey.historyKeepsAudio) var historyKeepsAudio: Bool = true
+    @AppStorage(PreferenceKey.historyRetention) var historyRetention: HistoryRetention = .defaultRetention
+    @AppStorage(PreferenceKey.escapeCancelsDictation) var escapeCancelsDictation: Bool = true
+    /// `HotKeyCombo.storageString`, or empty for no shortcut.
+    @AppStorage(PreferenceKey.pasteLastShortcut) var pasteLastShortcut: String = HotKeyCombo.defaultPasteLast.storageString
+    /// `HotKeyCombo.storageString`, or empty for no shortcut.
+    @AppStorage(PreferenceKey.handsFreeShortcut) var handsFreeShortcut: String = ""
+    @AppStorage(PreferenceKey.mouseTriggerButton) var mouseTriggerButton: Int = MouseTriggerButton.off.rawValue
+    @AppStorage(PreferenceKey.learnCorrectionsMode) var learnCorrectionsMode: LearnCorrectionsMode = .defaultMode
+    @AppStorage(PreferenceKey.useScreenContext) var useScreenContext: Bool = true
 
     /// JSON-encoded `[AutoPauseAppEntry]` list (complex value not stored via `@AppStorage`).
     var autoPauseAppsJSON: String {
@@ -414,6 +426,43 @@ final class AppState: ObservableObject {
     /// Custom text snippets for expansion
     @Published var snippets: [Snippet] = []
 
+    /// Spoken forms rewritten to the user's text, for every engine.
+    @Published var wordReplacements: [WordReplacement] = []
+
+    /// Corrections noticed in dictated text, waiting for the user to accept.
+    @Published private(set) var dictionarySuggestions: [CorrectionSuggestion] = []
+
+    /// History entry whose audio is being transcribed again, if any.
+    @Published private(set) var retryingHistoryEntryID: UUID?
+
+    /// Settings page to show the next time the Settings window appears.
+    @Published var requestedSettingsPage: SettingsPage?
+
+    /// Failed dictation whose retry banner the user closed.
+    @Published private(set) var dismissedRecoveryEntryID: UUID?
+
+    /// History entry for the dictation being transcribed right now.
+    private var activeHistoryEntryID: UUID?
+
+    /// Whether the current recording was started with the hands-free
+    /// shortcut, so silence ends it the way it ends a double-tap recording.
+    private var isHandsFreeSession = false
+
+    /// True from the end of a recording until its text is delivered. Escape
+    /// cancels during this window as well as while recording.
+    private var isTranscribing = false {
+        didSet { refreshCancelKeyArming() }
+    }
+
+    /// Names and identifiers read from the screen when recording started.
+    private var screenContextTask: Task<[String], Never>?
+
+    /// Suggestions the user dismissed, so the same fix isn't offered again.
+    private var dismissedSuggestionKeys: Set<String> = []
+
+    /// Whether a word is ordinary vocabulary in a language. Replaceable in tests.
+    var isKnownWord: (String, String?) -> Bool
+
     // MARK: - Services
 
     let audioEngine: AudioRecording
@@ -431,6 +480,12 @@ final class AppState: ObservableObject {
     let permissionManager: any PermissionManaging
     /// Identifies the app that will receive injected text.
     let frontmostAppResolver: any FrontmostAppResolving
+    /// Past dictations, their text, and their audio.
+    let historyStore: DictationHistoryStore
+    /// Reads names and identifiers from the screen; nil when disabled.
+    let screenContextReader: (any ScreenContextReading)?
+    /// Notices the user fixing dictated words; nil when disabled.
+    let correctionObserver: (any CorrectionObserving)?
 
     /// Polls configured apps and pauses dictation while they run.
     let autoPauseMonitor = AutoPauseMonitor()
@@ -527,6 +582,9 @@ final class AppState: ObservableObject {
         // default arguments are evaluated outside the initializer's isolation,
         // the same reason `cursorOverlay` has no default either.
         frontmostAppResolver: (any FrontmostAppResolving)? = nil,
+        historyStore: DictationHistoryStore? = nil,
+        screenContextReader: (any ScreenContextReading)? = nil,
+        correctionObserver: (any CorrectionObserving)? = nil,
         skipSystemIntegration: Bool = false
     ) {
         self.audioEngine = audioEngine
@@ -543,9 +601,19 @@ final class AppState: ObservableObject {
         self.transcriptCleanup = transcriptCleanup
         self.permissionManager = permissionManager ?? PermissionManager(audioEngine: audioEngine, hotKeyManager: hotKeyManager)
         self.skipSystemIntegration = skipSystemIntegration
+        // Tests and other headless runs keep history in memory and never read
+        // another app's text.
+        self.historyStore = historyStore
+            ?? DictationHistoryStore(directory: skipSystemIntegration ? nil : DictationHistoryStore.defaultDirectory)
+        self.screenContextReader = screenContextReader ?? (skipSystemIntegration ? nil : ScreenContextReader())
+        self.correctionObserver = correctionObserver ?? (skipSystemIntegration ? nil : CorrectionObserver())
+        self.isKnownWord = { word, language in
+            MainActor.assumeIsolated { SpellingOracle.shared.isKnownWord(word, language: language) }
+        }
 
         VocaLogger.info(.appState, "Initializing... id=\(ObjectIdentifier(self))")
         loadSnippets()
+        loadDictionary()
         if !skipSystemIntegration {
             syncLaunchAtLogin()
         }
@@ -572,6 +640,12 @@ final class AppState: ObservableObject {
                 self?.objectWillChange.send()
             }
             .store(in: &cancellables)
+
+        self.historyStore.objectWillChange
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] _ in self?.objectWillChange.send() }
+            .store(in: &cancellables)
+        self.historyStore.applyRetention(historyRetention)
     }
 
     /// Single production AppState instance for the process.
@@ -707,8 +781,8 @@ final class AppState: ObservableObject {
         audioEngine.onSilenceDetected = { [weak self] in
             Task { @MainActor in
                 guard let self = self else { return }
-                if self.activationMode == .doubleTapToggle && self.isRecording {
-                    VocaLogger.info(.appState, "Silence detected — auto-stopping recording (double-tap mode)")
+                if (self.activationMode == .doubleTapToggle || self.isHandsFreeSession) && self.isRecording {
+                    VocaLogger.info(.appState, "Silence detected — auto-stopping recording (toggle session)")
                     await self.stopRecordingAndTranscribe()
                 }
             }
@@ -771,6 +845,31 @@ final class AppState: ObservableObject {
             }
         }
 
+        if let shortcutMonitor = hotKeyManager as? HotKeyShortcutMonitoring {
+            shortcutMonitor.onShortcut = { [weak self] action in
+                Task { @MainActor in
+                    await self?.handleShortcut(action)
+                }
+            }
+            shortcutMonitor.onCancel = { [weak self] in
+                Task { @MainActor in
+                    await self?.cancelDictation()
+                }
+            }
+        }
+        syncShortcutConfiguration()
+
+        // Escape is only claimed while there is a dictation to cancel.
+        $appStatus
+            .sink { [weak self] status in
+                self?.refreshCancelKeyArming(status: status)
+            }
+            .store(in: &cancellables)
+
+        correctionObserver?.onCorrections = { [weak self] corrections in
+            self?.receiveCorrections(corrections)
+        }
+
         // Wire permission manager: start hotkey listener when permissions granted
         permissionManager.onAllPermissionsGranted = { [weak self] in
             guard let self = self else { return }
@@ -820,6 +919,13 @@ final class AppState: ObservableObject {
             .dropFirst()  // skip the subscription replay of the just-loaded value
             .sink { [weak self] snippets in
                 self?.saveSnippets(snippets)
+            }
+            .store(in: &cancellables)
+
+        $wordReplacements
+            .dropFirst()
+            .sink { replacements in
+                Self.saveJSON(replacements, forKey: PreferenceKey.wordReplacements)
             }
             .store(in: &cancellables)
 
@@ -1316,6 +1422,13 @@ final class AppState: ObservableObject {
         cursorOverlay.hide()
         appStatus = .idle
         errorMessage = nil
+        isTranscribing = false
+        screenContextTask?.cancel()
+        screenContextTask = nil
+        if let id = activeHistoryEntryID {
+            historyStore.markCancelled(id)
+            activeHistoryEntryID = nil
+        }
     }
 
     /// Play start, then stop, for the tone currently selected in Settings.
@@ -1350,6 +1463,9 @@ final class AppState: ObservableObject {
         // when VocaMac itself is in front at that point.
         pendingTargetApp = frontmostAppResolver.currentFrontmostApp()
 
+        // Starting another dictation means the user is done fixing the last one.
+        correctionObserver?.flush()
+
         guard appStatus == .idle else {
             // If stuck in .processing or .error for too long, force recovery
             // so the user can start a fresh recording.
@@ -1382,6 +1498,7 @@ final class AppState: ObservableObject {
         recordingGeneration = UUID()
         let generation = recordingGeneration
         recordingInjectsResult = injectResult
+        startScreenContextCapture(injectResult: injectResult)
         appStatus = .recording
         isRecording = true
         errorMessage = nil
@@ -1530,6 +1647,16 @@ final class AppState: ObservableObject {
         }
 
         appStatus = .processing
+        isTranscribing = true
+        defer {
+            if generation == recordingGeneration { isTranscribing = false }
+        }
+
+        let contextTask = screenContextTask
+        screenContextTask = nil
+        // Saved before transcribing, so a crash or failure can't lose it.
+        let historyID = injectResult ? beginHistoryEntry(audio: audioData) : nil
+        activeHistoryEntryID = historyID
 
         do {
             let language = selectedLanguage == "auto" ? nil : selectedLanguage
@@ -1555,7 +1682,10 @@ final class AppState: ObservableObject {
                 )
             }
 
-            guard generation == recordingGeneration else { return }
+            guard generation == recordingGeneration else {
+                if let historyID { historyStore.markCancelled(historyID) }
+                return
+            }
             lastTranscription = result
 
             // Update stats
@@ -1571,15 +1701,27 @@ final class AppState: ObservableObject {
                     nextWritingProfile = nil
                     activeWritingStyle = resolved
                 }
+                let contextTerms = await Self.awaitContextTerms(contextTask)
                 let output = await outputPipeline.process(
                     result.text, profile: profile, snippetList: snippets,
                     cleanupEnabled: transcriptCleanupEnabled, rewritingEnabled: writingRewriteEnabled,
                     model: selectedCleanupModelKind, customPrompt: effectiveCleanupPrompt,
                     language: result.detectedLanguage, autoCapitalize: autoCapitalize,
-                    trailingSpace: appendTrailingSpace, preview: !injectResult
+                    trailingSpace: appendTrailingSpace, preview: !injectResult,
+                    dictionary: dictionaryContext(contextTerms: contextTerms, language: result.detectedLanguage)
                 )
-                guard generation == recordingGeneration, !Task.isCancelled else { return }
+                guard generation == recordingGeneration, !Task.isCancelled else {
+                    if let historyID { historyStore.markCancelled(historyID) }
+                    return
+                }
                 lastOutput = output
+                if let historyID {
+                    historyStore.complete(
+                        historyID, rawText: result.text, finalText: output.text, summary: output.summary,
+                        language: result.detectedLanguage, transcriptionSeconds: result.duration,
+                        keepAudio: historyKeepsAudio
+                    )
+                }
                 if injectResult {
                     let current = frontmostAppResolver.currentFrontmostApp()
                         ?? frontmostAppResolver.lastActiveApp() ?? pendingTargetApp
@@ -1591,11 +1733,19 @@ final class AppState: ObservableObject {
                         return
                     }
                     textInjector.inject(text: output.text, preserveClipboard: preserveClipboard)
+                    observeCorrections(to: output.text)
                 } else {
                     settingsTestResultText = output.text
                 }
             } else {
                 VocaLogger.info(.appState, "Transcription produced no usable text (silence or blank audio)")
+                if let historyID {
+                    historyStore.complete(
+                        historyID, rawText: result.text, finalText: "", summary: nil,
+                        language: result.detectedLanguage, transcriptionSeconds: result.duration,
+                        keepAudio: historyKeepsAudio
+                    )
+                }
                 if !injectResult {
                     settingsTestResultText = nil
                 }
@@ -1604,9 +1754,19 @@ final class AppState: ObservableObject {
             cursorOverlay.hide()
             appStatus = .idle
         } catch {
-            guard generation == recordingGeneration else { return }
+            guard generation == recordingGeneration else {
+                if let historyID { historyStore.markCancelled(historyID) }
+                return
+            }
             cursorOverlay.hide()
-            errorMessage = "Transcription failed: \(error.localizedDescription)"
+            var message = "Transcription failed: \(error.localizedDescription)"
+            if let historyID {
+                historyStore.markFailed(historyID, message: error.localizedDescription)
+                if historyStore.entry(id: historyID)?.hasAudio == true {
+                    message += " Your audio is saved — retry it from the menu bar."
+                }
+            }
+            errorMessage = message
             appStatus = .error
 
             // Auto-recover after 3 seconds
@@ -1633,11 +1793,36 @@ final class AppState: ObservableObject {
         _ = await stopAudioEngine()
         isRecording = false
         audioLevel = 0.0
+        screenContextTask?.cancel()
+        screenContextTask = nil
         cursorOverlay.hide()
         hotKeyManager.resetKeyState()
         appStatus = .idle
         errorMessage = nil
-        VocaLogger.info(.appState, "Recording cancelled from overlay")
+        VocaLogger.info(.appState, "Recording cancelled")
+    }
+
+    /// Escape: throw away a recording, or drop a dictation still being
+    /// transcribed. A dictation cancelled mid-transcription keeps its audio in
+    /// history, so an accidental Escape can be undone with Retry.
+    func cancelDictation() async {
+        if isRecording || appStatus == .recording {
+            await cancelRecording()
+            return
+        }
+        guard isTranscribing else { return }
+        recordingGeneration = UUID()
+        finishingTranscription?.cancel()
+        isTranscribing = false
+        if let id = activeHistoryEntryID {
+            historyStore.markCancelled(id)
+            activeHistoryEntryID = nil
+        }
+        cursorOverlay.hide()
+        hotKeyManager.resetKeyState()
+        appStatus = .idle
+        errorMessage = nil
+        VocaLogger.info(.appState, "Dictation cancelled while transcribing")
     }
 
     /// Completes a recording the user ended while the microphone was still
@@ -2282,6 +2467,368 @@ final class AppState: ObservableObject {
                 snapshot: second
             )
         default: return false
+        }
+    }
+}
+
+// MARK: - History, Shortcuts, and Dictionary
+
+extension AppState {
+
+    // MARK: History
+
+    /// Record a dictation in history before it is transcribed. Returns nil
+    /// when history is off.
+    fileprivate func beginHistoryEntry(audio: [Float]) -> UUID? {
+        guard historyEnabled else { return nil }
+        historyStore.applyRetention(historyRetention)
+        let modelID = currentModel?.size.rawValue ?? selectedModelSize
+        return historyStore.begin(
+            audio: audio,
+            target: frontmostAppResolver.currentFrontmostApp() ?? pendingTargetApp,
+            modelID: modelID,
+            language: selectedLanguage == "auto" ? nil : selectedLanguage,
+            audioSeconds: Double(audio.count) / 16_000
+        )
+    }
+
+    /// The newest dictation, when it failed or was interrupted and can be
+    /// retried, unless the user dismissed the banner for it.
+    var recoverableHistoryEntry: DictationHistoryEntry? {
+        guard historyEnabled, let entry = historyStore.latestRecoverableEntry,
+              entry.id != dismissedRecoveryEntryID else { return nil }
+        return entry
+    }
+
+    /// Hide the retry banner for an entry; it stays in History.
+    func dismissRecovery(_ id: UUID) {
+        dismissedRecoveryEntryID = id
+    }
+
+    /// Transcribe a history entry's audio again with the current model and
+    /// settings, and copy the result. Never pastes: VocaMac's own window is
+    /// in front when this runs, so the paste-last shortcut puts it in place.
+    @discardableResult
+    func retryHistoryEntry(_ id: UUID) async -> String? {
+        guard retryingHistoryEntryID == nil,
+              let entry = historyStore.entry(id: id), entry.hasAudio else { return nil }
+        retryingHistoryEntryID = id
+        defer { retryingHistoryEntryID = nil }
+
+        do {
+            let samples = try await historyStore.loadAudio(for: entry)
+            await ensureModelLoaded()
+            guard whisperService.isModelLoaded else {
+                showTemporaryError("Could not load the speech model. Open Settings → Speech Model and try again.")
+                return nil
+            }
+            let result = try await whisperService.transcribe(
+                audioData: samples,
+                language: selectedLanguage == "auto" ? nil : selectedLanguage,
+                translate: translationEnabled,
+                vocabulary: customVocabulary
+            )
+            let text = result.text.trimmingCharacters(in: .whitespacesAndNewlines)
+            var output: DictationOutputResult?
+            if !text.isEmpty {
+                let profile = resolveWritingStyle(for: entry.targetApp).profile
+                output = await outputPipeline.process(
+                    result.text, profile: profile, snippetList: snippets,
+                    cleanupEnabled: transcriptCleanupEnabled, rewritingEnabled: writingRewriteEnabled,
+                    model: selectedCleanupModelKind, customPrompt: effectiveCleanupPrompt,
+                    language: result.detectedLanguage, autoCapitalize: autoCapitalize,
+                    trailingSpace: appendTrailingSpace,
+                    dictionary: dictionaryContext(contextTerms: [], language: result.detectedLanguage)
+                )
+            }
+            historyStore.recordRetry(
+                id, rawText: result.text, finalText: output?.text ?? "", summary: output?.summary,
+                language: result.detectedLanguage, modelID: result.modelUsed.rawValue,
+                transcriptionSeconds: result.duration
+            )
+            guard let output else {
+                showTemporaryError("The retry didn't hear any words in that recording.")
+                return nil
+            }
+            lastOutput = output
+            copyToClipboard(output.text)
+            VocaLogger.info(.appState, "Retried dictation \(id) with \(result.modelUsed.displayName)")
+            return output.text
+        } catch {
+            showTemporaryError("Retry failed: \(error.localizedDescription)")
+            return nil
+        }
+    }
+
+    func copyToClipboard(_ text: String) {
+        NSPasteboard.general.clearContents()
+        NSPasteboard.general.setString(text, forType: .string)
+    }
+
+    func deleteHistoryEntry(_ id: UUID) {
+        historyStore.delete(id)
+    }
+
+    func clearHistory() {
+        historyStore.deleteAll()
+    }
+
+    /// Apply a retention change right away rather than at the next dictation.
+    func applyHistoryRetention() {
+        historyStore.applyRetention(historyRetention)
+    }
+
+    /// Open Settings on a specific page (e.g. History from the menu bar).
+    func requestSettingsPage(_ page: SettingsPage) {
+        requestedSettingsPage = page
+    }
+
+    // MARK: Shortcuts
+
+    /// Push the extra shortcuts and the mouse trigger to the hotkey listener.
+    func syncShortcutConfiguration() {
+        guard let monitor = hotKeyManager as? HotKeyShortcutMonitoring else { return }
+        var shortcuts: [HotKeyShortcutAction: HotKeyCombo] = [:]
+        if let combo = HotKeyCombo(storageString: pasteLastShortcut) {
+            shortcuts[.pasteLastDictation] = combo
+        }
+        if let combo = HotKeyCombo(storageString: handsFreeShortcut) {
+            shortcuts[.handsFreeToggle] = combo
+        }
+        monitor.updateShortcuts(shortcuts)
+        monitor.updateMouseTrigger(button: MouseTriggerButton.resolved(stored: mouseTriggerButton).rawValue)
+        refreshCancelKeyArming()
+    }
+
+    func shortcut(for action: HotKeyShortcutAction) -> HotKeyCombo? {
+        switch action {
+        case .pasteLastDictation: return HotKeyCombo(storageString: pasteLastShortcut)
+        case .handsFreeToggle: return HotKeyCombo(storageString: handsFreeShortcut)
+        }
+    }
+
+    func setShortcut(_ combo: HotKeyCombo?, for action: HotKeyShortcutAction) {
+        let stored = combo?.storageString ?? ""
+        switch action {
+        case .pasteLastDictation: pasteLastShortcut = stored
+        case .handsFreeToggle: handsFreeShortcut = stored
+        }
+        syncShortcutConfiguration()
+    }
+
+    func handleShortcut(_ action: HotKeyShortcutAction) async {
+        switch action {
+        case .pasteLastDictation:
+            pasteLastDictation()
+        case .handsFreeToggle:
+            await toggleHandsFreeDictation()
+        }
+    }
+
+    /// Start a dictation that runs until the shortcut is pressed again (or
+    /// silence ends it), whatever the activation mode is.
+    func toggleHandsFreeDictation() async {
+        if isRecording || appStatus == .recording {
+            await stopRecordingAndTranscribe()
+            return
+        }
+        isHandsFreeSession = true
+        await startRecording()
+        if !isRecording {
+            isHandsFreeSession = false
+        }
+    }
+
+    /// Type the most recent dictation again at the cursor.
+    func pasteLastDictation() {
+        guard !isRecording, appStatus != .recording else { return }
+        let fromHistory = historyEnabled ? historyStore.latestDeliveredText : nil
+        guard let text = fromHistory ?? lastOutput?.text ?? heldOutput,
+              !text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+            showTemporaryError("There's no dictation to paste yet.")
+            return
+        }
+        VocaLogger.info(.appState, "Pasting the last dictation again (\(text.count) chars)")
+        textInjector.inject(text: text, preserveClipboard: preserveClipboard)
+    }
+
+    fileprivate func refreshCancelKeyArming(status: AppStatus? = nil) {
+        guard let monitor = hotKeyManager as? HotKeyShortcutMonitoring else { return }
+        let current = status ?? appStatus
+        monitor.setCancelKeyArmed(escapeCancelsDictation && (current == .recording || isTranscribing))
+    }
+
+    // MARK: Dictionary
+
+    /// Vocabulary terms, one per entry. Stored in `customVocabulary` so the
+    /// Whisper recognition hint keeps working.
+    var vocabularyTerms: [String] {
+        WhisperService.vocabularyTerms(from: customVocabulary)
+    }
+
+    func setVocabularyTerms(_ terms: [String]) {
+        var seen = Set<String>()
+        let cleaned = terms
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .filter { !$0.isEmpty && seen.insert($0.lowercased()).inserted }
+        customVocabulary = cleaned.joined(separator: "\n")
+    }
+
+    /// Add a term, replacing a differently-cased copy of it.
+    func addVocabularyTerm(_ term: String) {
+        let trimmed = term.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return }
+        var terms = vocabularyTerms.filter { $0.lowercased() != trimmed.lowercased() }
+        terms.append(trimmed)
+        setVocabularyTerms(terms)
+    }
+
+    func removeVocabularyTerm(_ term: String) {
+        setVocabularyTerms(vocabularyTerms.filter { $0 != term })
+    }
+
+    /// Add a replacement, merging into an existing one that already writes
+    /// the same text.
+    func addWordReplacement(heard: String, replacement: String) {
+        let heard = heard.trimmingCharacters(in: .whitespacesAndNewlines)
+        let replacement = replacement.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !heard.isEmpty, !replacement.isEmpty else { return }
+        if let index = wordReplacements.firstIndex(where: { $0.replacement == replacement }) {
+            let forms = wordReplacements[index].heardForms
+            guard !forms.contains(where: { $0.lowercased() == heard.lowercased() }) else { return }
+            wordReplacements[index].heard = (forms + [heard]).joined(separator: ", ")
+        } else {
+            wordReplacements.append(WordReplacement(heard: heard, replacement: replacement))
+        }
+    }
+
+    func dictionaryContext(contextTerms: [String], language: String?) -> DictionaryContext {
+        let isKnownWord = self.isKnownWord
+        return DictionaryContext(
+            vocabulary: vocabularyTerms,
+            replacements: wordReplacements,
+            contextTerms: contextTerms,
+            isKnownWord: { isKnownWord($0, language) }
+        )
+    }
+
+    /// Accept a noticed correction: the corrected spelling becomes a
+    /// vocabulary term, plus a replacement when the engine heard different
+    /// letters (not just different casing or spacing).
+    func acceptDictionarySuggestion(_ suggestion: CorrectionSuggestion) {
+        learn(heard: suggestion.heard, corrected: suggestion.corrected)
+        dictionarySuggestions.removeAll { $0.id == suggestion.id }
+        saveSuggestions()
+    }
+
+    func dismissDictionarySuggestion(_ suggestion: CorrectionSuggestion) {
+        dictionarySuggestions.removeAll { $0.id == suggestion.id }
+        dismissedSuggestionKeys.insert(suggestion.id)
+        saveSuggestions()
+    }
+
+    private func learn(heard: String, corrected: String) {
+        addVocabularyTerm(corrected)
+        if DictionaryCorrector.normalized(heard) != DictionaryCorrector.normalized(corrected) {
+            addWordReplacement(heard: heard, replacement: corrected)
+        }
+        VocaLogger.info(.dictionary, "Learned a spelling from a correction")
+    }
+
+    fileprivate func receiveCorrections(_ corrections: [CorrectionLearner.Correction]) {
+        let mode = learnCorrectionsMode
+        guard mode != .off else { return }
+        let known = Set(vocabularyTerms)
+        for correction in corrections where !known.contains(correction.corrected) {
+            let key = CorrectionSuggestion.key(heard: correction.heard, corrected: correction.corrected)
+            guard !dismissedSuggestionKeys.contains(key) else { continue }
+            if mode == .automatic {
+                learn(heard: correction.heard, corrected: correction.corrected)
+                continue
+            }
+            if let index = dictionarySuggestions.firstIndex(where: { $0.id == key }) {
+                dictionarySuggestions[index].occurrences += 1
+                dictionarySuggestions[index].lastSeen = Date()
+            } else {
+                dictionarySuggestions.insert(
+                    CorrectionSuggestion(heard: correction.heard, corrected: correction.corrected,
+                                         occurrences: 1, lastSeen: Date()),
+                    at: 0
+                )
+            }
+        }
+        dictionarySuggestions = Array(dictionarySuggestions.prefix(50))
+        saveSuggestions()
+    }
+
+    /// Feed corrections through the same path the observer uses. Tests only.
+    func _receiveCorrectionsForTesting(_ corrections: [CorrectionLearner.Correction]) {
+        receiveCorrections(corrections)
+    }
+
+    fileprivate func observeCorrections(to text: String) {
+        guard learnCorrectionsMode != .off, let correctionObserver,
+              let processID = NSWorkspace.shared.frontmostApplication?.processIdentifier else { return }
+        let isKnownWord = self.isKnownWord
+        correctionObserver.observe(insertedText: text, processID: processID) { isKnownWord($0, "en") }
+    }
+
+    /// Start reading names and identifiers from the screen while the user speaks.
+    fileprivate func startScreenContextCapture(injectResult: Bool) {
+        screenContextTask?.cancel()
+        screenContextTask = nil
+        guard injectResult, useScreenContext, let reader = screenContextReader else { return }
+        let isKnownWord = self.isKnownWord
+        screenContextTask = Task { @MainActor in
+            guard let text = await reader.captureFrontmostContext(), !Task.isCancelled else { return [] }
+            return ScreenContextTerms.extract(from: text) { isKnownWord($0, "en") }
+        }
+    }
+
+    /// The screen terms, if they arrive in time. Never holds up a dictation
+    /// for more than a moment on a slow app.
+    fileprivate static func awaitContextTerms(_ task: Task<[String], Never>?) async -> [String] {
+        guard let task else { return [] }
+        return await withTaskGroup(of: [String]?.self) { group in
+            group.addTask { await task.value }
+            group.addTask {
+                try? await Task.sleep(nanoseconds: 300_000_000)
+                return nil
+            }
+            let first = await group.next() ?? nil
+            group.cancelAll()
+            return first ?? []
+        }
+    }
+
+    fileprivate func loadDictionary() {
+        wordReplacements = Self.loadJSON([WordReplacement].self, forKey: PreferenceKey.wordReplacements) ?? []
+        dictionarySuggestions = Self.loadJSON([CorrectionSuggestion].self, forKey: PreferenceKey.dictionarySuggestions) ?? []
+        dismissedSuggestionKeys = Set(
+            UserDefaults.standard.stringArray(forKey: PreferenceKey.dismissedDictionarySuggestions) ?? []
+        )
+    }
+
+    private func saveSuggestions() {
+        Self.saveJSON(dictionarySuggestions, forKey: PreferenceKey.dictionarySuggestions)
+        UserDefaults.standard.set(Array(dismissedSuggestionKeys), forKey: PreferenceKey.dismissedDictionarySuggestions)
+    }
+
+    fileprivate static func loadJSON<T: Decodable>(_ type: T.Type, forKey key: String) -> T? {
+        guard let data = UserDefaults.standard.data(forKey: key) else { return nil }
+        do {
+            return try JSONDecoder().decode(type, from: data)
+        } catch {
+            VocaLogger.error(.dictionary, "Could not read \(key): \(error)")
+            return nil
+        }
+    }
+
+    fileprivate static func saveJSON<T: Encodable>(_ value: T, forKey key: String) {
+        do {
+            UserDefaults.standard.set(try JSONEncoder().encode(value), forKey: key)
+        } catch {
+            VocaLogger.error(.dictionary, "Could not save \(key): \(error)")
         }
     }
 }

--- a/Sources/VocaMac/Models/AppState.swift
+++ b/Sources/VocaMac/Models/AppState.swift
@@ -186,7 +186,7 @@ final class AppState: ObservableObject {
     @AppStorage(PreferenceKey.transcriptCleanupModel) var transcriptCleanupModel: String = CleanupModelKind.defaultKind.rawValue
     @AppStorage(PreferenceKey.transcriptCleanupPrompt) var transcriptCleanupPrompt: String = ""
     @AppStorage(PreferenceKey.historyEnabled) var historyEnabled: Bool = true
-    @AppStorage(PreferenceKey.historyKeepsAudio) var historyKeepsAudio: Bool = true
+    @AppStorage(PreferenceKey.historyKeepsAudio) var historyKeepsAudio: Bool = false
     @AppStorage(PreferenceKey.historyRetention) var historyRetention: HistoryRetention = .defaultRetention
     @AppStorage(PreferenceKey.escapeCancelsDictation) var escapeCancelsDictation: Bool = true
     /// `HotKeyCombo.storageString`, or empty for no shortcut.

--- a/Sources/VocaMac/Models/AppState.swift
+++ b/Sources/VocaMac/Models/AppState.swift
@@ -2571,11 +2571,21 @@ extension AppState {
     }
 
     func deleteHistoryEntry(_ id: UUID) {
-        historyStore.delete(id)
+        if !historyStore.delete(id) {
+            showTemporaryError("Couldn't delete that dictation because the history file couldn't be saved. Nothing was removed.")
+        }
     }
 
     func clearHistory() {
-        historyStore.deleteAll()
+        if !historyStore.deleteAll() {
+            showTemporaryError("Couldn't delete your history because the history file couldn't be saved. Nothing was removed.")
+        }
+    }
+
+    func deleteAllHistoryAudio() {
+        if !historyStore.deleteAllAudio() {
+            showTemporaryError("Couldn't delete the recordings because the history file couldn't be saved. Nothing was removed.")
+        }
     }
 
     /// Apply a retention change right away rather than at the next dictation.

--- a/Sources/VocaMac/Models/DictationHistory.swift
+++ b/Sources/VocaMac/Models/DictationHistory.swift
@@ -1,0 +1,175 @@
+// DictationHistory.swift
+// VocaMac
+//
+// A local record of past dictations: what the engine heard, what was typed,
+// and the audio behind it, so a dictation can be copied, pasted again, or
+// retried after a failure.
+
+import Foundation
+
+/// Where a dictation got to before it was recorded in history.
+enum DictationHistoryStatus: String, Codable, Equatable {
+    /// Audio saved, transcription still running. A pending entry found at
+    /// launch means VocaMac quit or crashed mid-dictation.
+    case pending
+    /// Transcribed and delivered.
+    case completed
+    /// Transcribed, but the engine heard nothing usable.
+    case empty
+    /// The engine threw.
+    case failed
+    /// VocaMac quit or crashed before the dictation finished.
+    case interrupted
+    /// The user cancelled while the dictation was being transcribed.
+    case cancelled
+
+    var displayName: String {
+        switch self {
+        case .pending: return "Transcribing"
+        case .completed: return "Done"
+        case .empty: return "Nothing heard"
+        case .failed: return "Failed"
+        case .interrupted: return "Interrupted"
+        case .cancelled: return "Cancelled"
+        }
+    }
+
+    /// Statuses the user would want to retry: the audio exists but no text
+    /// reached them.
+    var needsRecovery: Bool {
+        switch self {
+        case .failed, .interrupted, .cancelled: return true
+        case .pending, .completed, .empty: return false
+        }
+    }
+}
+
+/// How long history entries are kept before they are deleted.
+enum HistoryRetention: String, CaseIterable, Identifiable, Codable {
+    case day
+    case week
+    case month
+    case forever
+
+    var id: String { rawValue }
+
+    static let defaultRetention: HistoryRetention = .month
+
+    var displayName: String {
+        switch self {
+        case .day: return "1 day"
+        case .week: return "7 days"
+        case .month: return "30 days"
+        case .forever: return "Forever"
+        }
+    }
+
+    /// Age after which an entry is deleted. `nil` keeps entries forever.
+    var maximumAge: TimeInterval? {
+        switch self {
+        case .day: return 24 * 60 * 60
+        case .week: return 7 * 24 * 60 * 60
+        case .month: return 30 * 24 * 60 * 60
+        case .forever: return nil
+        }
+    }
+
+    static func resolved(stored: String) -> HistoryRetention {
+        HistoryRetention(rawValue: stored) ?? defaultRetention
+    }
+}
+
+/// One dictation in history.
+struct DictationHistoryEntry: Codable, Identifiable, Equatable {
+    let id: UUID
+    let createdAt: Date
+    var status: DictationHistoryStatus
+    /// What the speech engine returned, before any dictionary, style, or cleanup.
+    var rawText: String
+    /// What VocaMac typed (or would have typed).
+    var finalText: String
+    /// One-line description of what the output pipeline did.
+    var summary: String?
+    var appName: String?
+    var bundleIdentifier: String?
+    var processName: String?
+    /// `ModelSize.rawValue` of the model that transcribed it.
+    var modelID: String
+    var language: String?
+    var audioSeconds: Double
+    var transcriptionSeconds: Double?
+    /// File name inside the history audio folder, when audio is kept.
+    var audioFileName: String?
+    var audioBytes: Int64?
+    var errorMessage: String?
+    var retryCount: Int
+
+    init(
+        id: UUID = UUID(),
+        createdAt: Date = Date(),
+        status: DictationHistoryStatus = .pending,
+        rawText: String = "",
+        finalText: String = "",
+        summary: String? = nil,
+        appName: String? = nil,
+        bundleIdentifier: String? = nil,
+        processName: String? = nil,
+        modelID: String,
+        language: String? = nil,
+        audioSeconds: Double,
+        transcriptionSeconds: Double? = nil,
+        audioFileName: String? = nil,
+        audioBytes: Int64? = nil,
+        errorMessage: String? = nil,
+        retryCount: Int = 0
+    ) {
+        self.id = id
+        self.createdAt = createdAt
+        self.status = status
+        self.rawText = rawText
+        self.finalText = finalText
+        self.summary = summary
+        self.appName = appName
+        self.bundleIdentifier = bundleIdentifier
+        self.processName = processName
+        self.modelID = modelID
+        self.language = language
+        self.audioSeconds = audioSeconds
+        self.transcriptionSeconds = transcriptionSeconds
+        self.audioFileName = audioFileName
+        self.audioBytes = audioBytes
+        self.errorMessage = errorMessage
+        self.retryCount = retryCount
+    }
+
+    /// The text a user means when they say "that dictation".
+    var displayText: String {
+        let final = finalText.trimmingCharacters(in: .whitespacesAndNewlines)
+        return final.isEmpty ? rawText.trimmingCharacters(in: .whitespacesAndNewlines) : final
+    }
+
+    /// Whether the dictionary, a writing style, or cleanup changed the words,
+    /// beyond spacing and case — the case where "show original" is useful.
+    var hasEditedOutput: Bool {
+        let raw = Self.comparable(rawText)
+        let final = Self.comparable(finalText)
+        return !raw.isEmpty && !final.isEmpty && raw != final
+    }
+
+    var hasAudio: Bool { audioFileName != nil }
+
+    /// The target app as a snapshot, for re-running its writing style on retry.
+    var targetApp: RunningAppSnapshot? {
+        guard let appName else { return nil }
+        return RunningAppSnapshot(displayName: appName, bundleIdentifier: bundleIdentifier, processName: processName)
+    }
+
+    /// Words only: sentence case, added punctuation, and spacing are what
+    /// every formatted dictation changes, so they don't count as an edit.
+    private static func comparable(_ text: String) -> String {
+        text.lowercased()
+            .components(separatedBy: CharacterSet.alphanumerics.inverted)
+            .filter { !$0.isEmpty }
+            .joined(separator: " ")
+    }
+}

--- a/Sources/VocaMac/Models/PersonalDictionary.swift
+++ b/Sources/VocaMac/Models/PersonalDictionary.swift
@@ -1,0 +1,96 @@
+// PersonalDictionary.swift
+// VocaMac
+//
+// The user's own words: vocabulary terms that must be spelled their way,
+// replacements for words an engine keeps getting wrong, and corrections
+// VocaMac noticed the user making.
+
+import Foundation
+
+/// Rewrite what an engine heard into what the user meant, e.g.
+/// "get hub" → "GitHub". Applied to every engine's output.
+struct WordReplacement: Identifiable, Codable, Equatable {
+    var id: UUID
+    /// One or more spoken forms, comma-separated. Matching ignores case.
+    var heard: String
+    /// Exactly what to type instead.
+    var replacement: String
+
+    init(id: UUID = UUID(), heard: String, replacement: String) {
+        self.id = id
+        self.heard = heard
+        self.replacement = replacement
+    }
+
+    /// Each non-empty spoken form in `heard`.
+    var heardForms: [String] {
+        heard.split(separator: ",")
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .filter { !$0.isEmpty }
+    }
+
+    var isValid: Bool {
+        !heardForms.isEmpty && !replacement.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+    }
+}
+
+/// A correction VocaMac saw the user make to dictated text.
+struct CorrectionSuggestion: Identifiable, Codable, Equatable {
+    /// What was typed.
+    var heard: String
+    /// What the user changed it to.
+    var corrected: String
+    var occurrences: Int
+    var lastSeen: Date
+
+    var id: String { Self.key(heard: heard, corrected: corrected) }
+
+    static func key(heard: String, corrected: String) -> String {
+        "\(heard.lowercased())→\(corrected)"
+    }
+}
+
+/// What VocaMac does when it sees the user correct a dictated word.
+enum LearnCorrectionsMode: String, CaseIterable, Identifiable, Codable {
+    case off
+    case suggest
+    case automatic
+
+    var id: String { rawValue }
+
+    static let defaultMode: LearnCorrectionsMode = .suggest
+
+    var displayName: String {
+        switch self {
+        case .off: return "Off"
+        case .suggest: return "Suggest words"
+        case .automatic: return "Add automatically"
+        }
+    }
+
+    var description: String {
+        switch self {
+        case .off:
+            return "VocaMac doesn't look at text after typing it."
+        case .suggest:
+            return "When you fix a word VocaMac typed, it suggests adding your spelling to the dictionary."
+        case .automatic:
+            return "When you fix a word VocaMac typed, your spelling is added to the dictionary right away."
+        }
+    }
+}
+
+/// Everything the output pipeline needs to apply the personal dictionary to
+/// one dictation.
+struct DictionaryContext {
+    var vocabulary: [String]
+    var replacements: [WordReplacement]
+    /// Names and identifiers read from the screen when recording started.
+    var contextTerms: [String]
+    /// Whether a word is ordinary vocabulary in the dictation's language.
+    var isKnownWord: (String) -> Bool
+
+    var isEmpty: Bool {
+        vocabulary.isEmpty && replacements.isEmpty && contextTerms.isEmpty
+    }
+}

--- a/Sources/VocaMac/Models/SettingsPage.swift
+++ b/Sources/VocaMac/Models/SettingsPage.swift
@@ -9,7 +9,9 @@ import SwiftUI
 /// Top-level settings topics shown in the left sidebar.
 enum SettingsPage: String, CaseIterable, Identifiable, Hashable {
     case dictation
+    case history
     case writingStyles
+    case dictionary
     case snippets
     case cleanup
     case speechModel
@@ -25,6 +27,8 @@ enum SettingsPage: String, CaseIterable, Identifiable, Hashable {
     var title: String {
         switch self {
         case .dictation: return "Dictation"
+        case .history: return "History"
+        case .dictionary: return "Dictionary"
         case .writingStyles: return "Writing Styles"
         case .snippets: return "Snippets"
         case .cleanup: return "Cleanup"
@@ -41,6 +45,8 @@ enum SettingsPage: String, CaseIterable, Identifiable, Hashable {
     var subtitle: String {
         switch self {
         case .dictation: return "Make voice typing feel natural to you."
+        case .history: return "Find, copy, and retry what you've dictated."
+        case .dictionary: return "Teach VocaMac the words you use."
         case .writingStyles: return "Match formatting and tone to the app where your words land."
         case .snippets: return "Turn a short spoken phrase into the text you use often."
         case .cleanup: return "Polish your words with an optional model running on this Mac."
@@ -57,6 +63,8 @@ enum SettingsPage: String, CaseIterable, Identifiable, Hashable {
     var systemImage: String {
         switch self {
         case .dictation: return "mic"
+        case .history: return "clock.arrow.circlepath"
+        case .dictionary: return "character.book.closed"
         case .writingStyles: return "textformat"
         case .snippets: return "text.quote"
         case .cleanup: return "wand.and.stars"

--- a/Sources/VocaMac/Models/SettingsSearchIndex.swift
+++ b/Sources/VocaMac/Models/SettingsSearchIndex.swift
@@ -56,6 +56,34 @@ enum SettingsSearchIndex {
             keywords: ["space", "output", "glue", "whitespace"]
         ),
         SettingsSearchEntry(
+            id: "paste-last-shortcut",
+            page: .dictation,
+            title: "Paste Last Dictation",
+            subtitle: "Shortcut to type your last dictation again",
+            keywords: ["paste", "last", "again", "repeat", "shortcut", "clipboard"]
+        ),
+        SettingsSearchEntry(
+            id: "hands-free-shortcut",
+            page: .dictation,
+            title: "Hands-free Dictation",
+            subtitle: "Shortcut to start and stop without holding",
+            keywords: ["hands free", "toggle", "long", "shortcut", "lock"]
+        ),
+        SettingsSearchEntry(
+            id: "escape-cancel",
+            page: .dictation,
+            title: "Escape Cancels Dictation",
+            subtitle: "Throw away a recording with Escape",
+            keywords: ["escape", "esc", "cancel", "discard", "abort"]
+        ),
+        SettingsSearchEntry(
+            id: "mouse-trigger",
+            page: .dictation,
+            title: "Mouse Button",
+            subtitle: "Dictate with a middle or side mouse button",
+            keywords: ["mouse", "button", "middle", "side", "click"]
+        ),
+        SettingsSearchEntry(
             id: "auto-capitalize",
             page: .dictation,
             title: "Auto-Capitalize Sentences",
@@ -176,10 +204,47 @@ enum SettingsSearchIndex {
         ),
         SettingsSearchEntry(
             id: "vocabulary",
-            page: .speechModel,
-            title: "Custom Vocabulary",
-            subtitle: "Hint proper nouns to Whisper",
-            keywords: ["vocab", "dictionary", "terms"]
+            page: .dictionary,
+            title: "Vocabulary",
+            subtitle: "Spell names and jargon your way with every model",
+            keywords: ["vocab", "dictionary", "terms", "custom vocabulary", "names", "jargon", "spelling"]
+        ),
+        SettingsSearchEntry(
+            id: "word-replacements",
+            page: .dictionary,
+            title: "Replacements",
+            subtitle: "Type something else for a word a model gets wrong",
+            keywords: ["replace", "replacement", "correction", "misheard", "substitute", "fix"]
+        ),
+        SettingsSearchEntry(
+            id: "learn-corrections",
+            page: .dictionary,
+            title: "Learn from My Corrections",
+            subtitle: "Suggest words you fixed after dictating",
+            keywords: ["learn", "auto", "suggest", "correction", "edit"]
+        ),
+        SettingsSearchEntry(
+            id: "screen-context",
+            page: .dictionary,
+            title: "Spell Names from the Screen",
+            subtitle: "Match names and identifiers you can see",
+            keywords: ["context", "screen", "identifier", "variable", "code", "names", "accessibility"]
+        ),
+
+        // History
+        SettingsSearchEntry(
+            id: "history",
+            page: .history,
+            title: "Dictation History",
+            subtitle: "Find, copy, replay, and retry past dictations",
+            keywords: ["history", "past", "previous", "transcripts", "retry", "search", "recordings", "audio", "undo"]
+        ),
+        SettingsSearchEntry(
+            id: "history-retention",
+            page: .history,
+            title: "Keep History For",
+            subtitle: "Delete dictations after a day, a week, or a month",
+            keywords: ["retention", "delete", "privacy", "storage", "keep audio"]
         ),
 
         // Audio

--- a/Sources/VocaMac/Models/TranscriptionEngine.swift
+++ b/Sources/VocaMac/Models/TranscriptionEngine.swift
@@ -28,6 +28,18 @@ enum PreferenceKey {
     static let transcriptCleanupEnabled = "vocamac.transcriptCleanup.enabled"
     static let transcriptCleanupModel = "vocamac.transcriptCleanup.model"
     static let transcriptCleanupPrompt = "vocamac.transcriptCleanup.prompt"
+    static let historyEnabled = "vocamac.history.enabled"
+    static let historyKeepsAudio = "vocamac.history.keepAudio"
+    static let historyRetention = "vocamac.history.retention"
+    static let escapeCancelsDictation = "vocamac.shortcuts.escapeCancels"
+    static let pasteLastShortcut = "vocamac.shortcuts.pasteLast"
+    static let handsFreeShortcut = "vocamac.shortcuts.handsFree"
+    static let mouseTriggerButton = "vocamac.shortcuts.mouseButton"
+    static let wordReplacements = "vocamac.dictionary.replacements"
+    static let dictionarySuggestions = "vocamac.dictionary.suggestions"
+    static let dismissedDictionarySuggestions = "vocamac.dictionary.dismissedSuggestions"
+    static let learnCorrectionsMode = "vocamac.dictionary.learnMode"
+    static let useScreenContext = "vocamac.dictionary.screenContext"
 }
 
 /// The on-device inference engine backing a model in the catalog.

--- a/Sources/VocaMac/Services/AccessibilityTextReader.swift
+++ b/Sources/VocaMac/Services/AccessibilityTextReader.swift
@@ -1,0 +1,186 @@
+// AccessibilityTextReader.swift
+// VocaMac
+//
+// Reads text from another app's focused field through the Accessibility API,
+// for on-screen spelling context and for learning from corrections. Every
+// call has a short timeout and runs off the main thread, and nothing read
+// here is stored or sent anywhere.
+
+import AppKit
+import ApplicationServices
+import Foundation
+
+/// An `AXUIElement` handed between the main actor and the AX worker queue.
+/// AX elements are thread-safe CF objects; the box only tells Swift so.
+struct AXElementBox: @unchecked Sendable {
+    let element: AXUIElement
+}
+
+/// The focused text field of an app and what it contained.
+struct FocusedTextSnapshot: @unchecked Sendable {
+    let element: AXElementBox
+    let processID: pid_t
+    let value: String
+    /// Caret position (UTF-16 offset) when the snapshot was taken.
+    let caretLocation: Int?
+}
+
+enum AccessibilityTextReader {
+
+    /// Longest field value read in full. Beyond this only the text around
+    /// the caret is used for context, and corrections aren't tracked.
+    static let maximumValueLength = 50_000
+
+    static let queue = DispatchQueue(label: "com.vocamac.accessibility-text", qos: .userInitiated)
+
+    private static let timeout: Float = 0.15
+
+    /// The focused element of the app with `processID`, if it is a readable,
+    /// non-secure text element.
+    static func focusedTextElement(processID: pid_t) -> AXUIElement? {
+        guard AXIsProcessTrusted(), processID != ProcessInfo.processInfo.processIdentifier else { return nil }
+        let app = AXUIElementCreateApplication(processID)
+        AXUIElementSetMessagingTimeout(app, timeout)
+        guard let focused = copyElement(app, kAXFocusedUIElementAttribute) else { return nil }
+        AXUIElementSetMessagingTimeout(focused, timeout)
+
+        let role = copyString(focused, kAXRoleAttribute) ?? ""
+        let subrole = copyString(focused, kAXSubroleAttribute) ?? ""
+        // Never read a password field, even to look at it.
+        if role == "AXSecureTextField" || subrole == (kAXSecureTextFieldSubrole as String) {
+            return nil
+        }
+        return focused
+    }
+
+    /// The element's full text value, or `nil` when it has none or it is
+    /// longer than `maximumValueLength`.
+    static func value(of element: AXUIElement) -> String? {
+        guard let value = copyString(element, kAXValueAttribute),
+              value.utf16.count <= maximumValueLength else { return nil }
+        return value
+    }
+
+    static func caretLocation(of element: AXUIElement) -> Int? {
+        var ref: CFTypeRef?
+        guard AXUIElementCopyAttributeValue(element, kAXSelectedTextRangeAttribute as CFString, &ref) == .success,
+              let ref, CFGetTypeID(ref) == AXValueGetTypeID() else { return nil }
+        var range = CFRange()
+        // swiftlint:disable:next force_cast
+        guard AXValueGetValue(ref as! AXValue, .cfRange, &range) else { return nil }
+        return range.location + range.length
+    }
+
+    /// The text visible in the element, falling back to the text around the
+    /// caret, plus the window title. Used only to find names and identifiers.
+    static func visibleContext(processID: pid_t) -> String? {
+        guard AXIsProcessTrusted(), processID != ProcessInfo.processInfo.processIdentifier else { return nil }
+        let app = AXUIElementCreateApplication(processID)
+        AXUIElementSetMessagingTimeout(app, timeout)
+
+        var parts: [String] = []
+        if let window = copyElement(app, kAXFocusedWindowAttribute),
+           let title = copyString(window, kAXTitleAttribute), !title.isEmpty {
+            parts.append(title)
+        }
+
+        if let element = focusedTextElement(processID: processID) {
+            if let visible = visibleText(of: element) {
+                parts.append(visible)
+            } else if let full = copyString(element, kAXValueAttribute) {
+                parts.append(textAroundCaret(full, caret: caretLocation(of: element)))
+            }
+        }
+        let text = parts.joined(separator: "\n")
+        return text.isEmpty ? nil : text
+    }
+
+    // MARK: - Private
+
+    private static func visibleText(of element: AXUIElement) -> String? {
+        var rangeRef: CFTypeRef?
+        guard AXUIElementCopyAttributeValue(element, kAXVisibleCharacterRangeAttribute as CFString, &rangeRef) == .success,
+              let rangeRef, CFGetTypeID(rangeRef) == AXValueGetTypeID() else { return nil }
+        var textRef: CFTypeRef?
+        guard AXUIElementCopyParameterizedAttributeValue(
+            element, kAXStringForRangeParameterizedAttribute as CFString, rangeRef, &textRef
+        ) == .success, let text = textRef as? String, !text.isEmpty else { return nil }
+        return String(text.prefix(20_000))
+    }
+
+    private static func textAroundCaret(_ text: String, caret: Int?) -> String {
+        let limit = 20_000
+        let utf16 = text.utf16
+        guard utf16.count > limit else { return text }
+        let center = min(max(caret ?? utf16.count, 0), utf16.count)
+        let lower = max(0, center - limit / 2)
+        let upper = min(utf16.count, lower + limit)
+        let start = utf16.index(utf16.startIndex, offsetBy: lower)
+        let end = utf16.index(utf16.startIndex, offsetBy: upper)
+        return String(text[start..<end])
+    }
+
+    private static func copyElement(_ element: AXUIElement, _ attribute: String) -> AXUIElement? {
+        var ref: CFTypeRef?
+        guard AXUIElementCopyAttributeValue(element, attribute as CFString, &ref) == .success,
+              let ref, CFGetTypeID(ref) == AXUIElementGetTypeID() else { return nil }
+        // swiftlint:disable:next force_cast
+        return (ref as! AXUIElement)
+    }
+
+    private static func copyString(_ element: AXUIElement, _ attribute: String) -> String? {
+        var ref: CFTypeRef?
+        guard AXUIElementCopyAttributeValue(element, attribute as CFString, &ref) == .success else { return nil }
+        return ref as? String
+    }
+}
+
+// MARK: - Screen Context
+
+/// Reads spelling context from the app the user is dictating into.
+@MainActor
+protocol ScreenContextReading: AnyObject {
+    /// Visible text of the frontmost app's focused field and window title.
+    func captureFrontmostContext() async -> String?
+}
+
+@MainActor
+final class ScreenContextReader: ScreenContextReading {
+    func captureFrontmostContext() async -> String? {
+        guard let processID = NSWorkspace.shared.frontmostApplication?.processIdentifier else { return nil }
+        return await withCheckedContinuation { continuation in
+            AccessibilityTextReader.queue.async {
+                continuation.resume(returning: AccessibilityTextReader.visibleContext(processID: processID))
+            }
+        }
+    }
+}
+
+// MARK: - Spelling
+
+/// Whether a word is ordinary vocabulary, using the system spell checker.
+/// Results are cached: the same few hundred words come up again and again.
+@MainActor
+final class SpellingOracle {
+    static let shared = SpellingOracle()
+
+    private var cache: [String: Bool] = [:]
+
+    /// `language` is an ISO code such as "en". Outside English every word is
+    /// treated as known, which turns off single-word fuzzy corrections rather
+    /// than trusting a checker for the wrong language.
+    func isKnownWord(_ word: String, language: String?) -> Bool {
+        if let language, !language.lowercased().hasPrefix("en") { return true }
+        let key = word.lowercased()
+        if let cached = cache[key] { return cached }
+        let checker = NSSpellChecker.shared
+        let misspelled = checker.checkSpelling(
+            of: key, startingAt: 0, language: "en", wrap: false,
+            inSpellDocumentWithTag: 0, wordCount: nil
+        )
+        let known = misspelled.location == NSNotFound
+        if cache.count > 5_000 { cache.removeAll() }
+        cache[key] = known
+        return known
+    }
+}

--- a/Sources/VocaMac/Services/CorrectionLearner.swift
+++ b/Sources/VocaMac/Services/CorrectionLearner.swift
@@ -1,0 +1,193 @@
+// CorrectionLearner.swift
+// VocaMac
+//
+// Works out which words a user corrected in text VocaMac typed, by comparing
+// the field's contents right after the dictation with its contents later.
+//
+// Only spelling fixes count: a name spelled differently, a casing change, or
+// words joined into one term. Rewording a sentence is the user writing, not a
+// transcription mistake, and is ignored.
+
+import Foundation
+
+enum CorrectionLearner {
+
+    struct Correction: Equatable {
+        let heard: String
+        let corrected: String
+    }
+
+    /// Longest edited region, in words, that is still treated as a fix
+    /// rather than a rewrite.
+    static let maximumEditedWords = 12
+
+    /// Corrections the user made inside the dictated text.
+    ///
+    /// - Parameters:
+    ///   - inserted: The text VocaMac typed.
+    ///   - before: The field's text just after typing it.
+    ///   - after: The field's text now.
+    ///   - caretLocation: Caret position in `before`, used to find the right
+    ///     copy of `inserted` when it appears more than once.
+    ///   - isKnownWord: Whether a lowercase word is ordinary vocabulary.
+    static func corrections(
+        inserted: String,
+        before: String,
+        after: String,
+        caretLocation: Int? = nil,
+        isKnownWord: (String) -> Bool
+    ) -> [Correction] {
+        let dictated = inserted.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !dictated.isEmpty, before != after else { return [] }
+        let old = Array(before)
+        let new = Array(after)
+        guard let insertedRange = locate(Array(dictated), in: old, caretLocation: caretLocation) else { return [] }
+
+        // The single region where the two texts differ.
+        var prefix = 0
+        while prefix < old.count, prefix < new.count, old[prefix] == new[prefix] { prefix += 1 }
+        var suffix = 0
+        while suffix < old.count - prefix, suffix < new.count - prefix,
+              old[old.count - 1 - suffix] == new[new.count - 1 - suffix] {
+            suffix += 1
+        }
+
+        // Widen to whole words so "Namratha" → "Namrata" compares whole names.
+        while prefix > 0, isWordCharacter(old[prefix - 1]) { prefix -= 1 }
+        while suffix > 0, isWordCharacter(old[old.count - suffix]) { suffix -= 1 }
+
+        let oldChanged = prefix..<(old.count - suffix)
+        let newChanged = prefix..<(new.count - suffix)
+        guard oldChanged.overlaps(insertedRange) || (oldChanged.isEmpty && insertedRange.contains(prefix)) else {
+            return []
+        }
+        // An edit reaching well outside the dictation is the user writing.
+        guard oldChanged.lowerBound >= insertedRange.lowerBound - 1,
+              oldChanged.upperBound <= insertedRange.upperBound + 1 else {
+            return []
+        }
+
+        let oldWords = words(in: String(old[oldChanged]))
+        let newWords = words(in: String(new[newChanged]))
+        guard !oldWords.isEmpty, !newWords.isEmpty,
+              oldWords.count <= maximumEditedWords, newWords.count <= maximumEditedWords else {
+            return []
+        }
+
+        var found: [Correction] = []
+        for block in substitutions(from: oldWords, to: newWords)
+        where (1...3).contains(block.old.count) && (1...2).contains(block.new.count) {
+            let heard = block.old.joined(separator: " ")
+            let corrected = block.new.joined(separator: " ")
+            if isLikelyCorrection(heard: heard, corrected: corrected, isKnownWord: isKnownWord) {
+                found.append(Correction(heard: heard, corrected: corrected))
+            }
+        }
+        return Array(found.prefix(3))
+    }
+
+    /// Whether changing `heard` to `corrected` looks like fixing a
+    /// transcription (spelling, casing, joining) rather than rewording.
+    static func isLikelyCorrection(heard: String, corrected: String, isKnownWord: (String) -> Bool) -> Bool {
+        guard heard != corrected,
+              corrected.count <= 40,
+              corrected.contains(where: \.isLetter) else { return false }
+        let heardKey = DictionaryCorrector.normalized(heard)
+        let correctedKey = DictionaryCorrector.normalized(corrected)
+        guard correctedKey.count >= 2, !heardKey.isEmpty else { return false }
+
+        if heardKey == correctedKey {
+            // Same letters: a casing or joining fix. Capitalizing an ordinary
+            // word ("hello" → "Hello") is sentence case, not a new term.
+            let isPlainCapitalization = corrected == corrected.prefix(1).uppercased() + corrected.dropFirst().lowercased()
+                && !corrected.contains(" ")
+            if isPlainCapitalization, isKnownWord(corrected.lowercased()) { return false }
+            return true
+        }
+
+        // Swapping one ordinary word for another ("their" → "there") is a
+        // grammar fix the dictionary can't help with.
+        let correctedIsPlainLowercase = corrected == corrected.lowercased()
+        if correctedIsPlainLowercase, corrected.split(separator: " ").allSatisfy({ isKnownWord(String($0)) }) {
+            return false
+        }
+
+        guard DictionaryCorrector.firstSound(heardKey) == DictionaryCorrector.firstSound(correctedKey) else {
+            return false
+        }
+        let distance = DictionaryCorrector.levenshtein(heardKey, correctedKey)
+        let ratio = Double(distance) / Double(max(heardKey.count, correctedKey.count))
+        return ratio <= 0.4
+    }
+
+    // MARK: - Private
+
+    /// Where `needle` sits in `haystack`, preferring the copy ending nearest
+    /// the caret (the one just typed).
+    private static func locate(_ needle: [Character], in haystack: [Character], caretLocation: Int?) -> Range<Int>? {
+        guard needle.count <= haystack.count else { return nil }
+        var ranges: [Range<Int>] = []
+        var start = 0
+        while start + needle.count <= haystack.count {
+            if haystack[start] == needle[0], Array(haystack[start..<(start + needle.count)]) == needle {
+                ranges.append(start..<(start + needle.count))
+                start += needle.count
+            } else {
+                start += 1
+            }
+        }
+        guard let caretLocation else { return ranges.last }
+        return ranges.min { abs($0.upperBound - caretLocation) < abs($1.upperBound - caretLocation) }
+    }
+
+    private static func words(in text: String) -> [String] {
+        text.components(separatedBy: .whitespacesAndNewlines)
+            .map { $0.trimmingCharacters(in: CharacterSet.punctuationCharacters.subtracting(CharacterSet(charactersIn: "'’-_."))) }
+            .map { $0.trimmingCharacters(in: CharacterSet(charactersIn: ".")) }
+            .filter { !$0.isEmpty }
+    }
+
+    /// Runs of words that were replaced, from a longest-common-subsequence
+    /// alignment of the two word lists.
+    private static func substitutions(from old: [String], to new: [String]) -> [(old: [String], new: [String])] {
+        var table = [[Int]](repeating: [Int](repeating: 0, count: new.count + 1), count: old.count + 1)
+        for i in stride(from: old.count - 1, through: 0, by: -1) {
+            for j in stride(from: new.count - 1, through: 0, by: -1) {
+                table[i][j] = old[i] == new[j] ? table[i + 1][j + 1] + 1 : max(table[i + 1][j], table[i][j + 1])
+            }
+        }
+
+        var blocks: [(old: [String], new: [String])] = []
+        var pendingOld: [String] = []
+        var pendingNew: [String] = []
+        func flush() {
+            if !pendingOld.isEmpty && !pendingNew.isEmpty {
+                blocks.append((pendingOld, pendingNew))
+            }
+            pendingOld = []
+            pendingNew = []
+        }
+
+        var i = 0
+        var j = 0
+        while i < old.count || j < new.count {
+            if i < old.count, j < new.count, old[i] == new[j] {
+                flush()
+                i += 1
+                j += 1
+            } else if j < new.count, i == old.count || table[i][j + 1] >= table[i + 1][j] {
+                pendingNew.append(new[j])
+                j += 1
+            } else {
+                pendingOld.append(old[i])
+                i += 1
+            }
+        }
+        flush()
+        return blocks
+    }
+
+    private static func isWordCharacter(_ character: Character) -> Bool {
+        character.isLetter || character.isNumber || character == "_" || character == "'" || character == "’"
+    }
+}

--- a/Sources/VocaMac/Services/CorrectionObserver.swift
+++ b/Sources/VocaMac/Services/CorrectionObserver.swift
@@ -1,0 +1,115 @@
+// CorrectionObserver.swift
+// VocaMac
+//
+// Watches for the user fixing a word VocaMac just typed. It reads the field
+// once just after the dictation lands and once more when the user starts
+// the next dictation or 20 seconds pass, whichever comes first. Two one-shot
+// reads, never polling.
+
+import AppKit
+import Foundation
+
+@MainActor
+protocol CorrectionObserving: AnyObject {
+    /// Called on the main actor with any corrections found.
+    var onCorrections: (([CorrectionLearner.Correction]) -> Void)? { get set }
+    /// Start watching the field `text` was just typed into.
+    func observe(insertedText text: String, processID: pid_t, isKnownWord: @escaping (String) -> Bool)
+    /// Compare now instead of waiting for the timer.
+    func flush()
+    func cancel()
+}
+
+@MainActor
+final class CorrectionObserver: CorrectionObserving {
+
+    /// Time for the paste to land before the first read.
+    static let baselineDelay: TimeInterval = 0.8
+    /// Longest wait before comparing, when the user doesn't dictate again.
+    static let comparisonDelay: TimeInterval = 20
+
+    var onCorrections: (([CorrectionLearner.Correction]) -> Void)?
+
+    private struct Observation {
+        let id: UUID
+        let text: String
+        let processID: pid_t
+        let isKnownWord: (String) -> Bool
+        var baseline: FocusedTextSnapshot?
+    }
+
+    private var observation: Observation?
+    private var comparisonWork: DispatchWorkItem?
+
+    func observe(insertedText text: String, processID: pid_t, isKnownWord: @escaping (String) -> Bool) {
+        flush()
+        let id = UUID()
+        observation = Observation(id: id, text: text, processID: processID, isKnownWord: isKnownWord)
+
+        DispatchQueue.main.asyncAfter(deadline: .now() + Self.baselineDelay) { [weak self] in
+            self?.captureBaseline(for: id)
+        }
+        let work = DispatchWorkItem { [weak self] in self?.flush() }
+        comparisonWork = work
+        DispatchQueue.main.asyncAfter(deadline: .now() + Self.comparisonDelay, execute: work)
+    }
+
+    func flush() {
+        comparisonWork?.cancel()
+        comparisonWork = nil
+        guard let current = observation else { return }
+        observation = nil
+        guard let baseline = current.baseline else { return }
+
+        let inserted = current.text
+        let isKnownWord = current.isKnownWord
+        AccessibilityTextReader.queue.async { [weak self] in
+            guard let after = AccessibilityTextReader.value(of: baseline.element.element),
+                  after != baseline.value else { return }
+            let before = baseline.value
+            let caret = baseline.caretLocation.map { utf16Offset in
+                // Character offsets, to match how the learner indexes text.
+                let utf16 = before.utf16
+                let clamped = min(max(utf16Offset, 0), utf16.count)
+                let index = utf16.index(utf16.startIndex, offsetBy: clamped)
+                return before.distance(from: before.startIndex, to: index)
+            }
+            DispatchQueue.main.async {
+                let corrections = CorrectionLearner.corrections(
+                    inserted: inserted, before: before, after: after,
+                    caretLocation: caret, isKnownWord: isKnownWord
+                )
+                guard !corrections.isEmpty else { return }
+                VocaLogger.info(.dictionary, "Noticed \(corrections.count) correction(s) to dictated text")
+                self?.onCorrections?(corrections)
+            }
+        }
+    }
+
+    func cancel() {
+        comparisonWork?.cancel()
+        comparisonWork = nil
+        observation = nil
+    }
+
+    private func captureBaseline(for id: UUID) {
+        guard let current = observation, current.id == id else { return }
+        let processID = current.processID
+        let inserted = current.text.trimmingCharacters(in: .whitespacesAndNewlines)
+        AccessibilityTextReader.queue.async { [weak self] in
+            guard let element = AccessibilityTextReader.focusedTextElement(processID: processID),
+                  let value = AccessibilityTextReader.value(of: element),
+                  value.contains(inserted) else { return }
+            let snapshot = FocusedTextSnapshot(
+                element: AXElementBox(element: element),
+                processID: processID,
+                value: value,
+                caretLocation: AccessibilityTextReader.caretLocation(of: element)
+            )
+            DispatchQueue.main.async {
+                guard let self, self.observation?.id == id else { return }
+                self.observation?.baseline = snapshot
+            }
+        }
+    }
+}

--- a/Sources/VocaMac/Services/DictationHistoryStore.swift
+++ b/Sources/VocaMac/Services/DictationHistoryStore.swift
@@ -1,0 +1,375 @@
+// DictationHistoryStore.swift
+// VocaMac
+//
+// Persists dictation history under Application Support. The audio for a
+// dictation is written before it is transcribed, so a crash, a failed decode,
+// or an accidental cancel never loses what the user said.
+
+import Foundation
+import Combine
+
+@MainActor
+final class DictationHistoryStore: ObservableObject {
+
+    /// Oldest entries beyond this count are deleted, audio and all.
+    static let maximumEntries = 2_000
+
+    /// Total audio kept on disk. Beyond this the oldest recordings lose their
+    /// audio first; their text stays.
+    static let maximumAudioBytes: Int64 = 1 << 30
+
+    /// Newest first.
+    @Published private(set) var entries: [DictationHistoryEntry] = []
+
+    /// `nil` keeps history in memory only (tests, and runs that must not
+    /// touch the user's Application Support folder).
+    let directory: URL?
+
+    /// Serializes every file write, so an index write can never race another
+    /// and a retry's audio read always sees the finished WAV file.
+    private let ioQueue = DispatchQueue(label: "com.vocamac.history.io", qos: .utility)
+
+    static var defaultDirectory: URL? {
+        FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first?
+            .appendingPathComponent("VocaMac", isDirectory: true)
+            .appendingPathComponent("History", isDirectory: true)
+    }
+
+    init(directory: URL?) {
+        self.directory = directory
+        loadIndex()
+    }
+
+    // MARK: - Paths
+
+    private var indexURL: URL? {
+        directory?.appendingPathComponent("index.json")
+    }
+
+    var audioDirectory: URL? {
+        directory?.appendingPathComponent("audio", isDirectory: true)
+    }
+
+    func audioURL(for entry: DictationHistoryEntry) -> URL? {
+        guard let name = entry.audioFileName, let folder = audioDirectory else { return nil }
+        return folder.appendingPathComponent(name)
+    }
+
+    // MARK: - Queries
+
+    func entry(id: UUID) -> DictationHistoryEntry? {
+        entries.first { $0.id == id }
+    }
+
+    /// Text of the most recent dictation that produced something, exactly as
+    /// it was typed (trailing space included), for "paste last dictation".
+    var latestDeliveredText: String? {
+        guard let entry = entries.first(where: { $0.status == .completed && !$0.displayText.isEmpty }) else {
+            return nil
+        }
+        return entry.finalText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ? entry.rawText : entry.finalText
+    }
+
+    /// The newest dictation when it failed, was interrupted, or was
+    /// cancelled mid-transcription and its audio can still be retried. A later
+    /// successful dictation supersedes it, so an old failure doesn't nag.
+    var latestRecoverableEntry: DictationHistoryEntry? {
+        guard let newest = entries.first, newest.status.needsRecovery, newest.hasAudio else { return nil }
+        return newest
+    }
+
+    /// Entries whose text or app name contains every word of `query`.
+    func search(_ query: String) -> [DictationHistoryEntry] {
+        let words = query.lowercased()
+            .components(separatedBy: .whitespacesAndNewlines)
+            .filter { !$0.isEmpty }
+        guard !words.isEmpty else { return entries }
+        return entries.filter { entry in
+            let haystack = [entry.rawText, entry.finalText, entry.appName ?? ""]
+                .joined(separator: " ")
+                .lowercased()
+            return words.allSatisfy { haystack.contains($0) }
+        }
+    }
+
+    // MARK: - Recording a Dictation
+
+    /// Record a dictation before it is transcribed and write its audio.
+    /// Returns the id to finish it with.
+    @discardableResult
+    func begin(
+        audio: [Float]?,
+        target: RunningAppSnapshot?,
+        modelID: String,
+        language: String?,
+        audioSeconds: Double,
+        now: Date = Date()
+    ) -> UUID {
+        var entry = DictationHistoryEntry(
+            createdAt: now,
+            status: .pending,
+            appName: target?.displayName,
+            bundleIdentifier: target?.bundleIdentifier,
+            processName: target?.processName,
+            modelID: modelID,
+            language: language,
+            audioSeconds: audioSeconds
+        )
+        if let audio, !audio.isEmpty, let folder = audioDirectory {
+            let name = "\(entry.id.uuidString).wav"
+            entry.audioFileName = name
+            entry.audioBytes = Int64(44 + audio.count * 2)
+            let fileURL = folder.appendingPathComponent(name)
+            ioQueue.async {
+                do {
+                    try FileManager.default.createDirectory(at: folder, withIntermediateDirectories: true)
+                    try FailedAudioDump.wavData(from: audio, sampleRate: 16_000).write(to: fileURL, options: .atomic)
+                } catch {
+                    VocaLogger.error(.history, "Could not save dictation audio: \(error.localizedDescription)")
+                }
+            }
+        }
+        entries.insert(entry, at: 0)
+        enforceCaps()
+        persist()
+        return entry.id
+    }
+
+    /// Finish a dictation that produced a result (possibly empty).
+    func complete(
+        _ id: UUID,
+        rawText: String,
+        finalText: String,
+        summary: String?,
+        language: String?,
+        transcriptionSeconds: Double?,
+        keepAudio: Bool
+    ) {
+        update(id) { entry in
+            entry.rawText = rawText
+            entry.finalText = finalText
+            entry.summary = summary
+            if let language { entry.language = language }
+            entry.transcriptionSeconds = transcriptionSeconds
+            entry.errorMessage = nil
+            let hasText = !entry.displayText.isEmpty
+            entry.status = hasText ? .completed : .empty
+            if hasText && !keepAudio {
+                removeAudio(of: &entry)
+            }
+        }
+    }
+
+    func markFailed(_ id: UUID, message: String) {
+        update(id) { entry in
+            entry.status = .failed
+            entry.errorMessage = message
+        }
+    }
+
+    func markCancelled(_ id: UUID) {
+        update(id) { entry in
+            guard entry.status == .pending else { return }
+            entry.status = .cancelled
+        }
+    }
+
+    /// Store the result of retrying an entry's audio.
+    func recordRetry(
+        _ id: UUID,
+        rawText: String,
+        finalText: String,
+        summary: String?,
+        language: String?,
+        modelID: String,
+        transcriptionSeconds: Double?
+    ) {
+        update(id) { entry in
+            entry.rawText = rawText
+            entry.finalText = finalText
+            entry.summary = summary
+            if let language { entry.language = language }
+            entry.modelID = modelID
+            entry.transcriptionSeconds = transcriptionSeconds
+            entry.errorMessage = nil
+            entry.retryCount += 1
+            entry.status = entry.displayText.isEmpty ? .empty : .completed
+        }
+    }
+
+    // MARK: - Deleting
+
+    func delete(_ id: UUID) {
+        guard let index = entries.firstIndex(where: { $0.id == id }) else { return }
+        var entry = entries.remove(at: index)
+        removeAudio(of: &entry)
+        persist()
+    }
+
+    func deleteAll() {
+        entries = []
+        if let folder = audioDirectory {
+            ioQueue.async {
+                try? FileManager.default.removeItem(at: folder)
+            }
+        }
+        persist()
+    }
+
+    /// Drop the audio of every entry but keep the text.
+    func deleteAllAudio() {
+        for index in entries.indices {
+            removeAudio(of: &entries[index])
+        }
+        persist()
+    }
+
+    /// Delete entries older than the retention window.
+    func applyRetention(_ retention: HistoryRetention, now: Date = Date()) {
+        guard let maximumAge = retention.maximumAge else { return }
+        let cutoff = now.addingTimeInterval(-maximumAge)
+        let expired = entries.filter { $0.createdAt < cutoff }
+        guard !expired.isEmpty else { return }
+        for var entry in expired {
+            removeAudio(of: &entry)
+        }
+        entries.removeAll { $0.createdAt < cutoff }
+        VocaLogger.info(.history, "Removed \(expired.count) history entr\(expired.count == 1 ? "y" : "ies") past \(retention.displayName)")
+        persist()
+    }
+
+    // MARK: - Audio
+
+    /// Load an entry's audio as 16 kHz mono samples.
+    func loadAudio(for entry: DictationHistoryEntry) async throws -> [Float] {
+        guard let url = audioURL(for: entry) else {
+            throw HistoryError.audioUnavailable
+        }
+        return try await withCheckedThrowingContinuation { continuation in
+            // Queued behind any write still in flight for this entry.
+            ioQueue.async {
+                do {
+                    let loaded = try AudioFileLoader().loadAudio(at: url)
+                    continuation.resume(returning: loaded.samples)
+                } catch {
+                    continuation.resume(throwing: HistoryError.audioUnreadable)
+                }
+            }
+        }
+    }
+
+    /// Resolves once every write queued so far has finished. Tests use it to
+    /// read the files back; the app never needs to wait.
+    func waitForPendingWrites() async {
+        await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
+            ioQueue.async { continuation.resume() }
+        }
+    }
+
+    enum HistoryError: LocalizedError {
+        case audioUnavailable
+        case audioUnreadable
+
+        var errorDescription: String? {
+            switch self {
+            case .audioUnavailable: return "This dictation has no saved audio."
+            case .audioUnreadable: return "The saved audio for this dictation could not be read."
+            }
+        }
+    }
+
+    // MARK: - Private
+
+    private func update(_ id: UUID, _ change: (inout DictationHistoryEntry) -> Void) {
+        guard let index = entries.firstIndex(where: { $0.id == id }) else { return }
+        change(&entries[index])
+        persist()
+    }
+
+    private func removeAudio(of entry: inout DictationHistoryEntry) {
+        guard let url = audioURL(for: entry) else { return }
+        entry.audioFileName = nil
+        entry.audioBytes = nil
+        ioQueue.async {
+            try? FileManager.default.removeItem(at: url)
+        }
+    }
+
+    private func enforceCaps() {
+        if entries.count > Self.maximumEntries {
+            let overflow = entries[Self.maximumEntries...]
+            for var entry in overflow {
+                removeAudio(of: &entry)
+            }
+            entries.removeLast(entries.count - Self.maximumEntries)
+        }
+
+        var audioBytes = entries.reduce(Int64(0)) { $0 + ($1.audioBytes ?? 0) }
+        var index = entries.count - 1
+        // The newest entry is never stripped: it is the one most likely to
+        // need a retry, and one recording alone cannot exceed the cap.
+        while audioBytes > Self.maximumAudioBytes, index > 0 {
+            if let bytes = entries[index].audioBytes {
+                removeAudio(of: &entries[index])
+                audioBytes -= bytes
+            }
+            index -= 1
+        }
+    }
+
+    private func persist() {
+        guard let indexURL, let directory else { return }
+        // Entries are values, so the snapshot is encoded off the main thread.
+        let snapshot = entries
+        ioQueue.async {
+            do {
+                try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+                let encoder = JSONEncoder()
+                encoder.dateEncodingStrategy = .iso8601
+                try encoder.encode(snapshot).write(to: indexURL, options: .atomic)
+            } catch {
+                VocaLogger.error(.history, "Could not save dictation history: \(error.localizedDescription)")
+            }
+        }
+    }
+
+    private func loadIndex() {
+        guard let indexURL, FileManager.default.fileExists(atPath: indexURL.path) else { return }
+        do {
+            let decoder = JSONDecoder()
+            decoder.dateDecodingStrategy = .iso8601
+            var loaded = try decoder.decode([DictationHistoryEntry].self, from: Data(contentsOf: indexURL))
+            var recovered = 0
+            for index in loaded.indices where loaded[index].status == .pending {
+                loaded[index].status = .interrupted
+                recovered += 1
+            }
+            entries = loaded
+            if recovered > 0 {
+                VocaLogger.warning(.history, "\(recovered) dictation(s) were interrupted before they finished; their audio is kept for retry")
+                persist()
+            }
+            removeOrphanedAudio()
+        } catch {
+            // Keep the unreadable file aside rather than overwrite it on the
+            // next save, so nothing is lost to a decoding bug.
+            let backup = indexURL.deletingPathExtension().appendingPathExtension("corrupt.json")
+            try? FileManager.default.removeItem(at: backup)
+            try? FileManager.default.moveItem(at: indexURL, to: backup)
+            VocaLogger.error(.history, "Dictation history was unreadable and was set aside: \(error.localizedDescription)")
+        }
+    }
+
+    /// Delete audio files no entry points at (a crash between writing the
+    /// audio and writing the index).
+    private func removeOrphanedAudio() {
+        guard let folder = audioDirectory else { return }
+        let referenced = Set(entries.compactMap(\.audioFileName))
+        ioQueue.async {
+            guard let files = try? FileManager.default.contentsOfDirectory(atPath: folder.path) else { return }
+            for file in files where !referenced.contains(file) {
+                try? FileManager.default.removeItem(at: folder.appendingPathComponent(file))
+            }
+        }
+    }
+}

--- a/Sources/VocaMac/Services/DictationHistoryStore.swift
+++ b/Sources/VocaMac/Services/DictationHistoryStore.swift
@@ -21,6 +21,12 @@ final class DictationHistoryStore: ObservableObject {
     /// Newest first.
     @Published private(set) var entries: [DictationHistoryEntry] = []
 
+    /// True when a change is in memory but the disk refused both the journal
+    /// and the index. Every later save rewrites the whole index until one
+    /// succeeds (quitting tries once more), so the change is kept as soon as
+    /// the disk accepts writes again.
+    @Published private(set) var hasUnsavedChanges = false
+
     /// `nil` keeps history in memory only (tests, and runs that must not
     /// touch the user's Application Support folder).
     let directory: URL?
@@ -112,6 +118,10 @@ final class DictationHistoryStore: ObservableObject {
     /// a deletion — launch removes it and never brings deleted audio back. If
     /// VocaMac dies before the write finishes, or the write fails, the entry
     /// ends up without audio instead of pointing at a file that isn't there.
+    ///
+    /// If the entry itself can't be saved, no audio is written (launch would
+    /// delete a file no saved entry owns) and the returned id matches no
+    /// entry: the dictation carries on without history.
     @discardableResult
     func begin(
         audio: [Float]?,
@@ -142,7 +152,11 @@ final class DictationHistoryStore: ObservableObject {
             pendingAudio = nil
         }
         entries.insert(entry, at: 0)
-        appendToJournal(JournalRecord(upsert: entry))
+        guard appendToJournal(JournalRecord(upsert: entry)) else {
+            entries.removeAll { $0.id == id }
+            VocaLogger.error(.history, "Couldn't save a history entry; this dictation won't be kept")
+            return id
+        }
 
         if let pendingAudio {
             let fileURL = pendingAudio.folder.appendingPathComponent(pendingAudio.name)
@@ -293,7 +307,7 @@ final class DictationHistoryStore: ObservableObject {
         guard !expired.isEmpty else { return }
         for var entry in expired {
             removeAudio(of: &entry)
-            appendToJournal(JournalRecord(delete: entry.id))
+            save(JournalRecord(delete: entry.id))
         }
         entries.removeAll { $0.createdAt < cutoff }
         VocaLogger.info(.history, "Removed \(expired.count) history entr\(expired.count == 1 ? "y" : "ies") past \(retention.displayName)")
@@ -344,7 +358,21 @@ final class DictationHistoryStore: ObservableObject {
     private func update(_ id: UUID, _ change: (inout DictationHistoryEntry) -> Void) {
         guard let index = entries.firstIndex(where: { $0.id == id }) else { return }
         change(&entries[index])
-        appendToJournal(JournalRecord(upsert: entries[index]))
+        save(JournalRecord(upsert: entries[index]))
+    }
+
+    /// Save a change that stays in memory even if the disk refuses it, such
+    /// as a dictation finishing. A refusal is retried by the next save.
+    private func save(_ record: JournalRecord) {
+        if !appendToJournal(record) {
+            hasUnsavedChanges = true
+        }
+    }
+
+    /// Retry a save the disk refused earlier. Called when VocaMac quits.
+    func saveIfNeeded() {
+        guard hasUnsavedChanges else { return }
+        compact()
     }
 
     /// Recordings to delete once the change that drops them is on disk.
@@ -378,7 +406,7 @@ final class DictationHistoryStore: ObservableObject {
             let overflow = entries[Self.maximumEntries...]
             for var entry in overflow {
                 removeAudio(of: &entry)
-                appendToJournal(JournalRecord(delete: entry.id))
+                save(JournalRecord(delete: entry.id))
             }
             entries.removeLast(entries.count - Self.maximumEntries)
         }
@@ -390,7 +418,7 @@ final class DictationHistoryStore: ObservableObject {
         while audioBytes > Self.maximumAudioBytes, index > 0 {
             if let bytes = entries[index].audioBytes {
                 removeAudio(of: &entries[index])
-                appendToJournal(JournalRecord(upsert: entries[index]))
+                save(JournalRecord(upsert: entries[index]))
                 audioBytes -= bytes
             }
             index -= 1
@@ -438,6 +466,10 @@ final class DictationHistoryStore: ObservableObject {
     @discardableResult
     private func appendToJournal(_ record: JournalRecord) -> Bool {
         guard let directory, let journalURL else { return true }
+        // An earlier change never reached disk; only a full rewrite covers it.
+        if hasUnsavedChanges {
+            return compact()
+        }
         do {
             var line = try Self.encoder.encode(record)
             line.append(0x0A)
@@ -475,6 +507,7 @@ final class DictationHistoryStore: ObservableObject {
                 try? FileManager.default.removeItem(at: journalURL)
             }
             journalLineCount = 0
+            hasUnsavedChanges = false
             flushAudioRemovals()
             return true
         } catch {
@@ -549,8 +582,8 @@ final class DictationHistoryStore: ObservableObject {
         if interrupted > 0 {
             VocaLogger.warning(.history, "\(interrupted) dictation(s) didn't finish; their audio is kept for retry")
         }
-        if changed {
-            compact()
+        if changed, !compact() {
+            hasUnsavedChanges = true
         }
     }
 

--- a/Sources/VocaMac/Services/DictationHistoryStore.swift
+++ b/Sources/VocaMac/Services/DictationHistoryStore.swift
@@ -25,8 +25,9 @@ final class DictationHistoryStore: ObservableObject {
     /// touch the user's Application Support folder).
     let directory: URL?
 
-    /// Serializes every file write, so an index write can never race another
-    /// and a retry's audio read always sees the finished WAV file.
+    /// Serializes audio file writes, reads, and deletions, so a retry's read
+    /// always sees the finished WAV file. The index and journal are written
+    /// synchronously on the main actor.
     private let ioQueue = DispatchQueue(label: "com.vocamac.history.io", qos: .utility)
 
     private static let sampleRate = 16_000
@@ -150,8 +151,8 @@ final class DictationHistoryStore: ObservableObject {
             }
         }
         entries.insert(entry, at: 0)
+        appendToJournal(JournalRecord(upsert: entry))
         enforceCaps()
-        persist()
         return entry.id
     }
 
@@ -223,17 +224,17 @@ final class DictationHistoryStore: ObservableObject {
         guard let index = entries.firstIndex(where: { $0.id == id }) else { return }
         var entry = entries.remove(at: index)
         removeAudio(of: &entry)
-        persist()
+        appendToJournal(JournalRecord(delete: id))
     }
 
     func deleteAll() {
         entries = []
+        compact()
         if let folder = audioDirectory {
             ioQueue.async {
                 try? FileManager.default.removeItem(at: folder)
             }
         }
-        persist()
     }
 
     /// Drop the audio of every entry but keep the text.
@@ -241,7 +242,7 @@ final class DictationHistoryStore: ObservableObject {
         for index in entries.indices {
             removeAudio(of: &entries[index])
         }
-        persist()
+        compact()
     }
 
     /// Delete entries older than the retention window.
@@ -252,10 +253,10 @@ final class DictationHistoryStore: ObservableObject {
         guard !expired.isEmpty else { return }
         for var entry in expired {
             removeAudio(of: &entry)
+            appendToJournal(JournalRecord(delete: entry.id))
         }
         entries.removeAll { $0.createdAt < cutoff }
         VocaLogger.info(.history, "Removed \(expired.count) history entr\(expired.count == 1 ? "y" : "ies") past \(retention.displayName)")
-        persist()
     }
 
     // MARK: - Audio
@@ -278,8 +279,8 @@ final class DictationHistoryStore: ObservableObject {
         }
     }
 
-    /// Resolves once every write queued so far has finished. Tests use it to
-    /// read the files back; the app never needs to wait.
+    /// Resolves once every audio file operation queued so far has finished.
+    /// Tests use it to read the files back; the app never needs to wait.
     func waitForPendingWrites() async {
         await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
             ioQueue.async { continuation.resume() }
@@ -303,7 +304,7 @@ final class DictationHistoryStore: ObservableObject {
     private func update(_ id: UUID, _ change: (inout DictationHistoryEntry) -> Void) {
         guard let index = entries.firstIndex(where: { $0.id == id }) else { return }
         change(&entries[index])
-        persist()
+        appendToJournal(JournalRecord(upsert: entries[index]))
     }
 
     private func removeAudio(of entry: inout DictationHistoryEntry) {
@@ -320,6 +321,7 @@ final class DictationHistoryStore: ObservableObject {
             let overflow = entries[Self.maximumEntries...]
             for var entry in overflow {
                 removeAudio(of: &entry)
+                appendToJournal(JournalRecord(delete: entry.id))
             }
             entries.removeLast(entries.count - Self.maximumEntries)
         }
@@ -331,35 +333,113 @@ final class DictationHistoryStore: ObservableObject {
         while audioBytes > Self.maximumAudioBytes, index > 0 {
             if let bytes = entries[index].audioBytes {
                 removeAudio(of: &entries[index])
+                appendToJournal(JournalRecord(upsert: entries[index]))
                 audioBytes -= bytes
             }
             index -= 1
         }
     }
 
-    private func persist() {
-        guard let indexURL, let directory else { return }
-        // Entries are values, so the snapshot is encoded off the main thread.
-        let snapshot = entries
-        ioQueue.async {
-            do {
+    // MARK: - Index and Journal
+    //
+    // Every change is appended to `journal.jsonl` synchronously as one small
+    // line, so it is on disk before VocaMac moves on and survives a crash or
+    // force quit. The full `index.json` is rewritten only now and then — at
+    // launch, after bulk changes, and once the journal grows — and the
+    // journal is replayed over it on the next launch.
+
+    /// One journal line: an entry's latest state, or its deletion.
+    private struct JournalRecord: Codable {
+        var upsert: DictationHistoryEntry?
+        var delete: UUID?
+    }
+
+    /// Journal lines before the index is rewritten and the journal cleared.
+    static let compactionThreshold = 500
+
+    private var journalURL: URL? {
+        directory?.appendingPathComponent("journal.jsonl")
+    }
+
+    private var journalLineCount = 0
+
+    private static let encoder: JSONEncoder = {
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        return encoder
+    }()
+
+    private static let decoder: JSONDecoder = {
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        return decoder
+    }()
+
+    private func appendToJournal(_ record: JournalRecord) {
+        guard let directory, let journalURL else { return }
+        do {
+            var line = try Self.encoder.encode(record)
+            line.append(0x0A)
+            if !FileManager.default.fileExists(atPath: journalURL.path) {
                 try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
-                let encoder = JSONEncoder()
-                encoder.dateEncodingStrategy = .iso8601
-                try encoder.encode(snapshot).write(to: indexURL, options: .atomic)
-            } catch {
-                VocaLogger.error(.history, "Could not save dictation history: \(error.localizedDescription)")
+                FileManager.default.createFile(atPath: journalURL.path, contents: nil)
+            }
+            let handle = try FileHandle(forWritingTo: journalURL)
+            defer { try? handle.close() }
+            try handle.seekToEnd()
+            try handle.write(contentsOf: line)
+            journalLineCount += 1
+            if journalLineCount >= Self.compactionThreshold {
+                compact()
+            }
+        } catch {
+            VocaLogger.error(.history, "Could not append to the history journal: \(error.localizedDescription)")
+            compact()
+        }
+    }
+
+    /// Write the whole history to `index.json`, then clear the journal. The
+    /// journal is only removed after the index is safely replaced, so a
+    /// failure here loses nothing.
+    private func compact() {
+        guard let directory, let indexURL else { return }
+        do {
+            try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+            try Self.encoder.encode(entries).write(to: indexURL, options: .atomic)
+            if let journalURL {
+                try? FileManager.default.removeItem(at: journalURL)
+            }
+            journalLineCount = 0
+        } catch {
+            VocaLogger.error(.history, "Could not save dictation history: \(error.localizedDescription)")
+        }
+    }
+
+    /// Apply journal lines over the loaded index. A torn last line (VocaMac
+    /// died mid-write) is skipped.
+    private func replayJournal(onto entries: inout [DictationHistoryEntry]) -> Bool {
+        guard let journalURL, let data = try? Data(contentsOf: journalURL), !data.isEmpty else { return false }
+        var byID = Dictionary(entries.map { ($0.id, $0) }, uniquingKeysWith: { _, latest in latest })
+        for line in data.split(separator: 0x0A) where !line.isEmpty {
+            guard let record = try? Self.decoder.decode(JournalRecord.self, from: Data(line)) else {
+                VocaLogger.warning(.history, "Skipped an unreadable history journal line")
+                continue
+            }
+            if let entry = record.upsert {
+                byID[entry.id] = entry
+            } else if let id = record.delete {
+                byID[id] = nil
             }
         }
+        entries = byID.values.sorted { $0.createdAt > $1.createdAt }
+        return true
     }
 
     private func loadIndex() {
         var loaded: [DictationHistoryEntry] = []
         if let indexURL, FileManager.default.fileExists(atPath: indexURL.path) {
             do {
-                let decoder = JSONDecoder()
-                decoder.dateDecodingStrategy = .iso8601
-                loaded = try decoder.decode([DictationHistoryEntry].self, from: Data(contentsOf: indexURL))
+                loaded = try Self.decoder.decode([DictationHistoryEntry].self, from: Data(contentsOf: indexURL))
             } catch {
                 // Keep the unreadable file aside rather than overwrite it on the
                 // next save. Its recordings are recovered below.
@@ -370,7 +450,7 @@ final class DictationHistoryStore: ObservableObject {
             }
         }
 
-        var changed = false
+        var changed = replayJournal(onto: &loaded)
         for index in loaded.indices {
             if loaded[index].status == .pending {
                 loaded[index].status = .interrupted
@@ -400,7 +480,7 @@ final class DictationHistoryStore: ObservableObject {
             VocaLogger.warning(.history, "\(interrupted) dictation(s) didn't finish; their audio is kept for retry")
         }
         if changed {
-            persist()
+            compact()
         }
     }
 

--- a/Sources/VocaMac/Services/DictationHistoryStore.swift
+++ b/Sources/VocaMac/Services/DictationHistoryStore.swift
@@ -234,30 +234,55 @@ final class DictationHistoryStore: ObservableObject {
 
     // MARK: - Deleting
 
-    func delete(_ id: UUID) {
-        guard let index = entries.firstIndex(where: { $0.id == id }) else { return }
+    // Deletions the user asks for are all-or-nothing: if the change can't be
+    // saved, the history is put back as it was and nothing is removed from
+    // disk, so what's on screen always matches what the next launch loads.
+    // Each returns whether the deletion was saved.
+
+    @discardableResult
+    func delete(_ id: UUID) -> Bool {
+        guard let index = entries.firstIndex(where: { $0.id == id }) else { return true }
+        let previous = entries
         var entry = entries.remove(at: index)
         removeAudio(of: &entry)
         // Saves the deletion, then deletes the recording.
-        appendToJournal(JournalRecord(delete: id))
+        guard appendToJournal(JournalRecord(delete: id)) else {
+            entries = previous
+            return false
+        }
+        return true
     }
 
-    func deleteAll() {
+    @discardableResult
+    func deleteAll() -> Bool {
+        let previous = entries
         entries = []
         pendingAudioRemovals = []
-        // Only wipe the recordings once the empty history is saved.
-        guard compact(), let folder = audioDirectory else { return }
-        ioQueue.async {
-            try? FileManager.default.removeItem(at: folder)
+        guard compact() else {
+            entries = previous
+            return false
         }
+        // Only wipe the recordings once the empty history is saved.
+        if let folder = audioDirectory {
+            ioQueue.async {
+                try? FileManager.default.removeItem(at: folder)
+            }
+        }
+        return true
     }
 
     /// Drop the audio of every entry but keep the text.
-    func deleteAllAudio() {
+    @discardableResult
+    func deleteAllAudio() -> Bool {
+        let previous = entries
         for index in entries.indices {
             removeAudio(of: &entries[index])
         }
-        compact()
+        guard compact() else {
+            entries = previous
+            return false
+        }
+        return true
     }
 
     /// Delete entries older than the retention window.
@@ -407,8 +432,12 @@ final class DictationHistoryStore: ObservableObject {
         return decoder
     }()
 
-    private func appendToJournal(_ record: JournalRecord) {
-        guard let directory, let journalURL else { return }
+    /// Save one change: append it to the journal, or failing that rewrite
+    /// the whole index. Returns false if neither worked, in which case any
+    /// recordings the change would have deleted are left on disk.
+    @discardableResult
+    private func appendToJournal(_ record: JournalRecord) -> Bool {
+        guard let directory, let journalURL else { return true }
         do {
             var line = try Self.encoder.encode(record)
             line.append(0x0A)
@@ -425,9 +454,10 @@ final class DictationHistoryStore: ObservableObject {
             if journalLineCount >= Self.compactionThreshold {
                 compact()
             }
+            return true
         } catch {
             VocaLogger.error(.history, "Could not append to the history journal: \(error.localizedDescription)")
-            compact()
+            return compact()
         }
     }
 
@@ -436,7 +466,8 @@ final class DictationHistoryStore: ObservableObject {
     /// failure here loses nothing.
     @discardableResult
     private func compact() -> Bool {
-        guard let directory, let indexURL else { return false }
+        // In-memory history has nothing to save.
+        guard let directory, let indexURL else { return true }
         do {
             try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
             try Self.encoder.encode(entries).write(to: indexURL, options: .atomic)
@@ -448,6 +479,9 @@ final class DictationHistoryStore: ObservableObject {
             return true
         } catch {
             VocaLogger.error(.history, "Could not save dictation history: \(error.localizedDescription)")
+            // The change these removals belong to wasn't saved; a later save
+            // for something else must not delete them.
+            pendingAudioRemovals = []
             return false
         }
     }

--- a/Sources/VocaMac/Services/DictationHistoryStore.swift
+++ b/Sources/VocaMac/Services/DictationHistoryStore.swift
@@ -238,16 +238,17 @@ final class DictationHistoryStore: ObservableObject {
         guard let index = entries.firstIndex(where: { $0.id == id }) else { return }
         var entry = entries.remove(at: index)
         removeAudio(of: &entry)
+        // Saves the deletion, then deletes the recording.
         appendToJournal(JournalRecord(delete: id))
     }
 
     func deleteAll() {
         entries = []
-        compact()
-        if let folder = audioDirectory {
-            ioQueue.async {
-                try? FileManager.default.removeItem(at: folder)
-            }
+        pendingAudioRemovals = []
+        // Only wipe the recordings once the empty history is saved.
+        guard compact(), let folder = audioDirectory else { return }
+        ioQueue.async {
+            try? FileManager.default.removeItem(at: folder)
         }
     }
 
@@ -321,12 +322,29 @@ final class DictationHistoryStore: ObservableObject {
         appendToJournal(JournalRecord(upsert: entries[index]))
     }
 
+    /// Recordings to delete once the change that drops them is on disk.
+    private var pendingAudioRemovals: [URL] = []
+
+    /// Drop an entry's audio. The file itself is only deleted after the
+    /// journal or index write that records this change has succeeded (see
+    /// `flushAudioRemovals`), so an exit in between can never leave an entry
+    /// on disk whose audio is already gone.
     private func removeAudio(of entry: inout DictationHistoryEntry) {
         guard let url = audioURL(for: entry) else { return }
         entry.audioFileName = nil
         entry.audioBytes = nil
+        pendingAudioRemovals.append(url)
+    }
+
+    /// Delete recordings whose removal is now saved.
+    private func flushAudioRemovals() {
+        guard !pendingAudioRemovals.isEmpty else { return }
+        let urls = pendingAudioRemovals
+        pendingAudioRemovals = []
         ioQueue.async {
-            try? FileManager.default.removeItem(at: url)
+            for url in urls {
+                try? FileManager.default.removeItem(at: url)
+            }
         }
     }
 
@@ -403,6 +421,7 @@ final class DictationHistoryStore: ObservableObject {
             try handle.seekToEnd()
             try handle.write(contentsOf: line)
             journalLineCount += 1
+            flushAudioRemovals()
             if journalLineCount >= Self.compactionThreshold {
                 compact()
             }
@@ -415,8 +434,9 @@ final class DictationHistoryStore: ObservableObject {
     /// Write the whole history to `index.json`, then clear the journal. The
     /// journal is only removed after the index is safely replaced, so a
     /// failure here loses nothing.
-    private func compact() {
-        guard let directory, let indexURL else { return }
+    @discardableResult
+    private func compact() -> Bool {
+        guard let directory, let indexURL else { return false }
         do {
             try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
             try Self.encoder.encode(entries).write(to: indexURL, options: .atomic)
@@ -424,8 +444,11 @@ final class DictationHistoryStore: ObservableObject {
                 try? FileManager.default.removeItem(at: journalURL)
             }
             journalLineCount = 0
+            flushAudioRemovals()
+            return true
         } catch {
             VocaLogger.error(.history, "Could not save dictation history: \(error.localizedDescription)")
+            return false
         }
     }
 

--- a/Sources/VocaMac/Services/DictationHistoryStore.swift
+++ b/Sources/VocaMac/Services/DictationHistoryStore.swift
@@ -29,6 +29,13 @@ final class DictationHistoryStore: ObservableObject {
     /// and a retry's audio read always sees the finished WAV file.
     private let ioQueue = DispatchQueue(label: "com.vocamac.history.io", qos: .utility)
 
+    private static let sampleRate = 16_000
+
+    /// Size of a 16-bit mono WAV file with a 44-byte header.
+    static func wavByteCount(sampleCount: Int) -> Int64 {
+        Int64(44 + sampleCount * 2)
+    }
+
     static var defaultDirectory: URL? {
         FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first?
             .appendingPathComponent("VocaMac", isDirectory: true)
@@ -94,8 +101,14 @@ final class DictationHistoryStore: ObservableObject {
 
     // MARK: - Recording a Dictation
 
-    /// Record a dictation before it is transcribed and write its audio.
-    /// Returns the id to finish it with.
+    /// Record a dictation before it is transcribed. Returns once its audio
+    /// is on disk, so a crash or failure during transcription can't lose it,
+    /// with the id to finish it with.
+    ///
+    /// The WAV file is written before the index. If VocaMac dies between the
+    /// two, the next launch finds the unindexed file and restores it as an
+    /// interrupted dictation. If the write fails, the entry is recorded
+    /// without audio rather than pointing at a file that doesn't exist.
     @discardableResult
     func begin(
         audio: [Float]?,
@@ -104,7 +117,7 @@ final class DictationHistoryStore: ObservableObject {
         language: String?,
         audioSeconds: Double,
         now: Date = Date()
-    ) -> UUID {
+    ) async -> UUID {
         var entry = DictationHistoryEntry(
             createdAt: now,
             status: .pending,
@@ -117,16 +130,23 @@ final class DictationHistoryStore: ObservableObject {
         )
         if let audio, !audio.isEmpty, let folder = audioDirectory {
             let name = "\(entry.id.uuidString).wav"
-            entry.audioFileName = name
-            entry.audioBytes = Int64(44 + audio.count * 2)
             let fileURL = folder.appendingPathComponent(name)
-            ioQueue.async {
-                do {
-                    try FileManager.default.createDirectory(at: folder, withIntermediateDirectories: true)
-                    try FailedAudioDump.wavData(from: audio, sampleRate: 16_000).write(to: fileURL, options: .atomic)
-                } catch {
-                    VocaLogger.error(.history, "Could not save dictation audio: \(error.localizedDescription)")
+            let saved = await withCheckedContinuation { (continuation: CheckedContinuation<Bool, Never>) in
+                ioQueue.async {
+                    do {
+                        try FileManager.default.createDirectory(at: folder, withIntermediateDirectories: true)
+                        try FailedAudioDump.wavData(from: audio, sampleRate: Self.sampleRate)
+                            .write(to: fileURL, options: .atomic)
+                        continuation.resume(returning: true)
+                    } catch {
+                        VocaLogger.error(.history, "Could not save dictation audio: \(error.localizedDescription)")
+                        continuation.resume(returning: false)
+                    }
                 }
+            }
+            if saved {
+                entry.audioFileName = name
+                entry.audioBytes = Self.wavByteCount(sampleCount: audio.count)
             }
         }
         entries.insert(entry, at: 0)
@@ -334,42 +354,89 @@ final class DictationHistoryStore: ObservableObject {
     }
 
     private func loadIndex() {
-        guard let indexURL, FileManager.default.fileExists(atPath: indexURL.path) else { return }
-        do {
-            let decoder = JSONDecoder()
-            decoder.dateDecodingStrategy = .iso8601
-            var loaded = try decoder.decode([DictationHistoryEntry].self, from: Data(contentsOf: indexURL))
-            var recovered = 0
-            for index in loaded.indices where loaded[index].status == .pending {
+        var loaded: [DictationHistoryEntry] = []
+        if let indexURL, FileManager.default.fileExists(atPath: indexURL.path) {
+            do {
+                let decoder = JSONDecoder()
+                decoder.dateDecodingStrategy = .iso8601
+                loaded = try decoder.decode([DictationHistoryEntry].self, from: Data(contentsOf: indexURL))
+            } catch {
+                // Keep the unreadable file aside rather than overwrite it on the
+                // next save. Its recordings are recovered below.
+                let backup = indexURL.deletingPathExtension().appendingPathExtension("corrupt.json")
+                try? FileManager.default.removeItem(at: backup)
+                try? FileManager.default.moveItem(at: indexURL, to: backup)
+                VocaLogger.error(.history, "Dictation history was unreadable and was set aside: \(error.localizedDescription)")
+            }
+        }
+
+        var changed = false
+        for index in loaded.indices {
+            if loaded[index].status == .pending {
                 loaded[index].status = .interrupted
-                recovered += 1
+                changed = true
             }
-            entries = loaded
-            if recovered > 0 {
-                VocaLogger.warning(.history, "\(recovered) dictation(s) were interrupted before they finished; their audio is kept for retry")
-                persist()
+            // Never advertise audio that isn't there.
+            if let name = loaded[index].audioFileName, let folder = audioDirectory,
+               !FileManager.default.fileExists(atPath: folder.appendingPathComponent(name).path) {
+                loaded[index].audioFileName = nil
+                loaded[index].audioBytes = nil
+                changed = true
             }
-            removeOrphanedAudio()
-        } catch {
-            // Keep the unreadable file aside rather than overwrite it on the
-            // next save, so nothing is lost to a decoding bug.
-            let backup = indexURL.deletingPathExtension().appendingPathExtension("corrupt.json")
-            try? FileManager.default.removeItem(at: backup)
-            try? FileManager.default.moveItem(at: indexURL, to: backup)
-            VocaLogger.error(.history, "Dictation history was unreadable and was set aside: \(error.localizedDescription)")
+        }
+
+        let recovered = recoverUnindexedAudio(
+            referenced: Set(loaded.compactMap(\.audioFileName)),
+            knownIDs: Set(loaded.map(\.id))
+        )
+        if !recovered.isEmpty {
+            loaded = (loaded + recovered).sorted { $0.createdAt > $1.createdAt }
+            changed = true
+        }
+
+        entries = loaded
+        let interrupted = loaded.filter { $0.status == .interrupted }.count
+        if interrupted > 0 {
+            VocaLogger.warning(.history, "\(interrupted) dictation(s) didn't finish; their audio is kept for retry")
+        }
+        if changed {
+            persist()
         }
     }
 
-    /// Delete audio files no entry points at (a crash between writing the
-    /// audio and writing the index).
-    private func removeOrphanedAudio() {
-        guard let folder = audioDirectory else { return }
-        let referenced = Set(entries.compactMap(\.audioFileName))
-        ioQueue.async {
-            guard let files = try? FileManager.default.contentsOfDirectory(atPath: folder.path) else { return }
-            for file in files where !referenced.contains(file) {
-                try? FileManager.default.removeItem(at: folder.appendingPathComponent(file))
+    /// Recordings on disk that the index doesn't list: VocaMac stopped
+    /// between writing the audio and writing the index. Each becomes an
+    /// interrupted dictation so it can still be retried.
+    private func recoverUnindexedAudio(referenced: Set<String>, knownIDs: Set<UUID>) -> [DictationHistoryEntry] {
+        guard let folder = audioDirectory,
+              let files = try? FileManager.default.contentsOfDirectory(atPath: folder.path) else { return [] }
+        var recovered: [DictationHistoryEntry] = []
+        for file in files where file.hasSuffix(".wav") && !referenced.contains(file) {
+            let url = folder.appendingPathComponent(file)
+            let attributes = try? FileManager.default.attributesOfItem(atPath: url.path)
+            let bytes = (attributes?[.size] as? NSNumber)?.int64Value ?? 0
+            guard bytes > 44 else {
+                try? FileManager.default.removeItem(at: url)
+                continue
             }
+            let id = UUID(uuidString: String(file.dropLast(4))) ?? UUID()
+            // Audio of an entry that already has its text: a leftover the
+            // user chose not to keep, not a lost dictation.
+            guard !knownIDs.contains(id) else {
+                try? FileManager.default.removeItem(at: url)
+                continue
+            }
+            let samples = Double(bytes - 44) / 2
+            recovered.append(DictationHistoryEntry(
+                id: id,
+                createdAt: (attributes?[.creationDate] as? Date) ?? Date(),
+                status: .interrupted,
+                modelID: "",
+                audioSeconds: samples / Double(Self.sampleRate),
+                audioFileName: file,
+                audioBytes: bytes
+            ))
         }
+        return recovered
     }
 }

--- a/Sources/VocaMac/Services/DictationHistoryStore.swift
+++ b/Sources/VocaMac/Services/DictationHistoryStore.swift
@@ -305,11 +305,13 @@ final class DictationHistoryStore: ObservableObject {
         let cutoff = now.addingTimeInterval(-maximumAge)
         let expired = entries.filter { $0.createdAt < cutoff }
         guard !expired.isEmpty else { return }
+        // Out of memory first, so a fallback full rewrite during the saves
+        // below can't write expired entries back.
+        entries.removeAll { $0.createdAt < cutoff }
         for var entry in expired {
             removeAudio(of: &entry)
             save(JournalRecord(delete: entry.id))
         }
-        entries.removeAll { $0.createdAt < cutoff }
         VocaLogger.info(.history, "Removed \(expired.count) history entr\(expired.count == 1 ? "y" : "ies") past \(retention.displayName)")
     }
 
@@ -403,12 +405,13 @@ final class DictationHistoryStore: ObservableObject {
 
     private func enforceCaps() {
         if entries.count > Self.maximumEntries {
-            let overflow = entries[Self.maximumEntries...]
+            let overflow = Array(entries[Self.maximumEntries...])
+            // Out of memory first, as in `applyRetention`.
+            entries.removeLast(entries.count - Self.maximumEntries)
             for var entry in overflow {
                 removeAudio(of: &entry)
                 save(JournalRecord(delete: entry.id))
             }
-            entries.removeLast(entries.count - Self.maximumEntries)
         }
 
         var audioBytes = entries.reduce(Int64(0)) { $0 + ($1.audioBytes ?? 0) }

--- a/Sources/VocaMac/Services/DictationHistoryStore.swift
+++ b/Sources/VocaMac/Services/DictationHistoryStore.swift
@@ -106,10 +106,12 @@ final class DictationHistoryStore: ObservableObject {
     /// is on disk, so a crash or failure during transcription can't lose it,
     /// with the id to finish it with.
     ///
-    /// The WAV file is written before the index. If VocaMac dies between the
-    /// two, the next launch finds the unindexed file and restores it as an
-    /// interrupted dictation. If the write fails, the entry is recorded
-    /// without audio rather than pointing at a file that doesn't exist.
+    /// The entry is journaled, naming its WAV file, *before* the file is
+    /// written. So every recording on disk belongs to an entry the journal
+    /// knows about, and a file nothing refers to can only be left over from
+    /// a deletion — launch removes it and never brings deleted audio back. If
+    /// VocaMac dies before the write finishes, or the write fails, the entry
+    /// ends up without audio instead of pointing at a file that isn't there.
     @discardableResult
     func begin(
         audio: [Float]?,
@@ -129,14 +131,26 @@ final class DictationHistoryStore: ObservableObject {
             language: language,
             audioSeconds: audioSeconds
         )
+        let id = entry.id
+        let pendingAudio: (samples: [Float], folder: URL, name: String)?
         if let audio, !audio.isEmpty, let folder = audioDirectory {
-            let name = "\(entry.id.uuidString).wav"
-            let fileURL = folder.appendingPathComponent(name)
+            let name = "\(id.uuidString).wav"
+            entry.audioFileName = name
+            entry.audioBytes = Self.wavByteCount(sampleCount: audio.count)
+            pendingAudio = (audio, folder, name)
+        } else {
+            pendingAudio = nil
+        }
+        entries.insert(entry, at: 0)
+        appendToJournal(JournalRecord(upsert: entry))
+
+        if let pendingAudio {
+            let fileURL = pendingAudio.folder.appendingPathComponent(pendingAudio.name)
             let saved = await withCheckedContinuation { (continuation: CheckedContinuation<Bool, Never>) in
                 ioQueue.async {
                     do {
-                        try FileManager.default.createDirectory(at: folder, withIntermediateDirectories: true)
-                        try FailedAudioDump.wavData(from: audio, sampleRate: Self.sampleRate)
+                        try FileManager.default.createDirectory(at: pendingAudio.folder, withIntermediateDirectories: true)
+                        try FailedAudioDump.wavData(from: pendingAudio.samples, sampleRate: Self.sampleRate)
                             .write(to: fileURL, options: .atomic)
                         continuation.resume(returning: true)
                     } catch {
@@ -145,15 +159,15 @@ final class DictationHistoryStore: ObservableObject {
                     }
                 }
             }
-            if saved {
-                entry.audioFileName = name
-                entry.audioBytes = Self.wavByteCount(sampleCount: audio.count)
+            if !saved {
+                update(id) { entry in
+                    entry.audioFileName = nil
+                    entry.audioBytes = nil
+                }
             }
         }
-        entries.insert(entry, at: 0)
-        appendToJournal(JournalRecord(upsert: entry))
         enforceCaps()
-        return entry.id
+        return id
     }
 
     /// Finish a dictation that produced a result (possibly empty).
@@ -437,12 +451,14 @@ final class DictationHistoryStore: ObservableObject {
 
     private func loadIndex() {
         var loaded: [DictationHistoryEntry] = []
+        var indexWasUnreadable = false
         if let indexURL, FileManager.default.fileExists(atPath: indexURL.path) {
             do {
                 loaded = try Self.decoder.decode([DictationHistoryEntry].self, from: Data(contentsOf: indexURL))
             } catch {
                 // Keep the unreadable file aside rather than overwrite it on the
-                // next save. Its recordings are recovered below.
+                // next save, and keep its recordings too.
+                indexWasUnreadable = true
                 let backup = indexURL.deletingPathExtension().appendingPathExtension("corrupt.json")
                 try? FileManager.default.removeItem(at: backup)
                 try? FileManager.default.moveItem(at: indexURL, to: backup)
@@ -465,13 +481,10 @@ final class DictationHistoryStore: ObservableObject {
             }
         }
 
-        let recovered = recoverUnindexedAudio(
-            referenced: Set(loaded.compactMap(\.audioFileName)),
-            knownIDs: Set(loaded.map(\.id))
-        )
-        if !recovered.isEmpty {
-            loaded = (loaded + recovered).sorted { $0.createdAt > $1.createdAt }
-            changed = true
+        // With the index unreadable, "unreferenced" would mean every
+        // recording it listed; leave them for the set-aside file.
+        if !indexWasUnreadable {
+            removeUnreferencedAudio(referenced: Set(loaded.compactMap(\.audioFileName)))
         }
 
         entries = loaded
@@ -484,39 +497,16 @@ final class DictationHistoryStore: ObservableObject {
         }
     }
 
-    /// Recordings on disk that the index doesn't list: VocaMac stopped
-    /// between writing the audio and writing the index. Each becomes an
-    /// interrupted dictation so it can still be retried.
-    private func recoverUnindexedAudio(referenced: Set<String>, knownIDs: Set<UUID>) -> [DictationHistoryEntry] {
+    /// Delete files in the audio folder no entry refers to. Because an entry
+    /// is journaled before its audio is written, these can only be recordings
+    /// whose deletion was saved but whose file removal hadn't run yet (or a
+    /// temporary file from a write that never finished). Deleted audio stays
+    /// deleted.
+    private func removeUnreferencedAudio(referenced: Set<String>) {
         guard let folder = audioDirectory,
-              let files = try? FileManager.default.contentsOfDirectory(atPath: folder.path) else { return [] }
-        var recovered: [DictationHistoryEntry] = []
-        for file in files where file.hasSuffix(".wav") && !referenced.contains(file) {
-            let url = folder.appendingPathComponent(file)
-            let attributes = try? FileManager.default.attributesOfItem(atPath: url.path)
-            let bytes = (attributes?[.size] as? NSNumber)?.int64Value ?? 0
-            guard bytes > 44 else {
-                try? FileManager.default.removeItem(at: url)
-                continue
-            }
-            let id = UUID(uuidString: String(file.dropLast(4))) ?? UUID()
-            // Audio of an entry that already has its text: a leftover the
-            // user chose not to keep, not a lost dictation.
-            guard !knownIDs.contains(id) else {
-                try? FileManager.default.removeItem(at: url)
-                continue
-            }
-            let samples = Double(bytes - 44) / 2
-            recovered.append(DictationHistoryEntry(
-                id: id,
-                createdAt: (attributes?[.creationDate] as? Date) ?? Date(),
-                status: .interrupted,
-                modelID: "",
-                audioSeconds: samples / Double(Self.sampleRate),
-                audioFileName: file,
-                audioBytes: bytes
-            ))
+              let files = try? FileManager.default.contentsOfDirectory(atPath: folder.path) else { return }
+        for file in files where !referenced.contains(file) {
+            try? FileManager.default.removeItem(at: folder.appendingPathComponent(file))
         }
-        return recovered
     }
 }

--- a/Sources/VocaMac/Services/DictationOutputPipeline.swift
+++ b/Sources/VocaMac/Services/DictationOutputPipeline.swift
@@ -24,15 +24,28 @@ struct DictationOutputPipeline {
         language: String?,
         autoCapitalize: Bool,
         trailingSpace: Bool,
-        preview: Bool = false
+        preview: Bool = false,
+        dictionary: DictionaryContext? = nil
     ) async -> DictationOutputResult {
         func result(_ text: String, _ summary: String) -> DictationOutputResult {
             DictationOutputResult(original: original, text: text, summary: summary)
         }
         guard profile.cleanup != .raw else { return result(original, "Raw transcription") }
-        let masked = snippets.expandMasked(
-            in: original.trimmingCharacters(in: .whitespacesAndNewlines), using: snippetList
-        )
+
+        // The personal dictionary runs first, so snippets, styles, and cleanup
+        // all see the user's spelling. Terms whose exact casing matters travel
+        // through the snippet mask, which formatting and cleanup never touch.
+        var input = original.trimmingCharacters(in: .whitespacesAndNewlines)
+        var protectedTerms: [Snippet] = []
+        if let dictionary, !dictionary.isEmpty {
+            let correction = DictionaryCorrector.correct(
+                input, context: dictionary,
+                allowIdentifierJoins: profile.format == .code || profile.format == .terminal
+            )
+            input = correction.text
+            protectedTerms = correction.protectedTerms.map { Snippet(trigger: $0, expansion: $0) }
+        }
+        let masked = snippets.expandMasked(in: input, using: snippetList + protectedTerms)
         func render(_ text: String, rules: WritingStyleRules) -> String {
             masked.restore(in: WritingStyleEngine.format(
                 text, rules: rules, globalAutoCapitalize: autoCapitalize,

--- a/Sources/VocaMac/Services/DictionaryCorrector.swift
+++ b/Sources/VocaMac/Services/DictionaryCorrector.swift
@@ -1,0 +1,330 @@
+// DictionaryCorrector.swift
+// VocaMac
+//
+// Applies the personal dictionary to a transcript from any engine.
+//
+// Whisper can take vocabulary as a recognition hint, but Parakeet, Apple
+// Speech, and the ONNX models cannot, and even Whisper still misspells. This
+// runs after transcription for every engine and does three things, in order:
+//
+// 1. Replacements: exact spoken forms → the user's text ("get hub" → "GitHub").
+// 2. Vocabulary: spoken words whose letters match a term, ignoring case,
+//    spaces, and punctuation ("voca mac" → "VocaMac"), plus a conservative
+//    fuzzy match for near-misses of longer terms ("Namratha" → "Namrata").
+// 3. Screen context: the same letter match against names and identifiers
+//    read from the screen, never fuzzy.
+//
+// Everything here is pure and deterministic, so it is fast, testable, and
+// never rewrites a sentence the way a language model can.
+
+import Foundation
+
+struct DictionaryCorrection: Equatable {
+    struct Change: Equatable {
+        let from: String
+        let to: String
+    }
+
+    var text: String
+    /// Terms the dictionary put in the text whose exact spelling later
+    /// formatting must not touch (e.g. `iPhone` must not become `IPhone`).
+    var protectedTerms: [String]
+    var changes: [Change]
+}
+
+enum DictionaryCorrector {
+
+    /// Longest run of spoken words that can join into one term.
+    static let maximumWindow = 4
+
+    static func correct(
+        _ text: String,
+        context: DictionaryContext,
+        allowIdentifierJoins: Bool
+    ) -> DictionaryCorrection {
+        var result = DictionaryCorrection(text: text, protectedTerms: [], changes: [])
+        guard !text.isEmpty, !context.isEmpty else { return result }
+
+        applyReplacements(context.replacements, to: &result)
+        applyTerms(
+            vocabulary: context.vocabulary,
+            contextTerms: context.contextTerms,
+            allowIdentifierJoins: allowIdentifierJoins,
+            isKnownWord: context.isKnownWord,
+            to: &result
+        )
+
+        var seen = Set<String>()
+        result.protectedTerms = result.protectedTerms.filter { seen.insert($0).inserted }
+        return result
+    }
+
+    // MARK: - Replacements
+
+    private static func applyReplacements(_ replacements: [WordReplacement], to result: inout DictionaryCorrection) {
+        let pairs = replacements
+            .filter(\.isValid)
+            .flatMap { replacement in
+                replacement.heardForms.map { (heard: $0, replacement: replacement.replacement) }
+            }
+            .sorted { $0.heard.count > $1.heard.count }
+        guard !pairs.isEmpty else { return }
+
+        let pattern = pairs.map { pair -> String in
+            let escaped = NSRegularExpression.escapedPattern(for: pair.heard)
+            let prefix = pair.heard.first.map(isWordCharacter) == true ? "\\b" : "(?<!\\S)"
+            let suffix = pair.heard.last.map(isWordCharacter) == true ? "\\b" : "(?!\\S)"
+            return "(\(prefix)\(escaped)\(suffix))"
+        }.joined(separator: "|")
+        guard let regex = try? NSRegularExpression(pattern: pattern, options: [.caseInsensitive]) else { return }
+
+        let source = result.text as NSString
+        let matches = regex.matches(in: result.text, range: NSRange(location: 0, length: source.length))
+        guard !matches.isEmpty else { return }
+
+        let output = NSMutableString(string: result.text)
+        for match in matches.reversed() {
+            guard let group = (1..<match.numberOfRanges).first(where: { match.range(at: $0).location != NSNotFound }) else {
+                continue
+            }
+            let replacement = pairs[group - 1].replacement
+            let heard = source.substring(with: match.range)
+            output.replaceCharacters(in: match.range, with: replacement)
+            result.changes.insert(.init(from: heard, to: replacement), at: 0)
+            if needsProtection(replacement) {
+                result.protectedTerms.append(replacement)
+            }
+        }
+        result.text = output as String
+    }
+
+    // MARK: - Vocabulary and Screen Terms
+
+    private struct Candidate {
+        let term: String
+        let isUserTerm: Bool
+    }
+
+    private static func applyTerms(
+        vocabulary: [String],
+        contextTerms: [String],
+        allowIdentifierJoins: Bool,
+        isKnownWord: (String) -> Bool,
+        to result: inout DictionaryCorrection
+    ) {
+        var exact: [String: Candidate] = [:]
+        for term in contextTerms {
+            let key = normalized(term)
+            guard key.count >= 2 else { continue }
+            exact[key] = Candidate(term: term, isUserTerm: false)
+        }
+        // The user's own terms win over anything read from the screen.
+        for term in vocabulary {
+            let key = normalized(term)
+            guard key.count >= 2 else { continue }
+            exact[key] = Candidate(term: term, isUserTerm: true)
+        }
+        guard !exact.isEmpty else { return }
+
+        let fuzzyTerms = vocabulary.filter { normalized($0).count >= 5 }
+        let tokens = self.tokens(in: result.text)
+        guard !tokens.isEmpty else { return }
+
+        let source = result.text as NSString
+        var edits: [(range: NSRange, term: String)] = []
+        var index = 0
+
+        while index < tokens.count {
+            let joinable = joinableLength(from: index, tokens: tokens, source: source)
+            var matched = false
+
+            // 1. Exact letter match, longest window first.
+            for length in stride(from: min(maximumWindow, joinable), through: 1, by: -1) {
+                let window = tokens[index..<(index + length)]
+                let key = window.map { normalized($0.text) }.joined()
+                guard let candidate = exact[key] else { continue }
+                if length > 1, !candidate.isUserTerm, isIdentifierShaped(candidate.term), !allowIdentifierJoins {
+                    continue
+                }
+                let range = span(of: window)
+                let spoken = source.substring(with: range)
+                if spoken != candidate.term {
+                    edits.append((range, candidate.term))
+                }
+                if needsProtection(candidate.term) {
+                    result.protectedTerms.append(candidate.term)
+                }
+                index += length
+                matched = true
+                break
+            }
+            if matched { continue }
+
+            // 2. Near-miss of a longer vocabulary term.
+            if let (length, term) = fuzzyMatch(
+                at: index, tokens: tokens, joinable: joinable,
+                terms: fuzzyTerms, isKnownWord: isKnownWord
+            ) {
+                let range = span(of: tokens[index..<(index + length)])
+                edits.append((range, term))
+                if needsProtection(term) {
+                    result.protectedTerms.append(term)
+                }
+                index += length
+                continue
+            }
+
+            index += 1
+        }
+
+        guard !edits.isEmpty else { return }
+        let output = NSMutableString(string: result.text)
+        for edit in edits.reversed() {
+            let spoken = source.substring(with: edit.range)
+            output.replaceCharacters(in: edit.range, with: edit.term)
+            result.changes.append(.init(from: spoken, to: edit.term))
+        }
+        result.text = output as String
+    }
+
+    private static func fuzzyMatch(
+        at index: Int,
+        tokens: [Token],
+        joinable: Int,
+        terms: [String],
+        isKnownWord: (String) -> Bool
+    ) -> (length: Int, term: String)? {
+        guard !terms.isEmpty else { return nil }
+        var best: (length: Int, term: String, distance: Int)?
+
+        for length in 1...min(3, joinable) {
+            let window = tokens[index..<(index + length)]
+            // A real word is never "corrected" into a term on its own: "cloud"
+            // must stay "cloud" even when "Claude" is in the dictionary.
+            if window.allSatisfy({ isKnownWord($0.text) }) { continue }
+            let key = window.map { normalized($0.text) }.joined()
+            guard key.count >= 4 else { continue }
+
+            for term in terms {
+                let target = normalized(term)
+                let limit = target.count >= 9 ? 2 : 1
+                guard abs(target.count - key.count) <= limit,
+                      firstSound(target) == firstSound(key) else { continue }
+                let distance = levenshtein(key, target, limit: limit)
+                guard distance > 0, distance <= limit else { continue }
+                if best == nil || distance < best!.distance {
+                    best = (length, term, distance)
+                }
+            }
+        }
+        return best.map { ($0.length, $0.term) }
+    }
+
+    // MARK: - Tokens
+
+    struct Token {
+        let text: String
+        let range: NSRange
+    }
+
+    private static let tokenRegex = try? NSRegularExpression(pattern: #"[\p{L}\p{N}]+(?:['’][\p{L}]+)*"#)
+
+    static func tokens(in text: String) -> [Token] {
+        guard let tokenRegex else { return [] }
+        let source = text as NSString
+        return tokenRegex.matches(in: text, range: NSRange(location: 0, length: source.length)).map {
+            Token(text: source.substring(with: $0.range), range: $0.range)
+        }
+    }
+
+    /// How many tokens starting at `index` are separated only by spaces or
+    /// hyphens — a comma or full stop between words means they are not one term.
+    private static func joinableLength(from index: Int, tokens: [Token], source: NSString) -> Int {
+        var length = 1
+        while index + length < tokens.count, length < maximumWindow {
+            let previous = tokens[index + length - 1].range
+            let next = tokens[index + length].range
+            let gapStart = previous.location + previous.length
+            let gap = source.substring(with: NSRange(location: gapStart, length: next.location - gapStart))
+            guard gap.allSatisfy({ $0 == " " || $0 == "-" }) else { break }
+            length += 1
+        }
+        return length
+    }
+
+    private static func span(of window: ArraySlice<Token>) -> NSRange {
+        guard let first = window.first?.range, let last = window.last?.range else {
+            return NSRange(location: 0, length: 0)
+        }
+        return NSRange(location: first.location, length: last.location + last.length - first.location)
+    }
+
+    // MARK: - Helpers
+
+    /// Letters and digits only, lowercased: "Voca-Mac" and "voca mac" agree.
+    static func normalized(_ text: String) -> String {
+        String(text.lowercased().unicodeScalars.filter { CharacterSet.alphanumerics.contains($0) }.map(Character.init))
+    }
+
+    /// Whether formatting could change the term's spelling: a lowercase start
+    /// (sentence case would capitalize it), capitals after the first letter,
+    /// or anything that isn't a letter.
+    static func needsProtection(_ term: String) -> Bool {
+        let trimmed = term.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard let first = trimmed.first, trimmed.contains(where: \.isLetter) else { return false }
+        if first.isLetter && first.isLowercase { return true }
+        // Capitals inside a word ("GitHub"), not at the start of each word ("New York").
+        if trimmed.split(separator: " ").contains(where: { $0.dropFirst().contains(where: \.isUppercase) }) {
+            return true
+        }
+        return trimmed.contains { !$0.isLetter && $0 != " " && $0 != "'" && $0 != "’" }
+    }
+
+    /// camelCase, snake_case, kebab-case, dotted, or containing digits — a code
+    /// identifier rather than a name. Only joined from several spoken words in
+    /// code and terminal apps.
+    static func isIdentifierShaped(_ term: String) -> Bool {
+        guard let first = term.first else { return false }
+        if first.isLowercase && term.contains(where: { $0.isUppercase }) { return true }
+        return term.contains { $0 == "_" || $0 == "-" || $0 == "." || $0.isNumber }
+    }
+
+    /// Rough first sound, so fuzzy matching never swaps a word for a term that
+    /// starts differently: c/k/q, s/z, and ph/f are treated as one.
+    static func firstSound(_ key: String) -> Character? {
+        var text = key
+        if text.hasPrefix("ph") { text = "f" + text.dropFirst(2) }
+        guard let first = text.first else { return nil }
+        switch first {
+        case "c", "q": return "k"
+        case "z": return "s"
+        default: return first
+        }
+    }
+
+    /// Edit distance, giving up once it exceeds `limit`.
+    static func levenshtein(_ a: String, _ b: String, limit: Int = .max) -> Int {
+        let left = Array(a)
+        let right = Array(b)
+        if left.isEmpty { return right.count }
+        if right.isEmpty { return left.count }
+        var previous = Array(0...right.count)
+        var current = [Int](repeating: 0, count: right.count + 1)
+        for i in 1...left.count {
+            current[0] = i
+            var rowMinimum = current[0]
+            for j in 1...right.count {
+                let cost = left[i - 1] == right[j - 1] ? 0 : 1
+                current[j] = min(previous[j] + 1, current[j - 1] + 1, previous[j - 1] + cost)
+                rowMinimum = min(rowMinimum, current[j])
+            }
+            if rowMinimum > limit { return rowMinimum }
+            swap(&previous, &current)
+        }
+        return previous[right.count]
+    }
+
+    private static func isWordCharacter(_ character: Character) -> Bool {
+        character.isLetter || character.isNumber || character == "_"
+    }
+}

--- a/Sources/VocaMac/Services/HotKeyManager.swift
+++ b/Sources/VocaMac/Services/HotKeyManager.swift
@@ -68,6 +68,29 @@ final class HotKeyManager {
     /// has had a chance to fire.
     private var safetyTimeoutSeconds: Double = 65.0
 
+    /// Extra shortcuts (paste last dictation, hands-free toggle) matched on
+    /// key-down with exactly these modifiers.
+    private var shortcuts: [HotKeyShortcutAction: HotKeyCombo] = [:]
+
+    /// Base keys of shortcuts whose key-down was consumed, so the matching
+    /// key-up and any autorepeat are consumed too.
+    private var heldShortcutKeyCodes: Set<Int> = []
+
+    /// Whether Escape cancels right now. Armed only while a dictation is
+    /// recording or transcribing, so Escape reaches other apps the rest of
+    /// the time.
+    private var isCancelKeyArmed = false
+
+    /// Whether the current Escape press was consumed as a cancel.
+    private var isCancelKeyHeld = false
+
+    /// `CGEvent` button number that works like the hotkey (2 = middle,
+    /// 3 = back, 4 = forward). 0 turns the mouse trigger off.
+    private var mouseTriggerButton = 0
+
+    /// Whether the mouse trigger button's press was consumed.
+    private var isMouseButtonHeld = false
+
     // MARK: - Callbacks
 
     /// Called when recording should start
@@ -75,6 +98,12 @@ final class HotKeyManager {
 
     /// Called when recording should stop
     var onRecordingStop: (() -> Void)?
+
+    /// Called when one of the extra shortcuts is pressed.
+    var onShortcut: ((HotKeyShortcutAction) -> Void)?
+
+    /// Called when Escape is pressed while the cancel key is armed.
+    var onCancel: (() -> Void)?
 
     // MARK: - Accessibility Permission
 
@@ -120,11 +149,15 @@ final class HotKeyManager {
         self.isModifierKeyHeld = false
         self.isBaseKeyHeld = false
 
-        // Create event tap for key events and flags changed (modifier keys)
+        // Create event tap for key events, flags changed (modifier keys),
+        // and the extra mouse buttons that can act as the hotkey. Moves and
+        // primary clicks are not included, so the tap stays out of the way.
         let eventMask: CGEventMask = (
             (1 << CGEventType.keyDown.rawValue) |
             (1 << CGEventType.keyUp.rawValue) |
-            (1 << CGEventType.flagsChanged.rawValue)
+            (1 << CGEventType.flagsChanged.rawValue) |
+            (1 << CGEventType.otherMouseDown.rawValue) |
+            (1 << CGEventType.otherMouseUp.rawValue)
         )
 
         // We need to pass `self` as a raw pointer to the C callback
@@ -173,6 +206,9 @@ final class HotKeyManager {
         isToggled = false
         isModifierKeyHeld = false
         isBaseKeyHeld = false
+        heldShortcutKeyCodes = []
+        isCancelKeyHeld = false
+        isMouseButtonHeld = false
         cancelSafetyTimer()
 
         VocaLogger.info(.hotKeyManager, "Stopped listening")
@@ -187,6 +223,7 @@ final class HotKeyManager {
         isToggled = false
         isModifierKeyHeld = false
         isBaseKeyHeld = false
+        isMouseButtonHeld = false
         cancelSafetyTimer()
         VocaLogger.debug(.hotKeyManager, "Key state reset")
     }
@@ -211,6 +248,22 @@ final class HotKeyManager {
         if let threshold = doubleTapThreshold { self.doubleTapThreshold = threshold }
         if let timeout = safetyTimeout { self.safetyTimeoutSeconds = timeout }
         if let modifiers = modifiers { self.requiredModifiers = modifiers }
+    }
+
+    /// Replace the extra shortcuts. An action missing from the map is off.
+    func updateShortcuts(_ shortcuts: [HotKeyShortcutAction: HotKeyCombo]) {
+        self.shortcuts = shortcuts
+    }
+
+    /// Arm or disarm Escape as the cancel key.
+    func setCancelKeyArmed(_ armed: Bool) {
+        isCancelKeyArmed = armed
+    }
+
+    /// Use a mouse button as the hotkey (0 turns it off).
+    func updateMouseTrigger(button: Int) {
+        mouseTriggerButton = button
+        isMouseButtonHeld = false
     }
 
     // MARK: - Event Tap Callback
@@ -245,6 +298,10 @@ final class HotKeyManager {
     private func handleEvent(type: CGEventType, event: CGEvent) -> Bool {
         guard !isSelfGeneratedEvent(event) else { return false }
 
+        if type == .otherMouseDown || type == .otherMouseUp {
+            return handleMouseEvent(isDown: type == .otherMouseDown, event: event)
+        }
+
         let keyCode = Int(event.getIntegerValueField(.keyboardEventKeycode))
 
         // For modifier keys (like Option), we use flagsChanged events
@@ -258,10 +315,79 @@ final class HotKeyManager {
             }
             return handleModifierReleaseDuringCombo(flags: event.flags)
         } else if type == .keyDown || type == .keyUp {
-            return handleRegularKeyEvent(keyCode: keyCode, isKeyDown: type == .keyDown, event: event)
+            let isKeyDown = type == .keyDown
+            if handleCancelKeyEvent(keyCode: keyCode, isKeyDown: isKeyDown, event: event) {
+                return true
+            }
+            if handleShortcutKeyEvent(keyCode: keyCode, isKeyDown: isKeyDown, event: event) {
+                return true
+            }
+            return handleRegularKeyEvent(keyCode: keyCode, isKeyDown: isKeyDown, event: event)
         }
 
         return false
+    }
+
+    /// Escape cancels while armed, whatever modifiers are held — in
+    /// push-to-talk the hotkey itself is usually still down.
+    private func handleCancelKeyEvent(keyCode: Int, isKeyDown: Bool, event: CGEvent) -> Bool {
+        guard keyCode == KeyCodeReference.escapeKeyCode else { return false }
+        if isKeyDown {
+            if event.getIntegerValueField(.keyboardEventAutorepeat) != 0 {
+                return isCancelKeyHeld
+            }
+            guard isCancelKeyArmed else { return false }
+            isCancelKeyHeld = true
+            VocaLogger.debug(.hotKeyManager, "Escape pressed — cancelling dictation")
+            DispatchQueue.main.async { [weak self] in
+                self?.onCancel?()
+            }
+            return true
+        }
+        guard isCancelKeyHeld else { return false }
+        isCancelKeyHeld = false
+        return true
+    }
+
+    /// Extra shortcuts fire on key-down with exactly their modifiers. One
+    /// identical to the activation hotkey is ignored so the hotkey keeps working.
+    private func handleShortcutKeyEvent(keyCode: Int, isKeyDown: Bool, event: CGEvent) -> Bool {
+        guard isKeyDown else {
+            return heldShortcutKeyCodes.remove(keyCode) != nil
+        }
+        if event.getIntegerValueField(.keyboardEventAutorepeat) != 0 {
+            return heldShortcutKeyCodes.contains(keyCode)
+        }
+        let modifiers = HotKeyModifiers(cgEventFlags: event.flags)
+        let activation = HotKeyCombo(keyCode: targetKeyCode, modifiers: requiredModifiers)
+        guard let action = HotKeyShortcutAction.allCases.first(where: { action in
+            guard let combo = shortcuts[action] else { return false }
+            return combo.keyCode == keyCode && combo.modifiers == modifiers && combo != activation
+        }) else { return false }
+
+        heldShortcutKeyCodes.insert(keyCode)
+        VocaLogger.debug(.hotKeyManager, "Shortcut pressed: \(action.rawValue)")
+        DispatchQueue.main.async { [weak self] in
+            self?.onShortcut?(action)
+        }
+        return true
+    }
+
+    /// The configured mouse button behaves exactly like the hotkey.
+    private func handleMouseEvent(isDown: Bool, event: CGEvent) -> Bool {
+        guard mouseTriggerButton > 0,
+              Int(event.getIntegerValueField(.mouseEventButtonNumber)) == mouseTriggerButton else {
+            return false
+        }
+        if isDown {
+            isMouseButtonHeld = true
+            handleKeyDown()
+            return true
+        }
+        guard isMouseButtonHeld else { return false }
+        isMouseButtonHeld = false
+        handleKeyUp()
+        return true
     }
 
     /// Detect a required modifier being released while a combo hotkey's base
@@ -506,6 +632,62 @@ extension HotKeyManager: HotKeyMonitoring {
     func _updateConfiguration(keyCode: Int?, mode: ActivationMode?, doubleTapThreshold: Double?, safetyTimeout: Double?, modifiers: HotKeyModifiers?) {
         updateConfiguration(keyCode: keyCode, mode: mode, doubleTapThreshold: doubleTapThreshold, safetyTimeout: safetyTimeout, modifiers: modifiers)
     }
+}
+
+// MARK: - Extra Shortcuts
+
+/// Actions bound to their own global shortcut, besides the activation hotkey.
+enum HotKeyShortcutAction: String, CaseIterable, Identifiable {
+    /// Type the last dictation again at the cursor.
+    case pasteLastDictation
+    /// Start or stop a dictation without holding anything.
+    case handsFreeToggle
+
+    var id: String { rawValue }
+
+    var displayName: String {
+        switch self {
+        case .pasteLastDictation: return "Paste last dictation"
+        case .handsFreeToggle: return "Hands-free dictation"
+        }
+    }
+}
+
+/// Mouse buttons that can start dictation, by `CGEvent` button number.
+enum MouseTriggerButton: Int, CaseIterable, Identifiable {
+    case off = 0
+    case middle = 2
+    case back = 3
+    case forward = 4
+
+    var id: Int { rawValue }
+
+    var displayName: String {
+        switch self {
+        case .off: return "Off"
+        case .middle: return "Middle button"
+        case .back: return "Back button (button 4)"
+        case .forward: return "Forward button (button 5)"
+        }
+    }
+
+    static func resolved(stored: Int) -> MouseTriggerButton {
+        MouseTriggerButton(rawValue: stored) ?? .off
+    }
+}
+
+extension HotKeyCombo {
+    /// Compact preference form: "keyCode:modifiers".
+    var storageString: String { "\(keyCode):\(modifiers.rawValue)" }
+
+    init?(storageString: String) {
+        let parts = storageString.split(separator: ":")
+        guard parts.count == 2, let keyCode = Int(parts[0]), let modifiers = Int(parts[1]) else { return nil }
+        self.init(keyCode: keyCode, modifiers: HotKeyModifiers(rawValue: modifiers))
+    }
+
+    /// ⌃⌘V, matching Wispr Flow's paste-last shortcut.
+    static let defaultPasteLast = HotKeyCombo(keyCode: 9, modifiers: [.control, .command])
 }
 
 // MARK: - HotKeyModifiers Conversion

--- a/Sources/VocaMac/Services/Logger.swift
+++ b/Sources/VocaMac/Services/Logger.swift
@@ -143,6 +143,8 @@ enum LogCategory: String {
     case updateChecker = "UpdateChecker"
     case onboarding = "Onboarding"
     case transcriptCleanup = "TranscriptCleanup"
+    case history = "History"
+    case dictionary = "Dictionary"
     case general = "General"
 }
 

--- a/Sources/VocaMac/Services/ScreenContextTerms.swift
+++ b/Sources/VocaMac/Services/ScreenContextTerms.swift
@@ -1,0 +1,80 @@
+// ScreenContextTerms.swift
+// VocaMac
+//
+// Picks the words from on-screen text that a speech engine is likely to get
+// wrong: code identifiers and names. The dictionary corrector then spells a
+// dictation's matching words the way the screen does.
+
+import Foundation
+
+enum ScreenContextTerms {
+
+    static let maximumTerms = 300
+
+    private static let patterns: [NSRegularExpression] = [
+        // camelCase and iOS-style names: userId, iPhone, macOS
+        #"\b[a-z][a-z0-9]*[A-Z][A-Za-z0-9]*\b"#,
+        // Capitals inside a word: GitHub, OpenAI, UserService
+        #"\b[A-Z][a-z0-9]+[A-Z][A-Za-z0-9]*\b"#,
+        // snake_case and SCREAMING_CASE
+        #"\b[A-Za-z][A-Za-z0-9]*(?:_[A-Za-z0-9]+)+\b"#,
+        // kebab-case
+        #"\b[a-z][a-z0-9]*(?:-[a-z0-9]+)+\b"#,
+    ].compactMap { try? NSRegularExpression(pattern: $0) }
+
+    /// Capitalized words; kept only when they don't start a sentence and
+    /// aren't ordinary words (which would make "Apple" out of "apple").
+    private static let capitalizedWord = try? NSRegularExpression(pattern: #"\b[A-Z][a-z]{2,}\b"#)
+
+    /// Distinct terms in reading order, at most `maximumTerms`.
+    static func extract(from text: String, isKnownWord: (String) -> Bool) -> [String] {
+        guard !text.isEmpty else { return [] }
+        let source = text as NSString
+        let fullRange = NSRange(location: 0, length: source.length)
+
+        var found: [(location: Int, term: String)] = []
+        for regex in patterns {
+            for match in regex.matches(in: text, range: fullRange) {
+                found.append((match.range.location, source.substring(with: match.range)))
+            }
+        }
+
+        if let capitalizedWord {
+            for match in capitalizedWord.matches(in: text, range: fullRange)
+            where !startsSentence(at: match.range.location, in: source) {
+                let word = source.substring(with: match.range)
+                if !isKnownWord(word.lowercased()) {
+                    found.append((match.range.location, word))
+                }
+            }
+        }
+
+        var seen = Set<String>()
+        var terms: [String] = []
+        for item in found.sorted(by: { $0.location < $1.location }) {
+            guard DictionaryCorrector.normalized(item.term).count >= 3,
+                  seen.insert(item.term).inserted else { continue }
+            terms.append(item.term)
+            if terms.count == maximumTerms { break }
+        }
+        return terms
+    }
+
+    /// Whether the word at `location` opens a sentence or line, where a
+    /// capital letter says nothing about it being a name.
+    private static func startsSentence(at location: Int, in source: NSString) -> Bool {
+        var index = location - 1
+        while index >= 0 {
+            guard let scalar = UnicodeScalar(source.character(at: index)) else { return false }
+            let character = Character(scalar)
+            if character == " " || character == "\t" {
+                index -= 1
+                continue
+            }
+            return character == "\n" || character == "." || character == "!" || character == "?"
+                || character == "\"" || character == "“" || character == "#" || character == "-"
+                || character == "*" || character == ">"
+        }
+        return true
+    }
+}

--- a/Sources/VocaMac/Services/ServiceProtocols.swift
+++ b/Sources/VocaMac/Services/ServiceProtocols.swift
@@ -87,6 +87,19 @@ protocol HotKeyMonitoring: AnyObject {
     func _updateConfiguration(keyCode: Int?, mode: ActivationMode?, doubleTapThreshold: Double?, safetyTimeout: Double?, modifiers: HotKeyModifiers?)
 }
 
+/// Extra global shortcuts, the Escape cancel key, and the mouse trigger.
+/// Separate from `HotKeyMonitoring` so existing conformances keep compiling;
+/// the default implementations do nothing.
+protocol HotKeyShortcutMonitoring: AnyObject {
+    var onShortcut: ((HotKeyShortcutAction) -> Void)? { get set }
+    var onCancel: (() -> Void)? { get set }
+    func updateShortcuts(_ shortcuts: [HotKeyShortcutAction: HotKeyCombo])
+    func setCancelKeyArmed(_ armed: Bool)
+    func updateMouseTrigger(button: Int)
+}
+
+extension HotKeyManager: HotKeyShortcutMonitoring {}
+
 extension HotKeyMonitoring {
     func updateConfiguration(keyCode: Int? = nil, mode: ActivationMode? = nil, doubleTapThreshold: Double? = nil, safetyTimeout: Double? = nil, modifiers: HotKeyModifiers? = nil) {
         _updateConfiguration(keyCode: keyCode, mode: mode, doubleTapThreshold: doubleTapThreshold, safetyTimeout: safetyTimeout, modifiers: modifiers)

--- a/Sources/VocaMac/Views/DictionarySettingsPage.swift
+++ b/Sources/VocaMac/Views/DictionarySettingsPage.swift
@@ -1,0 +1,231 @@
+// DictionarySettingsPage.swift
+// VocaMac
+//
+// Settings → Dictionary: vocabulary, replacements, suggested words, and the
+// switches for learning from corrections and reading on-screen names.
+
+import SwiftUI
+
+struct DictionarySettingsPage: View {
+    @EnvironmentObject var appState: AppState
+    @State private var newTerm = ""
+    @State private var newHeard = ""
+    @State private var newReplacement = ""
+
+    var body: some View {
+        VocaSettingsPageContent {
+            if !appState.dictionarySuggestions.isEmpty {
+                VocaSettingsGroup("Suggested Words", subtitle: "Spellings you fixed after dictating. Add one and VocaMac will spell it your way next time.") {
+                    ForEach(appState.dictionarySuggestions) { suggestion in
+                        DictionarySuggestionRow(suggestion: suggestion)
+                        if suggestion.id != appState.dictionarySuggestions.last?.id { Divider() }
+                    }
+                }
+            }
+
+            VocaSettingsGroup("Vocabulary", subtitle: "Names, brands, and jargon you want spelled exactly this way, with every speech model.") {
+                if appState.vocabularyTerms.isEmpty {
+                    Text("No words yet. Try names of people, products, or tools you say often.")
+                        .foregroundStyle(.secondary)
+                } else {
+                    FlowTermList(terms: appState.vocabularyTerms) { term in
+                        appState.removeVocabularyTerm(term)
+                    }
+                }
+                HStack {
+                    TextField("Add a word, e.g. Kubernetes", text: $newTerm)
+                        .textFieldStyle(.roundedBorder)
+                        .onSubmit(addTerm)
+                    Button("Add", action: addTerm)
+                        .disabled(newTerm.trimmingCharacters(in: .whitespaces).isEmpty)
+                }
+                Text("VocaMac matches what it hears to these words ignoring case and spaces (“voca mac” → VocaMac) and fixes close misspellings of longer words. Whisper models also use the first words as a recognition hint.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+
+            VocaSettingsGroup("Replacements", subtitle: "Words a model keeps getting wrong, and what to type instead.") {
+                if appState.wordReplacements.isEmpty {
+                    Text("No replacements yet.")
+                        .foregroundStyle(.secondary)
+                } else {
+                    ForEach($appState.wordReplacements) { $replacement in
+                        WordReplacementRow(replacement: $replacement)
+                        Divider()
+                    }
+                }
+                HStack {
+                    TextField("When I say, e.g. get hub", text: $newHeard)
+                        .textFieldStyle(.roundedBorder)
+                    Image(systemName: "arrow.right").foregroundStyle(.secondary)
+                    TextField("Type, e.g. GitHub", text: $newReplacement)
+                        .textFieldStyle(.roundedBorder)
+                        .onSubmit(addReplacement)
+                    Button("Add", action: addReplacement)
+                        .disabled(newHeard.trimmingCharacters(in: .whitespaces).isEmpty
+                                  || newReplacement.trimmingCharacters(in: .whitespaces).isEmpty)
+                }
+                Text("Matching ignores case and only replaces whole words. Separate several spoken forms with commas. Replacements apply to every speech model; Raw dictation skips them.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+
+            VocaSettingsGroup("Learning") {
+                HStack {
+                    VStack(alignment: .leading, spacing: 4) {
+                        Text("Learn from my corrections")
+                        Text(appState.learnCorrectionsMode.description)
+                            .font(.caption).foregroundStyle(.secondary)
+                            .fixedSize(horizontal: false, vertical: true)
+                    }
+                    Spacer(minLength: 16)
+                    Picker("Learn from my corrections", selection: $appState.learnCorrectionsMode) {
+                        ForEach(LearnCorrectionsMode.allCases) { mode in
+                            Text(mode.displayName).tag(mode)
+                        }
+                    }
+                    .labelsHidden()
+                    .fixedSize()
+                }
+                Divider()
+                SettingsToggleRow(
+                    title: "Spell names from the screen",
+                    detail: "When you start dictating, VocaMac reads the text you can see in the field you're typing into and spells matching names and code identifiers the same way (“user id” → userId in code editors). It's read on this Mac, used once, and never saved.",
+                    isOn: $appState.useScreenContext
+                )
+                Text("Both need Accessibility permission and never read password fields.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+        }
+    }
+
+    private func addTerm() {
+        appState.addVocabularyTerm(newTerm)
+        newTerm = ""
+    }
+
+    private func addReplacement() {
+        appState.addWordReplacement(heard: newHeard, replacement: newReplacement)
+        newHeard = ""
+        newReplacement = ""
+    }
+}
+
+struct DictionarySuggestionRow: View {
+    @EnvironmentObject var appState: AppState
+    let suggestion: CorrectionSuggestion
+
+    var body: some View {
+        HStack {
+            Text(suggestion.heard).strikethrough().foregroundStyle(.secondary)
+            Image(systemName: "arrow.right").foregroundStyle(.secondary).font(.caption)
+            Text(suggestion.corrected).fontWeight(.medium)
+            if suggestion.occurrences > 1 {
+                Text("×\(suggestion.occurrences)").font(.caption).foregroundStyle(.secondary)
+            }
+            Spacer()
+            Button("Add") { appState.acceptDictionarySuggestion(suggestion) }
+                .buttonStyle(.borderedProminent)
+                .controlSize(.small)
+            Button("Dismiss") { appState.dismissDictionarySuggestion(suggestion) }
+                .controlSize(.small)
+        }
+    }
+}
+
+struct WordReplacementRow: View {
+    @EnvironmentObject var appState: AppState
+    @Binding var replacement: WordReplacement
+
+    var body: some View {
+        HStack {
+            TextField("When I say", text: $replacement.heard)
+                .textFieldStyle(.roundedBorder)
+            Image(systemName: "arrow.right").foregroundStyle(.secondary)
+            TextField("Type", text: $replacement.replacement)
+                .textFieldStyle(.roundedBorder)
+            Button(role: .destructive) {
+                let id = replacement.id
+                appState.wordReplacements.removeAll { $0.id == id }
+            } label: {
+                Image(systemName: "minus.circle.fill")
+            }
+            .buttonStyle(.borderless)
+            .help("Remove Replacement")
+            .accessibilityLabel("Remove Replacement")
+        }
+    }
+}
+
+/// Vocabulary terms as removable chips that wrap onto new lines.
+struct FlowTermList: View {
+    let terms: [String]
+    let onRemove: (String) -> Void
+
+    var body: some View {
+        FlowLayout(spacing: 6) {
+            ForEach(terms, id: \.self) { term in
+                HStack(spacing: 4) {
+                    Text(term)
+                    Button {
+                        onRemove(term)
+                    } label: {
+                        Image(systemName: "xmark.circle.fill")
+                            .foregroundStyle(.secondary)
+                    }
+                    .buttonStyle(.plain)
+                    .help("Remove \(term)")
+                    .accessibilityLabel("Remove \(term)")
+                }
+                .padding(.horizontal, 8)
+                .padding(.vertical, 4)
+                .background(Color.secondary.opacity(0.12), in: Capsule())
+            }
+        }
+    }
+}
+
+/// Minimal wrapping layout for chips.
+struct FlowLayout: Layout {
+    var spacing: CGFloat = 6
+
+    func sizeThatFits(proposal: ProposedViewSize, subviews: Subviews, cache: inout ()) -> CGSize {
+        let width = proposal.width ?? .infinity
+        var x: CGFloat = 0
+        var y: CGFloat = 0
+        var rowHeight: CGFloat = 0
+        var widest: CGFloat = 0
+        for subview in subviews {
+            let size = subview.sizeThatFits(.unspecified)
+            if x > 0, x + size.width > width {
+                y += rowHeight + spacing
+                x = 0
+                rowHeight = 0
+            }
+            x += size.width + spacing
+            widest = max(widest, x - spacing)
+            rowHeight = max(rowHeight, size.height)
+        }
+        return CGSize(width: width.isFinite ? width : widest, height: y + rowHeight)
+    }
+
+    func placeSubviews(in bounds: CGRect, proposal: ProposedViewSize, subviews: Subviews, cache: inout ()) {
+        var x = bounds.minX
+        var y = bounds.minY
+        var rowHeight: CGFloat = 0
+        for subview in subviews {
+            let size = subview.sizeThatFits(.unspecified)
+            if x > bounds.minX, x + size.width > bounds.maxX {
+                y += rowHeight + spacing
+                x = bounds.minX
+                rowHeight = 0
+            }
+            subview.place(at: CGPoint(x: x, y: y), proposal: ProposedViewSize(size))
+            x += size.width + spacing
+            rowHeight = max(rowHeight, size.height)
+        }
+    }
+}

--- a/Sources/VocaMac/Views/HistorySettingsPage.swift
+++ b/Sources/VocaMac/Views/HistorySettingsPage.swift
@@ -52,7 +52,7 @@ struct HistorySettingsPage: View {
                         .font(.caption)
                         .foregroundStyle(.secondary)
                     Spacer()
-                    Button("Delete Audio") { appState.historyStore.deleteAllAudio() }
+                    Button("Delete Audio") { appState.deleteAllHistoryAudio() }
                         .disabled(appState.historyStore.entries.allSatisfy { !$0.hasAudio })
                     Button("Delete All…", role: .destructive) { confirmingDeleteAll = true }
                         .disabled(appState.historyStore.entries.isEmpty)

--- a/Sources/VocaMac/Views/HistorySettingsPage.swift
+++ b/Sources/VocaMac/Views/HistorySettingsPage.swift
@@ -19,6 +19,15 @@ struct HistorySettingsPage: View {
 
     var body: some View {
         VocaSettingsPageContent {
+            if appState.historyStore.hasUnsavedChanges {
+                Label("Recent history changes couldn't be saved to disk. VocaMac keeps trying; check that your disk has free space.",
+                      systemImage: "exclamationmark.triangle.fill")
+                    .font(.callout)
+                    .foregroundStyle(.orange)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .vocaCard()
+            }
+
             VocaSettingsGroup("Keep History") {
                 SettingsToggleRow(
                     title: "Save dictation history",

--- a/Sources/VocaMac/Views/HistorySettingsPage.swift
+++ b/Sources/VocaMac/Views/HistorySettingsPage.swift
@@ -118,6 +118,8 @@ struct HistoryEntryRow: View {
     let entry: DictationHistoryEntry
     @ObservedObject var player: HistoryAudioPlayer
     @State private var showsOriginal = false
+    @State private var isOriginalHovered = false
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
     private var isRetrying: Bool { appState.retryingHistoryEntryID == entry.id }
 
@@ -160,17 +162,70 @@ struct HistoryEntryRow: View {
             }
 
             if entry.hasEditedOutput {
-                DisclosureGroup(isExpanded: $showsOriginal) {
-                    Text(entry.rawText.trimmingCharacters(in: .whitespacesAndNewlines))
-                        .font(.callout)
-                        .foregroundStyle(.secondary)
-                        .textSelection(.enabled)
+                VStack(alignment: .leading, spacing: 0) {
+                    Button {
+                        withAnimation(reduceMotion ? nil : .easeInOut(duration: 0.18)) {
+                            showsOriginal.toggle()
+                        }
+                    } label: {
+                        HStack(spacing: 8) {
+                            ZStack {
+                                RoundedRectangle(cornerRadius: 5)
+                                    .fill(VocaDesign.accent.opacity(0.12))
+                                Image(systemName: "chevron.right")
+                                    .font(.system(size: 9, weight: .bold))
+                                    .foregroundStyle(VocaDesign.accent)
+                                    .rotationEffect(.degrees(showsOriginal ? 90 : 0))
+                            }
+                            .frame(width: 20, height: 20)
+
+                            Text("Original transcript")
+                                .font(.caption.weight(.semibold))
+                                .foregroundStyle(.primary)
+
+                            if let summary = entry.summary {
+                                Text(summary)
+                                    .font(.caption2.weight(.medium))
+                                    .foregroundStyle(VocaDesign.accent)
+                                    .padding(.horizontal, 7)
+                                    .padding(.vertical, 2)
+                                    .background(VocaDesign.accent.opacity(0.10), in: Capsule())
+                            }
+
+                            Spacer(minLength: 8)
+
+                            Text(showsOriginal ? "Hide" : "Show")
+                                .font(.caption2.weight(.medium))
+                                .foregroundStyle(.secondary)
+                        }
                         .frame(maxWidth: .infinity, alignment: .leading)
-                } label: {
-                    Text("Original transcript\(entry.summary.map { " · \($0)" } ?? "")")
-                        .font(.caption)
-                        .foregroundStyle(.secondary)
+                        .padding(.horizontal, 10)
+                        .padding(.vertical, 8)
+                        .contentShape(Rectangle())
+                    }
+                    .buttonStyle(.plain)
+                    .accessibilityLabel("Original transcript")
+                    .accessibilityValue(showsOriginal ? "Expanded" : "Collapsed")
+                    .accessibilityHint("Shows the text before cleanup and writing style changes")
+
+                    if showsOriginal {
+                        Divider()
+                            .padding(.horizontal, 10)
+
+                        Text(entry.rawText.trimmingCharacters(in: .whitespacesAndNewlines))
+                            .font(.callout)
+                            .foregroundStyle(.secondary)
+                            .textSelection(.enabled)
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                            .padding(10)
+                    }
                 }
+                .background(
+                    Color.primary.opacity(isOriginalHovered ? 0.065 : 0.035),
+                    in: RoundedRectangle(cornerRadius: 8)
+                )
+                .overlay(RoundedRectangle(cornerRadius: 8).strokeBorder(VocaDesign.line))
+                .onHover { isOriginalHovered = $0 }
             }
         }
     }

--- a/Sources/VocaMac/Views/HistorySettingsPage.swift
+++ b/Sources/VocaMac/Views/HistorySettingsPage.swift
@@ -1,0 +1,262 @@
+// HistorySettingsPage.swift
+// VocaMac
+//
+// Settings → History: every past dictation with its text, the original
+// transcript, the audio, and a way to retry it.
+
+import AVFoundation
+import SwiftUI
+
+struct HistorySettingsPage: View {
+    @EnvironmentObject var appState: AppState
+    @ObservedObject private var player = HistoryAudioPlayer.shared
+    @State private var query = ""
+    @State private var confirmingDeleteAll = false
+
+    private var entries: [DictationHistoryEntry] {
+        appState.historyStore.search(query)
+    }
+
+    var body: some View {
+        VocaSettingsPageContent {
+            VocaSettingsGroup("Keep History") {
+                SettingsToggleRow(
+                    title: "Save dictation history",
+                    detail: "Keep what you dictated on this Mac so you can copy it, paste it again, or retry it. Nothing leaves your Mac.",
+                    isOn: $appState.historyEnabled
+                )
+                Divider()
+                SettingsToggleRow(
+                    title: "Keep audio recordings",
+                    detail: "Needed to play back or retry a dictation. Audio is always kept for dictations that failed or were interrupted, until they're retried or deleted.",
+                    isOn: $appState.historyKeepsAudio
+                )
+                .disabled(!appState.historyEnabled)
+                Divider()
+                HStack {
+                    Text("Keep dictations for")
+                    Spacer()
+                    Picker("Keep dictations for", selection: $appState.historyRetention) {
+                        ForEach(HistoryRetention.allCases) { retention in
+                            Text(retention.displayName).tag(retention)
+                        }
+                    }
+                    .labelsHidden()
+                    .fixedSize()
+                    .onChange(of: appState.historyRetention) { appState.applyHistoryRetention() }
+                }
+                .disabled(!appState.historyEnabled)
+                Divider()
+                HStack {
+                    Text(summaryText)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                    Spacer()
+                    Button("Delete Audio") { appState.historyStore.deleteAllAudio() }
+                        .disabled(appState.historyStore.entries.allSatisfy { !$0.hasAudio })
+                    Button("Delete All…", role: .destructive) { confirmingDeleteAll = true }
+                        .disabled(appState.historyStore.entries.isEmpty)
+                }
+            }
+
+            VStack(alignment: .leading, spacing: 8) {
+                HStack {
+                    VocaSectionHeader(title: "Dictations", systemImage: nil, subtitle: nil)
+                    Spacer()
+                    TextField("Search", text: $query)
+                        .textFieldStyle(.roundedBorder)
+                        .frame(maxWidth: 220)
+                }
+                if entries.isEmpty {
+                    Text(query.isEmpty ? "Your dictations will appear here." : "No dictations match “\(query)”.")
+                        .foregroundStyle(.secondary)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .vocaCard()
+                } else {
+                    LazyVStack(alignment: .leading, spacing: 10) {
+                        ForEach(entries) { entry in
+                            HistoryEntryRow(entry: entry, player: player)
+                                .vocaCard()
+                        }
+                    }
+                }
+            }
+        }
+        .confirmationDialog(
+            "Delete all dictation history?",
+            isPresented: $confirmingDeleteAll
+        ) {
+            Button("Delete All", role: .destructive) {
+                player.stop()
+                appState.clearHistory()
+            }
+        } message: {
+            Text("This removes every saved dictation and recording from this Mac.")
+        }
+        .onDisappear { player.stop() }
+    }
+
+    private var summaryText: String {
+        let entries = appState.historyStore.entries
+        let bytes = entries.reduce(Int64(0)) { $0 + ($1.audioBytes ?? 0) }
+        let size = ByteCountFormatter.string(fromByteCount: bytes, countStyle: .file)
+        return "\(entries.count) dictation\(entries.count == 1 ? "" : "s") · \(size) of audio"
+    }
+}
+
+struct HistoryEntryRow: View {
+    @EnvironmentObject var appState: AppState
+    let entry: DictationHistoryEntry
+    @ObservedObject var player: HistoryAudioPlayer
+    @State private var showsOriginal = false
+
+    private var isRetrying: Bool { appState.retryingHistoryEntryID == entry.id }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            HStack(spacing: 6) {
+                Text(entry.createdAt, format: .dateTime.month(.abbreviated).day().hour().minute())
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                if let app = entry.appName {
+                    Text("·").font(.caption).foregroundStyle(.tertiary)
+                    Text(app).font(.caption).foregroundStyle(.secondary)
+                }
+                Text("·").font(.caption).foregroundStyle(.tertiary)
+                Text(String(format: "%.1fs", entry.audioSeconds)).font(.caption).foregroundStyle(.secondary)
+                if entry.status != .completed {
+                    Text(entry.status.displayName)
+                        .font(.caption2.weight(.semibold))
+                        .padding(.horizontal, 6)
+                        .padding(.vertical, 2)
+                        .background(statusColor.opacity(0.18), in: Capsule())
+                        .foregroundStyle(statusColor)
+                }
+                if entry.retryCount > 0 {
+                    Text("Retried").font(.caption2).foregroundStyle(.secondary)
+                }
+                Spacer()
+                actions
+            }
+
+            if entry.displayText.isEmpty {
+                Text(entry.errorMessage ?? (entry.status == .empty ? "No words were heard." : "No text yet."))
+                    .foregroundStyle(.secondary)
+                    .font(.callout)
+            } else {
+                Text(entry.displayText)
+                    .textSelection(.enabled)
+                    .lineLimit(showsOriginal ? nil : 4)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+            }
+
+            if entry.hasEditedOutput {
+                DisclosureGroup(isExpanded: $showsOriginal) {
+                    Text(entry.rawText.trimmingCharacters(in: .whitespacesAndNewlines))
+                        .font(.callout)
+                        .foregroundStyle(.secondary)
+                        .textSelection(.enabled)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                } label: {
+                    Text("Original transcript\(entry.summary.map { " · \($0)" } ?? "")")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var actions: some View {
+        HStack(spacing: 10) {
+            if !entry.displayText.isEmpty {
+                Button { appState.copyToClipboard(entry.displayText) } label: {
+                    Image(systemName: "doc.on.doc")
+                }
+                .help("Copy")
+                .accessibilityLabel("Copy dictation")
+            }
+            if entry.hasEditedOutput {
+                Button { appState.copyToClipboard(entry.rawText.trimmingCharacters(in: .whitespacesAndNewlines)) } label: {
+                    Image(systemName: "text.badge.minus")
+                }
+                .help("Copy the original transcript, before cleanup and styling")
+                .accessibilityLabel("Copy original transcript")
+            }
+            if entry.hasAudio, let url = appState.historyStore.audioURL(for: entry) {
+                Button { player.toggle(url) } label: {
+                    Image(systemName: player.playingURL == url ? "stop.fill" : "play.fill")
+                }
+                .help(player.playingURL == url ? "Stop" : "Play recording")
+                .accessibilityLabel(player.playingURL == url ? "Stop playback" : "Play recording")
+
+                if isRetrying {
+                    ProgressView().controlSize(.small)
+                } else {
+                    Button {
+                        Task { await appState.retryHistoryEntry(entry.id) }
+                    } label: {
+                        Image(systemName: "arrow.clockwise")
+                    }
+                    .help("Transcribe again with the current model and copy the result")
+                    .accessibilityLabel("Retry transcription")
+                    .disabled(appState.retryingHistoryEntryID != nil)
+                }
+            }
+            Button(role: .destructive) {
+                if let url = appState.historyStore.audioURL(for: entry), player.playingURL == url { player.stop() }
+                appState.deleteHistoryEntry(entry.id)
+            } label: {
+                Image(systemName: "trash")
+            }
+            .help("Delete")
+            .accessibilityLabel("Delete dictation")
+        }
+        .buttonStyle(.borderless)
+    }
+
+    private var statusColor: Color {
+        switch entry.status {
+        case .failed, .interrupted: return .orange
+        case .cancelled, .empty: return .secondary
+        case .pending: return .yellow
+        case .completed: return VocaDesign.success
+        }
+    }
+}
+
+/// Plays one history recording at a time.
+@MainActor
+final class HistoryAudioPlayer: NSObject, ObservableObject, AVAudioPlayerDelegate {
+    static let shared = HistoryAudioPlayer()
+
+    @Published private(set) var playingURL: URL?
+    private var player: AVAudioPlayer?
+
+    func toggle(_ url: URL) {
+        if playingURL == url {
+            stop()
+            return
+        }
+        stop()
+        do {
+            let player = try AVAudioPlayer(contentsOf: url)
+            player.delegate = self
+            player.play()
+            self.player = player
+            playingURL = url
+        } catch {
+            VocaLogger.warning(.history, "Could not play recording: \(error.localizedDescription)")
+        }
+    }
+
+    func stop() {
+        player?.stop()
+        player = nil
+        playingURL = nil
+    }
+
+    nonisolated func audioPlayerDidFinishPlaying(_ player: AVAudioPlayer, successfully flag: Bool) {
+        Task { @MainActor in self.stop() }
+    }
+}

--- a/Sources/VocaMac/Views/HotKeySelectionControl.swift
+++ b/Sources/VocaMac/Views/HotKeySelectionControl.swift
@@ -129,7 +129,7 @@ struct HotKeySelectionControl: View {
     }
 }
 
-private struct HotKeyRecorderButton: View {
+struct HotKeyRecorderButton: View {
     @Binding var isRecording: Bool
 
     let onStart: () -> Void

--- a/Sources/VocaMac/Views/MenuBarView.swift
+++ b/Sources/VocaMac/Views/MenuBarView.swift
@@ -141,6 +141,19 @@ struct MenuBarView: View {
                 writingStyleSection
             }
 
+            // A dictation that failed or was interrupted, with its audio saved
+            if let entry = appState.recoverableHistoryEntry {
+                Divider()
+                recoverySection(entry)
+                    .vocaCard()
+            }
+
+            // A spelling the user fixed, offered for the dictionary
+            if let suggestion = appState.dictionarySuggestions.first {
+                Divider()
+                suggestionSection(suggestion)
+            }
+
             // Last Transcription
             if let transcription = appState.lastTranscription {
                 Divider()
@@ -691,10 +704,108 @@ struct MenuBarView: View {
         .foregroundStyle(isDenied ? .red : .orange)
     }
 
+    // MARK: - Recovery and Suggestions
+
+    private func recoverySection(_ entry: DictationHistoryEntry) -> some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Label(recoveryTitle(entry), systemImage: "exclamationmark.arrow.circlepath")
+                .font(.subheadline.weight(.semibold))
+                .foregroundStyle(.orange)
+            Text("The \(String(format: "%.0f", entry.audioSeconds))-second recording is saved. Retry transcribes it again and copies the text\(pasteShortcutHint).")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
+            HStack {
+                if appState.retryingHistoryEntryID == entry.id {
+                    ProgressView().controlSize(.small)
+                    Text("Transcribing…").font(.caption)
+                } else {
+                    Button("Retry") {
+                        Task { await appState.retryHistoryEntry(entry.id) }
+                    }
+                    .buttonStyle(.borderedProminent)
+                    .controlSize(.small)
+                    .disabled(appState.retryingHistoryEntryID != nil)
+                }
+                Button("Dismiss") { appState.dismissRecovery(entry.id) }
+                    .controlSize(.small)
+                Spacer()
+                Button("History…") { openHistory() }
+                    .buttonStyle(.link)
+                    .font(.caption)
+            }
+        }
+    }
+
+    private func recoveryTitle(_ entry: DictationHistoryEntry) -> String {
+        switch entry.status {
+        case .interrupted: return "Your last dictation was interrupted"
+        case .cancelled: return "Your last dictation was cancelled"
+        default: return "Your last dictation failed"
+        }
+    }
+
+    private var pasteShortcutHint: String {
+        guard let combo = appState.shortcut(for: .pasteLastDictation) else { return "" }
+        return " — then press \(KeyCodeReference.displayName(for: combo)) to paste it"
+    }
+
+    private func suggestionSection(_ suggestion: CorrectionSuggestion) -> some View {
+        HStack(spacing: 6) {
+            Image(systemName: "character.book.closed")
+                .foregroundStyle(VocaDesign.accent)
+            (Text("Spell it ") + Text(suggestion.corrected).fontWeight(.semibold) + Text(" next time?"))
+                .font(.caption)
+                .lineLimit(2)
+            Spacer()
+            Button("Add") { appState.acceptDictionarySuggestion(suggestion) }
+                .controlSize(.small)
+            Button {
+                appState.dismissDictionarySuggestion(suggestion)
+            } label: {
+                Image(systemName: "xmark")
+            }
+            .buttonStyle(.borderless)
+            .help("Dismiss")
+            .accessibilityLabel("Dismiss suggestion")
+        }
+    }
+
+    private func openHistory() {
+        appState.requestSettingsPage(.history)
+        settingsManager.open(appState: appState)
+    }
+
     // MARK: - Actions
 
     private var actionsSection: some View {
         VStack(spacing: 2) {
+            Button {
+                openHistory()
+            } label: {
+                HStack {
+                    Image(systemName: "clock.arrow.circlepath")
+                        .frame(width: 16)
+                    Text("History")
+                    Spacer()
+                    if let combo = appState.shortcut(for: .pasteLastDictation) {
+                        Text("Paste last: \(KeyCodeReference.displayName(for: combo))")
+                            .foregroundStyle(.secondary)
+                            .font(.caption)
+                    }
+                }
+                .font(.body)
+                .padding(.vertical, 6)
+                .padding(.horizontal, 8)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .contentShape(Rectangle())
+                .background(
+                    RoundedRectangle(cornerRadius: 6)
+                        .fill(Color.primary.opacity(0.0001))
+                )
+            }
+            .buttonStyle(MenuRowButtonStyle())
+
             Button {
                 settingsManager.open(appState: appState)
             } label: {

--- a/Sources/VocaMac/Views/SettingsView.swift
+++ b/Sources/VocaMac/Views/SettingsView.swift
@@ -92,9 +92,20 @@ struct SettingsView: View {
                 pageBeforeSearch = newValue
             }
         }
+        .onAppear(perform: showRequestedPage)
+        .onChange(of: appState.requestedSettingsPage) { showRequestedPage() }
         .frame(minWidth: 760, minHeight: 580)
         .tint(VocaDesign.accent)
         .groupBoxStyle(VocaGroupBoxStyle())
+    }
+
+    /// Jump to a page another part of the app asked for (e.g. History from
+    /// the menu bar), once.
+    private func showRequestedPage() {
+        guard let page = appState.requestedSettingsPage else { return }
+        searchText = ""
+        selectedPage = page
+        appState.requestedSettingsPage = nil
     }
 
     private var settingsSidebar: some View {
@@ -145,6 +156,10 @@ struct SettingsView: View {
             switch selectedPage ?? .dictation {
             case .dictation:
                 DictationSettingsPage()
+            case .history:
+                HistorySettingsPage()
+            case .dictionary:
+                DictionarySettingsPage()
             case .writingStyles:
                 WritingStylesSettingsTab()
             case .snippets:
@@ -352,6 +367,8 @@ struct DictationSettingsPage: View {
                         .font(.caption).foregroundStyle(.secondary)
                 }
             }
+
+            ShortcutSettingsGroup()
 
             VocaSettingsGroup("Your Text") {
                 SettingsToggleRow(
@@ -1079,31 +1096,20 @@ struct ModelSettingsTab: View {
                     .foregroundStyle(.secondary)
             }
 
-            if activeEngine?.supportsCustomVocabulary == true {
-                Divider()
+            Divider()
 
-                Text("Custom Vocabulary")
-                    .font(.subheadline.weight(.semibold))
-
-                TextEditor(text: $appState.customVocabulary)
-                    .font(.body)
-                    .frame(minHeight: 90)
-                    .overlay(alignment: .topLeading) {
-                        if appState.customVocabulary.isEmpty {
-                            Text("kubectl, PostgreSQL, nginx, Grafana")
-                                .foregroundStyle(.tertiary)
-                                .padding(.top, 8)
-                                .padding(.leading, 5)
-                                .allowsHitTesting(false)
-                        }
-                    }
-
-                let count = WhisperService.vocabularyTerms(from: appState.customVocabulary).count
-                Text(count == 0
-                     ? "Add names, jargon, or proper nouns (one per line or comma-separated) that get mis-transcribed."
-                     : "\(count) term\(count == 1 ? "" : "s"). Keep the list short; the model can only use the first 50 to 100 words as a hint.")
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
+            HStack {
+                VStack(alignment: .leading, spacing: 4) {
+                    Text("Vocabulary")
+                    Text(activeEngine?.supportsCustomVocabulary == true
+                         ? "Your dictionary spells names your way with every model; this model also uses it as a recognition hint."
+                         : "Your dictionary spells names your way with every model.")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+                Spacer()
+                Button("Open Dictionary") { appState.requestSettingsPage(.dictionary) }
             }
     }
         .onChange(of: appState.selectedLanguage) {
@@ -1323,6 +1329,8 @@ struct AudioSettingsTab: View {
                     Text("60 seconds").tag(60)
                     Text("120 seconds").tag(120)
                     Text("300 seconds (5 min)").tag(300)
+                    Text("10 minutes").tag(600)
+                    Text("20 minutes").tag(1200)
                 }
                 .onChange(of: appState.maxRecordingDuration) {
                     appState.syncHotKeyConfiguration()

--- a/Sources/VocaMac/Views/ShortcutSettingsGroup.swift
+++ b/Sources/VocaMac/Views/ShortcutSettingsGroup.swift
@@ -1,0 +1,171 @@
+// ShortcutSettingsGroup.swift
+// VocaMac
+//
+// Settings for the shortcuts beyond the activation hotkey: paste the last
+// dictation, hands-free dictation, Escape to cancel, and a mouse button.
+
+import SwiftUI
+
+struct ShortcutSettingsGroup: View {
+    @EnvironmentObject var appState: AppState
+
+    var body: some View {
+        VocaSettingsGroup("Shortcuts") {
+            ShortcutRecorderRow(
+                action: .pasteLastDictation,
+                detail: "Type your last dictation again at the cursor — handy when it landed in the wrong place."
+            )
+            Divider()
+            ShortcutRecorderRow(
+                action: .handsFreeToggle,
+                detail: "Press once to start and again to stop, without holding anything. Silence ends it too, per Settings → Audio."
+            )
+            Divider()
+            SettingsToggleRow(
+                title: "Escape cancels dictation",
+                detail: "Press Escape while recording or transcribing to throw the dictation away. A dictation cancelled while transcribing stays in History to retry.",
+                isOn: Binding(
+                    get: { appState.escapeCancelsDictation },
+                    set: { appState.escapeCancelsDictation = $0; appState.syncShortcutConfiguration() }
+                )
+            )
+            Divider()
+            HStack {
+                VStack(alignment: .leading, spacing: 4) {
+                    Text("Mouse button")
+                    Text("Use an extra mouse button like the hotkey: hold it to talk, or double-click it in Double-Tap mode.")
+                        .font(.caption).foregroundStyle(.secondary)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+                Spacer(minLength: 16)
+                Picker("Mouse button", selection: Binding(
+                    get: { MouseTriggerButton.resolved(stored: appState.mouseTriggerButton) },
+                    set: { appState.mouseTriggerButton = $0.rawValue; appState.syncShortcutConfiguration() }
+                )) {
+                    ForEach(MouseTriggerButton.allCases) { button in
+                        Text(button.displayName).tag(button)
+                    }
+                }
+                .labelsHidden()
+                .fixedSize()
+            }
+        }
+    }
+}
+
+/// One shortcut: its current keys, a Record button, and a Clear button.
+struct ShortcutRecorderRow: View {
+    @EnvironmentObject var appState: AppState
+    let action: HotKeyShortcutAction
+    let detail: String
+
+    @State private var isRecording = false
+    @State private var wasListeningBeforeRecording = false
+    @State private var problem: String?
+
+    private var combo: HotKeyCombo? { appState.shortcut(for: action) }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            HStack(alignment: .firstTextBaseline) {
+                VStack(alignment: .leading, spacing: 4) {
+                    Text(action.displayName)
+                    Text(detail)
+                        .font(.caption).foregroundStyle(.secondary)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+                Spacer(minLength: 16)
+                Text(combo.map { KeyCodeReference.displayName(for: $0) } ?? "None")
+                    .font(.system(.body, design: .rounded))
+                    .foregroundStyle(combo == nil ? .secondary : .primary)
+                    .padding(.horizontal, 8)
+                    .padding(.vertical, 3)
+                    .background(Color.secondary.opacity(0.12), in: RoundedRectangle(cornerRadius: 6))
+                    .accessibilityLabel("\(action.displayName) shortcut")
+                    .accessibilityValue(combo.map { KeyCodeReference.displayName(for: $0) } ?? "None")
+                HotKeyRecorderButton(
+                    isRecording: $isRecording,
+                    onStart: beginRecording,
+                    onCancel: finishRecording,
+                    onKeyRecorded: record
+                )
+                if combo != nil {
+                    Button("Clear") { appState.setShortcut(nil, for: action) }
+                        .controlSize(.small)
+                        .disabled(isRecording)
+                }
+            }
+            if isRecording {
+                Label("Press the keys, or press Escape to cancel", systemImage: "keyboard")
+                    .font(.caption)
+                    .foregroundStyle(Color.accentColor)
+            } else if let problem {
+                Label(problem, systemImage: "exclamationmark.triangle")
+                    .font(.caption)
+                    .foregroundStyle(.orange)
+            }
+        }
+        .onDisappear {
+            guard isRecording else { return }
+            isRecording = false
+            finishRecording()
+        }
+    }
+
+    private func beginRecording() {
+        problem = nil
+        wasListeningBeforeRecording = appState.hotKeyManager.isListening
+        if wasListeningBeforeRecording {
+            appState.hotKeyManager.stopListening()
+        }
+    }
+
+    private func finishRecording() {
+        if wasListeningBeforeRecording {
+            appState.hotKeyManager.startListening(
+                keyCode: appState.hotKeyCode,
+                mode: appState.activationMode,
+                doubleTapThreshold: appState.doubleTapThreshold,
+                safetyTimeout: Double(appState.maxRecordingDuration) + 5.0,
+                modifiers: appState.hotKeyModifiers
+            )
+            appState.syncShortcutConfiguration()
+        }
+        wasListeningBeforeRecording = false
+    }
+
+    private func record(_ newCombo: HotKeyCombo) {
+        defer { finishRecording() }
+        if let reason = ShortcutValidation.problem(with: newCombo, action: action, appState: appState) {
+            problem = reason
+            return
+        }
+        appState.setShortcut(newCombo, for: action)
+    }
+}
+
+/// Rules a secondary shortcut has to follow.
+@MainActor
+enum ShortcutValidation {
+    /// Function keys are fine alone; anything else needs a modifier, or
+    /// typing that letter anywhere would trigger the shortcut.
+    static func problem(with combo: HotKeyCombo, action: HotKeyShortcutAction, appState: AppState) -> String? {
+        if KeyCodeReference.isModifierKeyCode(combo.keyCode) {
+            return "Use a key with modifiers, like ⌃⌘V. A modifier on its own is reserved for the dictation hotkey."
+        }
+        if combo.modifiers.isEmpty && !isFunctionKey(combo.keyCode) {
+            return "Add ⌘, ⌃, or ⌥ so the shortcut doesn't fire while you type."
+        }
+        if combo == HotKeyCombo(keyCode: appState.hotKeyCode, modifiers: appState.hotKeyModifiers) {
+            return "That's your dictation hotkey. Pick different keys."
+        }
+        for other in HotKeyShortcutAction.allCases where other != action && appState.shortcut(for: other) == combo {
+            return "That's already the \(other.displayName.lowercased()) shortcut."
+        }
+        return nil
+    }
+
+    static func isFunctionKey(_ keyCode: Int) -> Bool {
+        [122, 120, 99, 118, 96, 97, 98, 100, 101, 109, 103, 111, 105, 107, 113, 106, 64, 79, 80, 90].contains(keyCode)
+    }
+}

--- a/Tests/VocaMacTests/AppStateHistoryTests.swift
+++ b/Tests/VocaMacTests/AppStateHistoryTests.swift
@@ -1,0 +1,269 @@
+// AppStateHistoryTests.swift
+// VocaMac
+//
+// History, paste-last, cancel, retry, hands-free, and dictionary wiring.
+
+import XCTest
+@testable import VocaMac
+
+@MainActor
+final class AppStateHistoryTests: XCTestCase {
+
+    private let speech = [Float](repeating: 0.2, count: 8_000)
+
+    private func dictate(_ appState: AppState, _ mocks: TestMocks, text: String) async {
+        mocks.whisperService.mockTranscriptionResult = VocaTranscription(
+            text: text, duration: 0.1, detectedLanguage: "en", audioLengthSeconds: 0.5, modelUsed: .tiny
+        )
+        mocks.audioEngine.stopRecordingResult = speech
+        await appState.startRecording()
+        await appState.stopRecordingAndTranscribe()
+    }
+
+    func testDictationIsRecordedInHistory() async {
+        let (appState, mocks) = AppState.makeTestState()
+        mocks.frontmostAppResolver.frontmostApp = RunningAppSnapshot(displayName: "Notes", bundleIdentifier: "com.apple.Notes")
+
+        await dictate(appState, mocks, text: "hello there")
+
+        let entry = appState.historyStore.entries.first
+        XCTAssertEqual(entry?.status, .completed)
+        XCTAssertEqual(entry?.rawText, "hello there")
+        XCTAssertEqual(entry?.finalText, mocks.textInjector.lastInjectedText)
+        XCTAssertEqual(entry?.appName, "Notes")
+    }
+
+    func testHistoryCanBeTurnedOff() async {
+        let (appState, mocks) = AppState.makeTestState()
+        appState.historyEnabled = false
+        await dictate(appState, mocks, text: "private words")
+        XCTAssertTrue(appState.historyStore.entries.isEmpty)
+    }
+
+    func testFailedTranscriptionIsKeptAsFailed() async {
+        let (appState, mocks) = AppState.makeTestState()
+        mocks.whisperService.shouldThrow = true
+        mocks.audioEngine.stopRecordingResult = speech
+        await appState.startRecording()
+        await appState.stopRecordingAndTranscribe()
+
+        XCTAssertEqual(appState.historyStore.entries.first?.status, .failed)
+        XCTAssertEqual(appState.appStatus, .error)
+    }
+
+    func testPasteLastDictationReinjectsTheLastText() async {
+        let (appState, mocks) = AppState.makeTestState()
+        await dictate(appState, mocks, text: "ship it")
+        let delivered = mocks.textInjector.lastInjectedText
+
+        appState.pasteLastDictation()
+
+        XCTAssertEqual(mocks.textInjector.injectCallCount, 2)
+        XCTAssertEqual(mocks.textInjector.lastInjectedText, delivered)
+    }
+
+    func testPasteLastWithNothingDictatedShowsAMessage() {
+        let (appState, mocks) = AppState.makeTestState()
+        appState.pasteLastDictation()
+        XCTAssertEqual(mocks.textInjector.injectCallCount, 0)
+        XCTAssertEqual(appState.appStatus, .error)
+    }
+
+    func testShortcutActionsRouteToHandlers() async {
+        let (appState, mocks) = AppState.makeTestState()
+        await dictate(appState, mocks, text: "again please")
+        await appState.handleShortcut(.pasteLastDictation)
+        XCTAssertEqual(mocks.textInjector.injectCallCount, 2)
+    }
+
+    func testShortcutsAndMouseAreSyncedToTheListener() {
+        let (appState, mocks) = AppState.makeTestState()
+        XCTAssertEqual(mocks.hotKeyManager.shortcuts[.pasteLastDictation], .defaultPasteLast)
+        XCTAssertNil(mocks.hotKeyManager.shortcuts[.handsFreeToggle])
+
+        appState.setShortcut(HotKeyCombo(keyCode: 49, modifiers: .option), for: .handsFreeToggle)
+        appState.setShortcut(nil, for: .pasteLastDictation)
+        appState.mouseTriggerButton = MouseTriggerButton.back.rawValue
+        appState.syncShortcutConfiguration()
+
+        XCTAssertEqual(mocks.hotKeyManager.shortcuts[.handsFreeToggle], HotKeyCombo(keyCode: 49, modifiers: .option))
+        XCTAssertNil(mocks.hotKeyManager.shortcuts[.pasteLastDictation])
+        XCTAssertEqual(mocks.hotKeyManager.mouseTriggerButton, 3)
+    }
+
+    func testEscapeIsArmedOnlyWhileRecording() async {
+        let (appState, mocks) = AppState.makeTestState()
+        XCTAssertFalse(mocks.hotKeyManager.isCancelKeyArmed)
+        await appState.startRecording()
+        XCTAssertTrue(mocks.hotKeyManager.isCancelKeyArmed)
+
+        await appState.cancelDictation()
+        XCTAssertFalse(appState.isRecording)
+        XCTAssertEqual(appState.appStatus, .idle)
+        XCTAssertFalse(mocks.hotKeyManager.isCancelKeyArmed)
+        XCTAssertNil(mocks.whisperService.lastTranscribedAudioData, "Cancelled audio is never transcribed")
+        XCTAssertTrue(appState.historyStore.entries.isEmpty)
+    }
+
+    func testEscapeStaysOffWhenDisabled() async {
+        let (appState, mocks) = AppState.makeTestState()
+        appState.escapeCancelsDictation = false
+        await appState.startRecording()
+        XCTAssertFalse(mocks.hotKeyManager.isCancelKeyArmed)
+        await appState.cancelRecording()
+    }
+
+    func testHandsFreeToggleStartsAndStops() async {
+        let (appState, mocks) = AppState.makeTestState()
+        mocks.audioEngine.stopRecordingResult = speech
+
+        await appState.toggleHandsFreeDictation()
+        XCTAssertTrue(appState.isRecording)
+
+        await appState.toggleHandsFreeDictation()
+        XCTAssertFalse(appState.isRecording)
+        XCTAssertEqual(mocks.textInjector.injectCallCount, 1)
+    }
+
+    func testHandsFreeSessionStopsOnSilenceInPushToTalkMode() async {
+        let (appState, mocks) = AppState.makeTestState()
+        appState.activationMode = .pushToTalk
+        mocks.audioEngine.stopRecordingResult = speech
+        await appState.toggleHandsFreeDictation()
+
+        mocks.audioEngine.onSilenceDetected?()
+        for _ in 0..<50 where appState.isRecording {
+            try? await Task.sleep(nanoseconds: 10_000_000)
+        }
+        XCTAssertFalse(appState.isRecording)
+    }
+
+    func testRetryTranscribesSavedAudioAgain() async throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("VocaMacRetry-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let store = DictationHistoryStore(directory: directory)
+        let (appState, mocks) = AppState.makeTestState(historyStore: store)
+
+        mocks.whisperService.shouldThrow = true
+        mocks.audioEngine.stopRecordingResult = speech
+        await appState.startRecording()
+        await appState.stopRecordingAndTranscribe()
+        let failed = try XCTUnwrap(appState.recoverableHistoryEntry)
+
+        mocks.whisperService.shouldThrow = false
+        mocks.whisperService.mockTranscriptionResult = VocaTranscription(
+            text: "second time lucky", duration: 0.1, detectedLanguage: "en", audioLengthSeconds: 0.5, modelUsed: .tiny
+        )
+        let text = await appState.retryHistoryEntry(failed.id)
+
+        XCTAssertNotNil(text)
+        XCTAssertEqual(mocks.whisperService.lastTranscribedAudioData?.count, speech.count)
+        XCTAssertEqual(store.entry(id: failed.id)?.status, .completed)
+        XCTAssertEqual(store.entry(id: failed.id)?.retryCount, 1)
+        XCTAssertNil(appState.recoverableHistoryEntry)
+    }
+
+    func testDismissingRecoveryKeepsTheEntry() async throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("VocaMacDismiss-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let (appState, mocks) = AppState.makeTestState(historyStore: DictationHistoryStore(directory: directory))
+        mocks.whisperService.shouldThrow = true
+        mocks.audioEngine.stopRecordingResult = speech
+        await appState.startRecording()
+        await appState.stopRecordingAndTranscribe()
+
+        let entry = try XCTUnwrap(appState.recoverableHistoryEntry)
+        appState.dismissRecovery(entry.id)
+        XCTAssertNil(appState.recoverableHistoryEntry)
+        XCTAssertNotNil(appState.historyStore.entry(id: entry.id))
+    }
+
+    // MARK: Dictionary
+
+    func testReplacementsApplyToDictation() async {
+        let (appState, mocks) = AppState.makeTestState()
+        appState.addWordReplacement(heard: "get hub", replacement: "GitHub")
+        await dictate(appState, mocks, text: "push it to get hub")
+        XCTAssertTrue(mocks.textInjector.lastInjectedText?.contains("GitHub") == true,
+                      mocks.textInjector.lastInjectedText ?? "")
+        XCTAssertEqual(appState.historyStore.entries.first?.rawText, "push it to get hub")
+    }
+
+    func testVocabularyAppliesForEveryEngine() async {
+        let (appState, mocks) = AppState.makeTestState()
+        appState.addVocabularyTerm("VocaMac")
+        await dictate(appState, mocks, text: "I use voca mac daily")
+        XCTAssertTrue(mocks.textInjector.lastInjectedText?.contains("VocaMac") == true,
+                      mocks.textInjector.lastInjectedText ?? "")
+    }
+
+    func testScreenContextSpellsIdentifiersInCodeApps() async {
+        let reader = MockScreenContextReader()
+        reader.text = "let userId = request.userId"
+        let (appState, mocks) = AppState.makeTestState(screenContextReader: reader)
+        appState.writingStyleDefault = .code
+        await dictate(appState, mocks, text: "log the user id")
+        XCTAssertEqual(reader.captureCallCount, 1)
+        XCTAssertTrue(mocks.textInjector.lastInjectedText?.contains("userId") == true,
+                      mocks.textInjector.lastInjectedText ?? "")
+    }
+
+    func testScreenContextCanBeTurnedOff() async {
+        let reader = MockScreenContextReader()
+        let (appState, mocks) = AppState.makeTestState(screenContextReader: reader)
+        appState.useScreenContext = false
+        await dictate(appState, mocks, text: "anything")
+        XCTAssertEqual(reader.captureCallCount, 0)
+    }
+
+    func testInjectedTextIsWatchedForCorrections() async {
+        let observer = MockCorrectionObserver()
+        let (appState, mocks) = AppState.makeTestState(correctionObserver: observer)
+        await dictate(appState, mocks, text: "first")
+        await appState.startRecording()
+        XCTAssertGreaterThanOrEqual(observer.flushCallCount, 2, "Each new dictation flushes the last one")
+        await appState.cancelRecording()
+    }
+
+    func testSuggestionsCanBeAcceptedOrDismissed() {
+        let (appState, _) = AppState.makeTestState()
+        appState._receiveCorrectionsForTesting([
+            .init(heard: "Namratha", corrected: "Namrata"),
+            .init(heard: "github", corrected: "GitHub"),
+        ])
+        XCTAssertEqual(appState.dictionarySuggestions.count, 2)
+
+        let namrata = appState.dictionarySuggestions.first { $0.corrected == "Namrata" }!
+        appState.acceptDictionarySuggestion(namrata)
+        XCTAssertTrue(appState.vocabularyTerms.contains("Namrata"))
+        XCTAssertEqual(appState.wordReplacements.first?.heard, "Namratha")
+
+        let github = appState.dictionarySuggestions.first { $0.corrected == "GitHub" }!
+        appState.dismissDictionarySuggestion(github)
+        XCTAssertTrue(appState.dictionarySuggestions.isEmpty)
+
+        // A dismissed fix isn't suggested again.
+        appState._receiveCorrectionsForTesting([.init(heard: "github", corrected: "GitHub")])
+        XCTAssertTrue(appState.dictionarySuggestions.isEmpty)
+    }
+
+    func testAutomaticLearningAddsWordsDirectly() {
+        let (appState, _) = AppState.makeTestState()
+        appState.learnCorrectionsMode = .automatic
+        appState._receiveCorrectionsForTesting([.init(heard: "github", corrected: "GitHub")])
+        XCTAssertTrue(appState.dictionarySuggestions.isEmpty)
+        XCTAssertEqual(appState.vocabularyTerms, ["GitHub"])
+        XCTAssertTrue(appState.wordReplacements.isEmpty, "A casing fix needs no replacement")
+    }
+
+    func testVocabularyTermsDeduplicateIgnoringCase() {
+        let (appState, _) = AppState.makeTestState()
+        appState.addVocabularyTerm("github")
+        appState.addVocabularyTerm("GitHub")
+        XCTAssertEqual(appState.vocabularyTerms, ["GitHub"])
+        appState.removeVocabularyTerm("GitHub")
+        XCTAssertTrue(appState.vocabularyTerms.isEmpty)
+    }
+}

--- a/Tests/VocaMacTests/AppStateHistoryTests.swift
+++ b/Tests/VocaMacTests/AppStateHistoryTests.swift
@@ -33,6 +33,22 @@ final class AppStateHistoryTests: XCTestCase {
         XCTAssertEqual(entry?.appName, "Notes")
     }
 
+    func testHistoryDefaultsToTextWithoutSuccessfulAudio() async throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("VocaMacHistoryDefaults-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let (appState, mocks) = AppState.makeTestState(historyStore: DictationHistoryStore(directory: directory))
+
+        XCTAssertTrue(appState.historyEnabled)
+        XCTAssertFalse(appState.historyKeepsAudio)
+
+        await dictate(appState, mocks, text: "keep the words")
+
+        let entry = try XCTUnwrap(appState.historyStore.entries.first)
+        XCTAssertEqual(entry.finalText, mocks.textInjector.lastInjectedText)
+        XCTAssertFalse(entry.hasAudio)
+    }
+
     func testHistoryCanBeTurnedOff() async {
         let (appState, mocks) = AppState.makeTestState()
         appState.historyEnabled = false

--- a/Tests/VocaMacTests/CorrectionLearnerTests.swift
+++ b/Tests/VocaMacTests/CorrectionLearnerTests.swift
@@ -1,0 +1,97 @@
+// CorrectionLearnerTests.swift
+// VocaMac
+
+import XCTest
+@testable import VocaMac
+
+final class CorrectionLearnerTests: XCTestCase {
+
+    private let isKnown: (String) -> Bool = { TestWords.common.contains($0.lowercased()) }
+
+    private func learn(_ inserted: String, before: String, after: String, caret: Int? = nil) -> [CorrectionLearner.Correction] {
+        CorrectionLearner.corrections(inserted: inserted, before: before, after: after,
+                                      caretLocation: caret, isKnownWord: isKnown)
+    }
+
+    func testNameSpellingFix() {
+        let corrections = learn("ask Namratha about it", before: "Hi. ask Namratha about it",
+                                after: "Hi. ask Namrata about it")
+        XCTAssertEqual(corrections, [.init(heard: "Namratha", corrected: "Namrata")])
+    }
+
+    func testCasingAndJoiningFix() {
+        XCTAssertEqual(learn("push to git hub", before: "push to git hub", after: "push to GitHub"),
+                       [.init(heard: "git hub", corrected: "GitHub")])
+        XCTAssertEqual(learn("push to github", before: "push to github", after: "push to GitHub"),
+                       [.init(heard: "github", corrected: "GitHub")])
+    }
+
+    func testSentenceCapitalizationIsNotATerm() {
+        XCTAssertTrue(learn("hello world", before: "hello world", after: "Hello world").isEmpty)
+    }
+
+    func testCommonWordSwapIsIgnored() {
+        XCTAssertTrue(learn("put it there", before: "put it there", after: "put it their").isEmpty)
+    }
+
+    func testRewordingIsIgnored() {
+        XCTAssertTrue(learn("that is big", before: "that is big", after: "that is large").isEmpty)
+    }
+
+    func testEditOutsideTheDictationIsIgnored() {
+        XCTAssertTrue(learn("ask Namratha", before: "Dear Bobb, ask Namratha", after: "Dear Bob, ask Namratha").isEmpty)
+    }
+
+    func testTextNotFoundIsIgnored() {
+        XCTAssertTrue(learn("something else", before: "hello", after: "hullo").isEmpty)
+    }
+
+    func testCaretPicksTheCopyJustTyped() {
+        let before = "ask Namratha. ask Namratha"
+        let after = "ask Namratha. ask Namrata"
+        XCTAssertEqual(learn("ask Namratha", before: before, after: after, caret: before.count),
+                       [.init(heard: "Namratha", corrected: "Namrata")])
+        // A caret at the first copy means the second edit wasn't in the dictation.
+        XCTAssertTrue(learn("ask Namratha", before: before, after: after, caret: 12).isEmpty)
+    }
+
+    func testLargeRewriteIsIgnored() {
+        let inserted = "one two three four five six seven eight nine ten eleven twelve thirteen"
+        let after = "uno dos tres cuatro cinco seis siete ocho nueve diez once doce trece"
+        XCTAssertTrue(learn(inserted, before: inserted, after: after).isEmpty)
+    }
+}
+
+final class ScreenContextTermsTests: XCTestCase {
+
+    private let isKnown: (String) -> Bool = { TestWords.common.contains($0.lowercased()) }
+
+    func testExtractsIdentifiersAndNames() {
+        let text = """
+        func loadUser(userId: String) { let max_retries = 3 }
+        Ping Namrata about the GitHub and OpenAI keys in api-client.
+        """
+        let terms = ScreenContextTerms.extract(from: text, isKnownWord: isKnown)
+        XCTAssertTrue(terms.contains("loadUser"))
+        XCTAssertTrue(terms.contains("userId"))
+        XCTAssertTrue(terms.contains("max_retries"))
+        XCTAssertTrue(terms.contains("Namrata"))
+        XCTAssertTrue(terms.contains("GitHub"))
+        XCTAssertTrue(terms.contains("OpenAI"))
+        XCTAssertTrue(terms.contains("api-client"))
+    }
+
+    func testSkipsSentenceStartsAndOrdinaryCapitalizedWords() {
+        let terms = ScreenContextTerms.extract(from: "Tomorrow we ship. Check the Apple notes.", isKnownWord: isKnown)
+        XCTAssertFalse(terms.contains("Tomorrow"))
+        XCTAssertFalse(terms.contains("Check"))
+        XCTAssertFalse(terms.contains("Apple"))
+    }
+
+    func testDeduplicatesAndCaps() {
+        let text = (0..<400).map { "varName\($0)" }.joined(separator: " ") + " varName0"
+        let terms = ScreenContextTerms.extract(from: text, isKnownWord: isKnown)
+        XCTAssertEqual(terms.count, ScreenContextTerms.maximumTerms)
+        XCTAssertEqual(terms.first, "varName0")
+    }
+}

--- a/Tests/VocaMacTests/DictationHistoryStoreTests.swift
+++ b/Tests/VocaMacTests/DictationHistoryStoreTests.swift
@@ -25,7 +25,7 @@ final class DictationHistoryStoreTests: XCTestCase {
 
     func testCompletedDictationKeepsTextAndAudio() async throws {
         let store = DictationHistoryStore(directory: directory)
-        let id = store.begin(audio: audio, target: target, modelID: "tiny", language: "en", audioSeconds: 1)
+        let id = await store.begin(audio: audio, target: target, modelID: "tiny", language: "en", audioSeconds: 1)
         XCTAssertEqual(store.entry(id: id)?.status, .pending)
 
         store.complete(id, rawText: "hello world", finalText: "Hello world. ", summary: "Formatting only",
@@ -44,7 +44,7 @@ final class DictationHistoryStoreTests: XCTestCase {
 
     func testAudioIsDroppedOnSuccessWhenNotKept() async {
         let store = DictationHistoryStore(directory: directory)
-        let id = store.begin(audio: audio, target: nil, modelID: "tiny", language: nil, audioSeconds: 1)
+        let id = await store.begin(audio: audio, target: nil, modelID: "tiny", language: nil, audioSeconds: 1)
         store.complete(id, rawText: "hi", finalText: "Hi", summary: nil, language: nil,
                        transcriptionSeconds: nil, keepAudio: false)
         XCTAssertFalse(store.entry(id: id)?.hasAudio ?? true)
@@ -53,15 +53,15 @@ final class DictationHistoryStoreTests: XCTestCase {
         XCTAssertTrue(files.isEmpty)
     }
 
-    func testFailedDictationIsRecoverable() {
+    func testFailedDictationIsRecoverable() async {
         let store = DictationHistoryStore(directory: directory)
-        let id = store.begin(audio: audio, target: nil, modelID: "tiny", language: nil, audioSeconds: 1)
+        let id = await store.begin(audio: audio, target: nil, modelID: "tiny", language: nil, audioSeconds: 1)
         store.markFailed(id, message: "decoder exploded")
         XCTAssertEqual(store.latestRecoverableEntry?.id, id)
         XCTAssertEqual(store.entry(id: id)?.errorMessage, "decoder exploded")
 
         // A later success supersedes it.
-        let next = store.begin(audio: audio, target: nil, modelID: "tiny", language: nil, audioSeconds: 1)
+        let next = await store.begin(audio: audio, target: nil, modelID: "tiny", language: nil, audioSeconds: 1)
         store.complete(next, rawText: "ok", finalText: "Ok", summary: nil, language: nil,
                        transcriptionSeconds: nil, keepAudio: true)
         XCTAssertNil(store.latestRecoverableEntry)
@@ -69,7 +69,7 @@ final class DictationHistoryStoreTests: XCTestCase {
 
     func testPendingEntryBecomesInterruptedAfterRelaunch() async {
         let store = DictationHistoryStore(directory: directory)
-        let id = store.begin(audio: audio, target: nil, modelID: "tiny", language: nil, audioSeconds: 1)
+        let id = await store.begin(audio: audio, target: nil, modelID: "tiny", language: nil, audioSeconds: 1)
         await store.waitForPendingWrites()
 
         let relaunched = DictationHistoryStore(directory: directory)
@@ -77,9 +77,9 @@ final class DictationHistoryStoreTests: XCTestCase {
         XCTAssertEqual(relaunched.latestRecoverableEntry?.id, id)
     }
 
-    func testRetryUpdatesEntry() {
+    func testRetryUpdatesEntry() async {
         let store = DictationHistoryStore(directory: nil)
-        let id = store.begin(audio: nil, target: nil, modelID: "tiny", language: nil, audioSeconds: 1)
+        let id = await store.begin(audio: nil, target: nil, modelID: "tiny", language: nil, audioSeconds: 1)
         store.markFailed(id, message: "boom")
         store.recordRetry(id, rawText: "fixed", finalText: "Fixed", summary: nil, language: "en",
                           modelID: "parakeet", transcriptionSeconds: 0.2)
@@ -90,21 +90,21 @@ final class DictationHistoryStoreTests: XCTestCase {
         XCTAssertNil(entry?.errorMessage)
     }
 
-    func testCancelOnlyAffectsPendingEntries() {
+    func testCancelOnlyAffectsPendingEntries() async {
         let store = DictationHistoryStore(directory: nil)
-        let id = store.begin(audio: nil, target: nil, modelID: "tiny", language: nil, audioSeconds: 1)
+        let id = await store.begin(audio: nil, target: nil, modelID: "tiny", language: nil, audioSeconds: 1)
         store.complete(id, rawText: "done", finalText: "Done", summary: nil, language: nil,
                        transcriptionSeconds: nil, keepAudio: true)
         store.markCancelled(id)
         XCTAssertEqual(store.entry(id: id)?.status, .completed)
     }
 
-    func testRetentionDeletesOldEntries() {
+    func testRetentionDeletesOldEntries() async {
         let store = DictationHistoryStore(directory: nil)
         let now = Date()
-        let old = store.begin(audio: nil, target: nil, modelID: "tiny", language: nil, audioSeconds: 1,
+        let old = await store.begin(audio: nil, target: nil, modelID: "tiny", language: nil, audioSeconds: 1,
                               now: now.addingTimeInterval(-3 * 24 * 60 * 60))
-        let recent = store.begin(audio: nil, target: nil, modelID: "tiny", language: nil, audioSeconds: 1, now: now)
+        let recent = await store.begin(audio: nil, target: nil, modelID: "tiny", language: nil, audioSeconds: 1, now: now)
         store.applyRetention(.day, now: now)
         XCTAssertNil(store.entry(id: old))
         XCTAssertNotNil(store.entry(id: recent))
@@ -113,12 +113,12 @@ final class DictationHistoryStoreTests: XCTestCase {
         XCTAssertNotNil(store.entry(id: recent))
     }
 
-    func testSearchMatchesEveryWord() {
+    func testSearchMatchesEveryWord() async {
         let store = DictationHistoryStore(directory: nil)
-        let first = store.begin(audio: nil, target: target, modelID: "tiny", language: nil, audioSeconds: 1)
+        let first = await store.begin(audio: nil, target: target, modelID: "tiny", language: nil, audioSeconds: 1)
         store.complete(first, rawText: "ship the release", finalText: "Ship the release.", summary: nil,
                        language: nil, transcriptionSeconds: nil, keepAudio: true)
-        let second = store.begin(audio: nil, target: nil, modelID: "tiny", language: nil, audioSeconds: 1)
+        let second = await store.begin(audio: nil, target: nil, modelID: "tiny", language: nil, audioSeconds: 1)
         store.complete(second, rawText: "lunch plans", finalText: "Lunch plans.", summary: nil,
                        language: nil, transcriptionSeconds: nil, keepAudio: true)
 
@@ -130,7 +130,7 @@ final class DictationHistoryStoreTests: XCTestCase {
 
     func testDeleteAllRemovesEntriesAndAudio() async {
         let store = DictationHistoryStore(directory: directory)
-        store.begin(audio: audio, target: nil, modelID: "tiny", language: nil, audioSeconds: 1)
+        await store.begin(audio: audio, target: nil, modelID: "tiny", language: nil, audioSeconds: 1)
         store.deleteAll()
         await store.waitForPendingWrites()
         XCTAssertTrue(store.entries.isEmpty)
@@ -144,6 +144,55 @@ final class DictationHistoryStoreTests: XCTestCase {
         XCTAssertTrue(entry.hasEditedOutput)
         entry.finalText = "Um gonna ship it."
         XCTAssertFalse(entry.hasEditedOutput)
+    }
+
+    func testFailedAudioWriteIsNotAdvertised() async throws {
+        // A file where the audio folder should be makes the write fail.
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        try Data().write(to: directory.appendingPathComponent("audio"))
+        let store = DictationHistoryStore(directory: directory)
+
+        let id = await store.begin(audio: audio, target: nil, modelID: "tiny", language: nil, audioSeconds: 1)
+
+        XCTAssertNotNil(store.entry(id: id))
+        XCTAssertFalse(store.entry(id: id)?.hasAudio ?? true)
+    }
+
+    func testUnindexedAudioIsRecoveredAsInterrupted() async throws {
+        // VocaMac stopped after writing the audio but before the index.
+        let folder = directory.appendingPathComponent("audio", isDirectory: true)
+        try FileManager.default.createDirectory(at: folder, withIntermediateDirectories: true)
+        let id = UUID()
+        try FailedAudioDump.wavData(from: audio, sampleRate: 16_000)
+            .write(to: folder.appendingPathComponent("\(id.uuidString).wav"))
+
+        let store = DictationHistoryStore(directory: directory)
+
+        let entry = try XCTUnwrap(store.entry(id: id))
+        XCTAssertEqual(entry.status, .interrupted)
+        XCTAssertTrue(entry.hasAudio)
+        XCTAssertEqual(entry.audioSeconds, 1, accuracy: 0.01)
+        XCTAssertEqual(store.latestRecoverableEntry?.id, id)
+        let samples = try await store.loadAudio(for: entry)
+        XCTAssertEqual(samples.count, audio.count)
+    }
+
+    func testMissingAudioFileIsNotAdvertisedAfterRelaunch() async throws {
+        let store = DictationHistoryStore(directory: directory)
+        let id = await store.begin(audio: audio, target: nil, modelID: "tiny", language: nil, audioSeconds: 1)
+        await store.waitForPendingWrites()
+        try FileManager.default.removeItem(at: XCTUnwrap(store.audioURL(for: XCTUnwrap(store.entry(id: id)))))
+
+        let relaunched = DictationHistoryStore(directory: directory)
+        XCTAssertNotNil(relaunched.entry(id: id))
+        XCTAssertFalse(relaunched.entry(id: id)?.hasAudio ?? true)
+    }
+
+    func testAudioIsOnDiskWhenBeginReturns() async throws {
+        let store = DictationHistoryStore(directory: directory)
+        let id = await store.begin(audio: audio, target: nil, modelID: "tiny", language: nil, audioSeconds: 1)
+        let url = try XCTUnwrap(store.audioURL(for: XCTUnwrap(store.entry(id: id))))
+        XCTAssertTrue(FileManager.default.fileExists(atPath: url.path))
     }
 
     func testRetentionResolvesUnknownValues() {

--- a/Tests/VocaMacTests/DictationHistoryStoreTests.swift
+++ b/Tests/VocaMacTests/DictationHistoryStoreTests.swift
@@ -398,6 +398,29 @@ final class DictationHistoryStoreTests: XCTestCase {
         XCTAssertEqual(DictationHistoryStore(directory: directory).entry(id: id)?.status, .failed)
     }
 
+    func testRetentionWithAFailingJournalNeverRestoresExpiredEntries() async throws {
+        let store = DictationHistoryStore(directory: directory)
+        let now = Date()
+        let old = now.addingTimeInterval(-10 * 24 * 60 * 60)
+        let first = await store.begin(audio: audio, target: nil, modelID: "tiny", language: nil, audioSeconds: 1, now: old)
+        let second = await store.begin(audio: audio, target: nil, modelID: "tiny", language: nil, audioSeconds: 1, now: old)
+        let recent = await store.begin(audio: nil, target: nil, modelID: "tiny", language: nil, audioSeconds: 1, now: now)
+        await store.waitForPendingWrites()
+        // The journal can't be appended to, but the index can be rewritten.
+        let journal = directory.appendingPathComponent("journal.jsonl")
+        try? FileManager.default.removeItem(at: journal)
+        try FileManager.default.createDirectory(at: journal, withIntermediateDirectories: true)
+
+        store.applyRetention(.week, now: now)
+        await store.waitForPendingWrites()
+        try FileManager.default.removeItem(at: journal)
+
+        let relaunched = DictationHistoryStore(directory: directory)
+        XCTAssertEqual(relaunched.entries.map(\.id), [recent])
+        XCTAssertNil(relaunched.entry(id: first))
+        XCTAssertNil(relaunched.entry(id: second))
+    }
+
     func testDeletionsSucceedInMemory() async {
         let store = DictationHistoryStore(directory: nil)
         let id = await store.begin(audio: nil, target: nil, modelID: "tiny", language: nil, audioSeconds: 1)

--- a/Tests/VocaMacTests/DictationHistoryStoreTests.swift
+++ b/Tests/VocaMacTests/DictationHistoryStoreTests.swift
@@ -1,0 +1,153 @@
+// DictationHistoryStoreTests.swift
+// VocaMac
+
+import XCTest
+@testable import VocaMac
+
+@MainActor
+final class DictationHistoryStoreTests: XCTestCase {
+
+    private var directory: URL!
+
+    override func setUp() {
+        super.setUp()
+        directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("VocaMacHistoryTests-\(UUID().uuidString)", isDirectory: true)
+    }
+
+    override func tearDown() {
+        try? FileManager.default.removeItem(at: directory)
+        super.tearDown()
+    }
+
+    private let target = RunningAppSnapshot(displayName: "Notes", bundleIdentifier: "com.apple.Notes")
+    private let audio = [Float](repeating: 0.25, count: 16_000)
+
+    func testCompletedDictationKeepsTextAndAudio() async throws {
+        let store = DictationHistoryStore(directory: directory)
+        let id = store.begin(audio: audio, target: target, modelID: "tiny", language: "en", audioSeconds: 1)
+        XCTAssertEqual(store.entry(id: id)?.status, .pending)
+
+        store.complete(id, rawText: "hello world", finalText: "Hello world. ", summary: "Formatting only",
+                       language: "en", transcriptionSeconds: 0.3, keepAudio: true)
+
+        let entry = try XCTUnwrap(store.entry(id: id))
+        XCTAssertEqual(entry.status, .completed)
+        XCTAssertEqual(entry.appName, "Notes")
+        XCTAssertEqual(entry.displayText, "Hello world.")
+        XCTAssertFalse(entry.hasEditedOutput, "Case and punctuation alone aren't an edit")
+        XCTAssertEqual(store.latestDeliveredText, "Hello world. ")
+
+        let samples = try await store.loadAudio(for: entry)
+        XCTAssertEqual(samples.count, audio.count)
+    }
+
+    func testAudioIsDroppedOnSuccessWhenNotKept() async {
+        let store = DictationHistoryStore(directory: directory)
+        let id = store.begin(audio: audio, target: nil, modelID: "tiny", language: nil, audioSeconds: 1)
+        store.complete(id, rawText: "hi", finalText: "Hi", summary: nil, language: nil,
+                       transcriptionSeconds: nil, keepAudio: false)
+        XCTAssertFalse(store.entry(id: id)?.hasAudio ?? true)
+        await store.waitForPendingWrites()
+        let files = (try? FileManager.default.contentsOfDirectory(atPath: store.audioDirectory!.path)) ?? []
+        XCTAssertTrue(files.isEmpty)
+    }
+
+    func testFailedDictationIsRecoverable() {
+        let store = DictationHistoryStore(directory: directory)
+        let id = store.begin(audio: audio, target: nil, modelID: "tiny", language: nil, audioSeconds: 1)
+        store.markFailed(id, message: "decoder exploded")
+        XCTAssertEqual(store.latestRecoverableEntry?.id, id)
+        XCTAssertEqual(store.entry(id: id)?.errorMessage, "decoder exploded")
+
+        // A later success supersedes it.
+        let next = store.begin(audio: audio, target: nil, modelID: "tiny", language: nil, audioSeconds: 1)
+        store.complete(next, rawText: "ok", finalText: "Ok", summary: nil, language: nil,
+                       transcriptionSeconds: nil, keepAudio: true)
+        XCTAssertNil(store.latestRecoverableEntry)
+    }
+
+    func testPendingEntryBecomesInterruptedAfterRelaunch() async {
+        let store = DictationHistoryStore(directory: directory)
+        let id = store.begin(audio: audio, target: nil, modelID: "tiny", language: nil, audioSeconds: 1)
+        await store.waitForPendingWrites()
+
+        let relaunched = DictationHistoryStore(directory: directory)
+        XCTAssertEqual(relaunched.entry(id: id)?.status, .interrupted)
+        XCTAssertEqual(relaunched.latestRecoverableEntry?.id, id)
+    }
+
+    func testRetryUpdatesEntry() {
+        let store = DictationHistoryStore(directory: nil)
+        let id = store.begin(audio: nil, target: nil, modelID: "tiny", language: nil, audioSeconds: 1)
+        store.markFailed(id, message: "boom")
+        store.recordRetry(id, rawText: "fixed", finalText: "Fixed", summary: nil, language: "en",
+                          modelID: "parakeet", transcriptionSeconds: 0.2)
+        let entry = store.entry(id: id)
+        XCTAssertEqual(entry?.status, .completed)
+        XCTAssertEqual(entry?.retryCount, 1)
+        XCTAssertEqual(entry?.modelID, "parakeet")
+        XCTAssertNil(entry?.errorMessage)
+    }
+
+    func testCancelOnlyAffectsPendingEntries() {
+        let store = DictationHistoryStore(directory: nil)
+        let id = store.begin(audio: nil, target: nil, modelID: "tiny", language: nil, audioSeconds: 1)
+        store.complete(id, rawText: "done", finalText: "Done", summary: nil, language: nil,
+                       transcriptionSeconds: nil, keepAudio: true)
+        store.markCancelled(id)
+        XCTAssertEqual(store.entry(id: id)?.status, .completed)
+    }
+
+    func testRetentionDeletesOldEntries() {
+        let store = DictationHistoryStore(directory: nil)
+        let now = Date()
+        let old = store.begin(audio: nil, target: nil, modelID: "tiny", language: nil, audioSeconds: 1,
+                              now: now.addingTimeInterval(-3 * 24 * 60 * 60))
+        let recent = store.begin(audio: nil, target: nil, modelID: "tiny", language: nil, audioSeconds: 1, now: now)
+        store.applyRetention(.day, now: now)
+        XCTAssertNil(store.entry(id: old))
+        XCTAssertNotNil(store.entry(id: recent))
+
+        store.applyRetention(.forever, now: now.addingTimeInterval(1_000_000))
+        XCTAssertNotNil(store.entry(id: recent))
+    }
+
+    func testSearchMatchesEveryWord() {
+        let store = DictationHistoryStore(directory: nil)
+        let first = store.begin(audio: nil, target: target, modelID: "tiny", language: nil, audioSeconds: 1)
+        store.complete(first, rawText: "ship the release", finalText: "Ship the release.", summary: nil,
+                       language: nil, transcriptionSeconds: nil, keepAudio: true)
+        let second = store.begin(audio: nil, target: nil, modelID: "tiny", language: nil, audioSeconds: 1)
+        store.complete(second, rawText: "lunch plans", finalText: "Lunch plans.", summary: nil,
+                       language: nil, transcriptionSeconds: nil, keepAudio: true)
+
+        XCTAssertEqual(store.search("release ship").map(\.id), [first])
+        XCTAssertEqual(store.search("notes").map(\.id), [first])
+        XCTAssertEqual(store.search("").count, 2)
+        XCTAssertTrue(store.search("nothing").isEmpty)
+    }
+
+    func testDeleteAllRemovesEntriesAndAudio() async {
+        let store = DictationHistoryStore(directory: directory)
+        store.begin(audio: audio, target: nil, modelID: "tiny", language: nil, audioSeconds: 1)
+        store.deleteAll()
+        await store.waitForPendingWrites()
+        XCTAssertTrue(store.entries.isEmpty)
+        XCTAssertFalse(FileManager.default.fileExists(atPath: store.audioDirectory!.path))
+        XCTAssertTrue(DictationHistoryStore(directory: directory).entries.isEmpty)
+    }
+
+    func testEditedOutputDetection() {
+        var entry = DictationHistoryEntry(rawText: "um gonna ship it", finalText: "Going to ship it.",
+                                          modelID: "tiny", audioSeconds: 1)
+        XCTAssertTrue(entry.hasEditedOutput)
+        entry.finalText = "Um gonna ship it."
+        XCTAssertFalse(entry.hasEditedOutput)
+    }
+
+    func testRetentionResolvesUnknownValues() {
+        XCTAssertEqual(HistoryRetention.resolved(stored: "bogus"), .month)
+        XCTAssertEqual(HistoryRetention.resolved(stored: "week"), .week)
+    }
+}

--- a/Tests/VocaMacTests/DictationHistoryStoreTests.swift
+++ b/Tests/VocaMacTests/DictationHistoryStoreTests.swift
@@ -347,6 +347,57 @@ final class DictationHistoryStoreTests: XCTestCase {
         XCTAssertTrue(FileManager.default.fileExists(atPath: url.path))
     }
 
+    func testEntryThatCantBeSavedWritesNoAudio() async throws {
+        let store = DictationHistoryStore(directory: directory)
+        try blockHistoryWrites()
+
+        let id = await store.begin(audio: audio, target: nil, modelID: "tiny", language: nil, audioSeconds: 1)
+        await store.waitForPendingWrites()
+
+        XCTAssertNil(store.entry(id: id), "The dictation carries on without history")
+        let audioFile = directory.appendingPathComponent("audio").appendingPathComponent("\(id.uuidString).wav")
+        XCTAssertFalse(FileManager.default.fileExists(atPath: audioFile.path),
+                       "No recording is written that no saved entry owns")
+        XCTAssertFalse(store.hasUnsavedChanges)
+    }
+
+    func testRefusedCompletionIsSavedOnceTheDiskRecovers() async throws {
+        let store = DictationHistoryStore(directory: directory)
+        let id = await store.begin(audio: nil, target: nil, modelID: "tiny", language: nil, audioSeconds: 1)
+        try blockHistoryWrites()
+
+        store.complete(id, rawText: "kept", finalText: "Kept", summary: nil, language: nil,
+                       transcriptionSeconds: nil, keepAudio: true)
+        XCTAssertTrue(store.hasUnsavedChanges)
+        XCTAssertEqual(store.entry(id: id)?.status, .completed, "The completion stays on screen")
+
+        for name in ["journal.jsonl", "index.json"] {
+            try FileManager.default.removeItem(at: directory.appendingPathComponent(name))
+        }
+        store.saveIfNeeded()
+        XCTAssertFalse(store.hasUnsavedChanges)
+
+        let relaunched = DictationHistoryStore(directory: directory)
+        XCTAssertEqual(relaunched.entry(id: id)?.status, .completed)
+        XCTAssertEqual(relaunched.entry(id: id)?.finalText, "Kept")
+    }
+
+    func testNextSaveRewritesEverythingAfterARefusal() async throws {
+        let store = DictationHistoryStore(directory: directory)
+        let id = await store.begin(audio: nil, target: nil, modelID: "tiny", language: nil, audioSeconds: 1)
+        try blockHistoryWrites()
+        store.markFailed(id, message: "boom")
+        for name in ["journal.jsonl", "index.json"] {
+            try FileManager.default.removeItem(at: directory.appendingPathComponent(name))
+        }
+
+        // An unrelated change saves the refused one too.
+        _ = await store.begin(audio: nil, target: nil, modelID: "tiny", language: nil, audioSeconds: 1)
+
+        XCTAssertFalse(store.hasUnsavedChanges)
+        XCTAssertEqual(DictationHistoryStore(directory: directory).entry(id: id)?.status, .failed)
+    }
+
     func testDeletionsSucceedInMemory() async {
         let store = DictationHistoryStore(directory: nil)
         let id = await store.begin(audio: nil, target: nil, modelID: "tiny", language: nil, audioSeconds: 1)

--- a/Tests/VocaMacTests/DictationHistoryStoreTests.swift
+++ b/Tests/VocaMacTests/DictationHistoryStoreTests.swift
@@ -195,6 +195,47 @@ final class DictationHistoryStoreTests: XCTestCase {
         XCTAssertTrue(FileManager.default.fileExists(atPath: url.path))
     }
 
+    func testCompletedDictationSurvivesAnImmediateExit() async throws {
+        let store = DictationHistoryStore(directory: directory)
+        let id = await store.begin(audio: audio, target: nil, modelID: "tiny", language: nil, audioSeconds: 1)
+        store.complete(id, rawText: "ship it", finalText: "Ship it. ", summary: nil, language: "en",
+                       transcriptionSeconds: 0.2, keepAudio: true)
+
+        // No waiting: a new instance reads what's on disk right now, as the
+        // next launch would after a crash.
+        let relaunched = DictationHistoryStore(directory: directory)
+        let entry = try XCTUnwrap(relaunched.entry(id: id))
+        XCTAssertEqual(entry.status, .completed)
+        XCTAssertEqual(entry.finalText, "Ship it. ")
+    }
+
+    func testDeletionsAreReplayedFromTheJournal() async {
+        let store = DictationHistoryStore(directory: directory)
+        let kept = await store.begin(audio: nil, target: nil, modelID: "tiny", language: nil, audioSeconds: 1)
+        let removed = await store.begin(audio: nil, target: nil, modelID: "tiny", language: nil, audioSeconds: 1)
+        store.delete(removed)
+
+        let relaunched = DictationHistoryStore(directory: directory)
+        XCTAssertNotNil(relaunched.entry(id: kept))
+        XCTAssertNil(relaunched.entry(id: removed))
+    }
+
+    func testTornJournalLineIsSkipped() async throws {
+        let store = DictationHistoryStore(directory: directory)
+        let id = await store.begin(audio: nil, target: nil, modelID: "tiny", language: nil, audioSeconds: 1)
+        store.complete(id, rawText: "hello", finalText: "Hello", summary: nil, language: nil,
+                       transcriptionSeconds: nil, keepAudio: true)
+        let journal = directory.appendingPathComponent("journal.jsonl")
+        let handle = try FileHandle(forWritingTo: journal)
+        try handle.seekToEnd()
+        try handle.write(contentsOf: Data(#"{"upsert":{"id":"#.utf8))
+        try handle.close()
+
+        let relaunched = DictationHistoryStore(directory: directory)
+        XCTAssertEqual(relaunched.entry(id: id)?.status, .completed)
+        XCTAssertFalse(FileManager.default.fileExists(atPath: journal.path), "Launch folds the journal into the index")
+    }
+
     func testRetentionResolvesUnknownValues() {
         XCTAssertEqual(HistoryRetention.resolved(stored: "bogus"), .month)
         XCTAssertEqual(HistoryRetention.resolved(stored: "week"), .week)

--- a/Tests/VocaMacTests/DictationHistoryStoreTests.swift
+++ b/Tests/VocaMacTests/DictationHistoryStoreTests.swift
@@ -274,6 +274,39 @@ final class DictationHistoryStoreTests: XCTestCase {
         XCTAssertTrue(FileManager.default.fileExists(atPath: directory.appendingPathComponent("index.corrupt.json").path))
     }
 
+    func testAudioIsRemovedOnlyAfterTheDeletionIsSaved() async throws {
+        let store = DictationHistoryStore(directory: directory)
+        let id = await store.begin(audio: audio, target: nil, modelID: "tiny", language: nil, audioSeconds: 1)
+        let url = try XCTUnwrap(store.audioURL(for: XCTUnwrap(store.entry(id: id))))
+        await store.waitForPendingWrites()
+        // Neither the journal nor the index can be written: a directory sits
+        // where each file goes.
+        let journal = directory.appendingPathComponent("journal.jsonl")
+        let index = directory.appendingPathComponent("index.json")
+        try? FileManager.default.removeItem(at: journal)
+        try FileManager.default.createDirectory(at: journal, withIntermediateDirectories: true)
+        try? FileManager.default.removeItem(at: index)
+        try FileManager.default.createDirectory(at: index, withIntermediateDirectories: true)
+
+        store.delete(id)
+        await store.waitForPendingWrites()
+
+        XCTAssertTrue(FileManager.default.fileExists(atPath: url.path),
+                      "A deletion that couldn't be saved must not delete the recording")
+    }
+
+    func testDroppingAudioKeepsTheFileUntilSaved() async throws {
+        let store = DictationHistoryStore(directory: directory)
+        let id = await store.begin(audio: audio, target: nil, modelID: "tiny", language: nil, audioSeconds: 1)
+        let url = try XCTUnwrap(store.audioURL(for: XCTUnwrap(store.entry(id: id))))
+        store.complete(id, rawText: "hi", finalText: "Hi", summary: nil, language: nil,
+                       transcriptionSeconds: nil, keepAudio: false)
+        await store.waitForPendingWrites()
+        XCTAssertFalse(FileManager.default.fileExists(atPath: url.path), "Removed once the completion is saved")
+        let relaunched = DictationHistoryStore(directory: directory)
+        XCTAssertEqual(relaunched.entry(id: id)?.status, .completed)
+    }
+
     func testRetentionResolvesUnknownValues() {
         XCTAssertEqual(HistoryRetention.resolved(stored: "bogus"), .month)
         XCTAssertEqual(HistoryRetention.resolved(stored: "week"), .week)

--- a/Tests/VocaMacTests/DictationHistoryStoreTests.swift
+++ b/Tests/VocaMacTests/DictationHistoryStoreTests.swift
@@ -274,25 +274,85 @@ final class DictationHistoryStoreTests: XCTestCase {
         XCTAssertTrue(FileManager.default.fileExists(atPath: directory.appendingPathComponent("index.corrupt.json").path))
     }
 
-    func testAudioIsRemovedOnlyAfterTheDeletionIsSaved() async throws {
+    /// Make both the journal and the index unwritable: a directory sits
+    /// where each file goes.
+    private func blockHistoryWrites() throws {
+        for name in ["journal.jsonl", "index.json"] {
+            let url = directory.appendingPathComponent(name)
+            try? FileManager.default.removeItem(at: url)
+            try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+        }
+    }
+
+    func testDeleteThatCantBeSavedIsUndone() async throws {
         let store = DictationHistoryStore(directory: directory)
         let id = await store.begin(audio: audio, target: nil, modelID: "tiny", language: nil, audioSeconds: 1)
         let url = try XCTUnwrap(store.audioURL(for: XCTUnwrap(store.entry(id: id))))
         await store.waitForPendingWrites()
-        // Neither the journal nor the index can be written: a directory sits
-        // where each file goes.
-        let journal = directory.appendingPathComponent("journal.jsonl")
-        let index = directory.appendingPathComponent("index.json")
-        try? FileManager.default.removeItem(at: journal)
-        try FileManager.default.createDirectory(at: journal, withIntermediateDirectories: true)
-        try? FileManager.default.removeItem(at: index)
-        try FileManager.default.createDirectory(at: index, withIntermediateDirectories: true)
+        try blockHistoryWrites()
 
-        store.delete(id)
+        XCTAssertFalse(store.delete(id))
         await store.waitForPendingWrites()
 
+        XCTAssertNotNil(store.entry(id: id), "The entry is put back")
+        XCTAssertTrue(store.entry(id: id)?.hasAudio ?? false)
         XCTAssertTrue(FileManager.default.fileExists(atPath: url.path),
                       "A deletion that couldn't be saved must not delete the recording")
+    }
+
+    func testDeleteAllThatCantBeSavedIsUndone() async throws {
+        let store = DictationHistoryStore(directory: directory)
+        let id = await store.begin(audio: audio, target: nil, modelID: "tiny", language: nil, audioSeconds: 1)
+        let url = try XCTUnwrap(store.audioURL(for: XCTUnwrap(store.entry(id: id))))
+        await store.waitForPendingWrites()
+        try blockHistoryWrites()
+
+        XCTAssertFalse(store.deleteAll())
+        await store.waitForPendingWrites()
+
+        XCTAssertEqual(store.entries.map(\.id), [id])
+        XCTAssertTrue(FileManager.default.fileExists(atPath: url.path))
+    }
+
+    func testDeleteAudioThatCantBeSavedIsUndone() async throws {
+        let store = DictationHistoryStore(directory: directory)
+        let id = await store.begin(audio: audio, target: nil, modelID: "tiny", language: nil, audioSeconds: 1)
+        let url = try XCTUnwrap(store.audioURL(for: XCTUnwrap(store.entry(id: id))))
+        await store.waitForPendingWrites()
+        try blockHistoryWrites()
+
+        XCTAssertFalse(store.deleteAllAudio())
+        await store.waitForPendingWrites()
+
+        XCTAssertTrue(store.entry(id: id)?.hasAudio ?? false)
+        XCTAssertTrue(FileManager.default.fileExists(atPath: url.path))
+    }
+
+    func testFailedSaveDoesNotLetALaterSaveDeleteAudio() async throws {
+        let store = DictationHistoryStore(directory: directory)
+        let first = await store.begin(audio: audio, target: nil, modelID: "tiny", language: nil, audioSeconds: 1)
+        let url = try XCTUnwrap(store.audioURL(for: XCTUnwrap(store.entry(id: first))))
+        await store.waitForPendingWrites()
+        try blockHistoryWrites()
+        XCTAssertFalse(store.delete(first))
+
+        // Writes work again; saving something else must not remove the
+        // recording of the deletion that never saved.
+        for name in ["journal.jsonl", "index.json"] {
+            try FileManager.default.removeItem(at: directory.appendingPathComponent(name))
+        }
+        _ = await store.begin(audio: nil, target: nil, modelID: "tiny", language: nil, audioSeconds: 1)
+        await store.waitForPendingWrites()
+
+        XCTAssertTrue(FileManager.default.fileExists(atPath: url.path))
+    }
+
+    func testDeletionsSucceedInMemory() async {
+        let store = DictationHistoryStore(directory: nil)
+        let id = await store.begin(audio: nil, target: nil, modelID: "tiny", language: nil, audioSeconds: 1)
+        XCTAssertTrue(store.delete(id))
+        XCTAssertTrue(store.deleteAll())
+        XCTAssertTrue(store.deleteAllAudio())
     }
 
     func testDroppingAudioKeepsTheFileUntilSaved() async throws {

--- a/Tests/VocaMacTests/DictationHistoryStoreTests.swift
+++ b/Tests/VocaMacTests/DictationHistoryStoreTests.swift
@@ -158,23 +158,46 @@ final class DictationHistoryStoreTests: XCTestCase {
         XCTAssertFalse(store.entry(id: id)?.hasAudio ?? true)
     }
 
-    func testUnindexedAudioIsRecoveredAsInterrupted() async throws {
-        // VocaMac stopped after writing the audio but before the index.
-        let folder = directory.appendingPathComponent("audio", isDirectory: true)
-        try FileManager.default.createDirectory(at: folder, withIntermediateDirectories: true)
-        let id = UUID()
-        try FailedAudioDump.wavData(from: audio, sampleRate: 16_000)
-            .write(to: folder.appendingPathComponent("\(id.uuidString).wav"))
-
+    func testDeletedAudioStaysDeletedAfterAnImmediateExit() async throws {
         let store = DictationHistoryStore(directory: directory)
+        let id = await store.begin(audio: audio, target: nil, modelID: "tiny", language: nil, audioSeconds: 1)
+        let url = try XCTUnwrap(store.audioURL(for: XCTUnwrap(store.entry(id: id))))
+        store.delete(id)
+        await store.waitForPendingWrites()
+        // Simulate VocaMac exiting after the deletion was saved but before
+        // the queued file removal ran.
+        try FailedAudioDump.wavData(from: audio, sampleRate: 16_000).write(to: url)
 
-        let entry = try XCTUnwrap(store.entry(id: id))
+        let relaunched = DictationHistoryStore(directory: directory)
+
+        XCTAssertNil(relaunched.entry(id: id))
+        XCTAssertTrue(relaunched.entries.isEmpty, "Deleted audio must never come back as a dictation")
+        XCTAssertFalse(FileManager.default.fileExists(atPath: url.path))
+    }
+
+    func testAudioFromDeleteAllStaysDeleted() async throws {
+        let store = DictationHistoryStore(directory: directory)
+        let id = await store.begin(audio: audio, target: nil, modelID: "tiny", language: nil, audioSeconds: 1)
+        let url = try XCTUnwrap(store.audioURL(for: XCTUnwrap(store.entry(id: id))))
+        store.deleteAll()
+        await store.waitForPendingWrites()
+        try FileManager.default.createDirectory(at: store.audioDirectory!, withIntermediateDirectories: true)
+        try FailedAudioDump.wavData(from: audio, sampleRate: 16_000).write(to: url)
+
+        XCTAssertTrue(DictationHistoryStore(directory: directory).entries.isEmpty)
+        XCTAssertFalse(FileManager.default.fileExists(atPath: url.path))
+    }
+
+    func testEntryIsJournaledBeforeItsAudioIsWritten() async throws {
+        let store = DictationHistoryStore(directory: directory)
+        let id = await store.begin(audio: audio, target: nil, modelID: "tiny", language: nil, audioSeconds: 1)
+        // A crash during the write: the entry is known, its file isn't there.
+        try FileManager.default.removeItem(at: XCTUnwrap(store.audioURL(for: XCTUnwrap(store.entry(id: id)))))
+
+        let relaunched = DictationHistoryStore(directory: directory)
+        let entry = try XCTUnwrap(relaunched.entry(id: id))
         XCTAssertEqual(entry.status, .interrupted)
-        XCTAssertTrue(entry.hasAudio)
-        XCTAssertEqual(entry.audioSeconds, 1, accuracy: 0.01)
-        XCTAssertEqual(store.latestRecoverableEntry?.id, id)
-        let samples = try await store.loadAudio(for: entry)
-        XCTAssertEqual(samples.count, audio.count)
+        XCTAssertFalse(entry.hasAudio)
     }
 
     func testMissingAudioFileIsNotAdvertisedAfterRelaunch() async throws {
@@ -234,6 +257,21 @@ final class DictationHistoryStoreTests: XCTestCase {
         let relaunched = DictationHistoryStore(directory: directory)
         XCTAssertEqual(relaunched.entry(id: id)?.status, .completed)
         XCTAssertFalse(FileManager.default.fileExists(atPath: journal.path), "Launch folds the journal into the index")
+    }
+
+    func testUnreadableIndexKeepsRecordings() async throws {
+        let store = DictationHistoryStore(directory: directory)
+        let id = await store.begin(audio: audio, target: nil, modelID: "tiny", language: nil, audioSeconds: 1)
+        let url = try XCTUnwrap(store.audioURL(for: XCTUnwrap(store.entry(id: id))))
+        await store.waitForPendingWrites()
+        // Force an index snapshot, then corrupt it.
+        _ = DictationHistoryStore(directory: directory)
+        try Data("not json".utf8).write(to: directory.appendingPathComponent("index.json"))
+
+        _ = DictationHistoryStore(directory: directory)
+
+        XCTAssertTrue(FileManager.default.fileExists(atPath: url.path))
+        XCTAssertTrue(FileManager.default.fileExists(atPath: directory.appendingPathComponent("index.corrupt.json").path))
     }
 
     func testRetentionResolvesUnknownValues() {

--- a/Tests/VocaMacTests/DictionaryCorrectorTests.swift
+++ b/Tests/VocaMacTests/DictionaryCorrectorTests.swift
@@ -1,0 +1,169 @@
+// DictionaryCorrectorTests.swift
+// VocaMac
+
+import XCTest
+@testable import VocaMac
+
+final class DictionaryCorrectorTests: XCTestCase {
+
+    private func correct(
+        _ text: String,
+        vocabulary: [String] = [],
+        replacements: [WordReplacement] = [],
+        context: [String] = [],
+        identifierJoins: Bool = false
+    ) -> DictionaryCorrection {
+        DictionaryCorrector.correct(
+            text,
+            context: DictionaryContext(
+                vocabulary: vocabulary,
+                replacements: replacements,
+                contextTerms: context,
+                isKnownWord: { TestWords.common.contains($0.lowercased()) }
+            ),
+            allowIdentifierJoins: identifierJoins
+        )
+    }
+
+    // MARK: Replacements
+
+    func testReplacementIgnoresCaseAndUsesUserSpelling() {
+        let result = correct("Push it to get hub please", replacements: [
+            WordReplacement(heard: "get hub", replacement: "GitHub"),
+        ])
+        XCTAssertEqual(result.text, "Push it to GitHub please")
+        XCTAssertEqual(result.protectedTerms, ["GitHub"])
+        XCTAssertEqual(result.changes, [.init(from: "get hub", to: "GitHub")])
+    }
+
+    func testReplacementMatchesWholeWordsOnly() {
+        let result = correct("the cattle and the cat", replacements: [
+            WordReplacement(heard: "cat", replacement: "Kat"),
+        ])
+        XCTAssertEqual(result.text, "the cattle and the Kat")
+    }
+
+    func testReplacementAcceptsSeveralSpokenForms() {
+        let replacement = WordReplacement(heard: "cube cuttle, cube control", replacement: "kubectl")
+        XCTAssertEqual(correct("run cube cuttle then Cube Control", replacements: [replacement]).text,
+                       "run kubectl then kubectl")
+    }
+
+    func testLongerSpokenFormWins() {
+        let result = correct("open ai studio", replacements: [
+            WordReplacement(heard: "open ai", replacement: "OpenAI"),
+            WordReplacement(heard: "open ai studio", replacement: "AI Studio"),
+        ])
+        XCTAssertEqual(result.text, "AI Studio")
+    }
+
+    // MARK: Vocabulary
+
+    func testVocabularyFixesCasingAndJoinsWords() {
+        XCTAssertEqual(correct("I love voca mac and github", vocabulary: ["VocaMac", "GitHub"]).text,
+                       "I love VocaMac and GitHub")
+    }
+
+    func testVocabularyDoesNotJoinAcrossPunctuation() {
+        XCTAssertEqual(correct("try voca. mac", vocabulary: ["VocaMac"]).text, "try voca. mac")
+    }
+
+    func testFuzzyFixesAnUnknownNearMiss() {
+        XCTAssertEqual(correct("ask Namratha about it", vocabulary: ["Namrata"]).text,
+                       "ask Namrata about it")
+    }
+
+    func testFuzzyNeverChangesAnOrdinaryWord() {
+        XCTAssertEqual(correct("the cloud is down", vocabulary: ["Claude"]).text, "the cloud is down")
+    }
+
+    func testFuzzyIgnoresShortTerms() {
+        XCTAssertEqual(correct("open jiro today", vocabulary: ["Jira"]).text, "open jiro today")
+    }
+
+    func testFuzzyJoinsSeveralWordsForLongTerms() {
+        XCTAssertEqual(correct("the post gress database", vocabulary: ["PostgreSQL"]).text,
+                       "the PostgreSQL database")
+    }
+
+    func testFuzzyRequiresSameFirstSound() {
+        XCTAssertEqual(correct("ask Tamrata about it", vocabulary: ["Namrata"]).text, "ask Tamrata about it")
+    }
+
+    // MARK: Screen context
+
+    func testScreenIdentifiersJoinOnlyInCodeApps() {
+        XCTAssertEqual(correct("set the user id value", context: ["userId"]).text, "set the user id value")
+        XCTAssertEqual(correct("set the user id value", context: ["userId"], identifierJoins: true).text,
+                       "set the userId value")
+    }
+
+    func testScreenNamesApplyEverywhere() {
+        XCTAssertEqual(correct("send it to open ai", context: ["OpenAI"]).text, "send it to OpenAI")
+    }
+
+    func testScreenTermsAreNeverFuzzy() {
+        XCTAssertEqual(correct("ask Namratha", context: ["Namrata"]).text, "ask Namratha")
+    }
+
+    func testUserVocabularyWinsOverScreenSpelling() {
+        XCTAssertEqual(correct("use voca mac", vocabulary: ["VocaMac"], context: ["Vocamac"]).text,
+                       "use VocaMac")
+    }
+
+    // MARK: Protection
+
+    func testProtectionRules() {
+        XCTAssertTrue(DictionaryCorrector.needsProtection("iPhone"))
+        XCTAssertTrue(DictionaryCorrector.needsProtection("kubectl"))
+        XCTAssertTrue(DictionaryCorrector.needsProtection("GitHub"))
+        XCTAssertTrue(DictionaryCorrector.needsProtection("C++"))
+        XCTAssertFalse(DictionaryCorrector.needsProtection("Namrata"))
+        XCTAssertFalse(DictionaryCorrector.needsProtection("New York"))
+    }
+
+    func testUnchangedTextHasNoChanges() {
+        let result = correct("nothing to see here", vocabulary: ["VocaMac"])
+        XCTAssertEqual(result.text, "nothing to see here")
+        XCTAssertTrue(result.changes.isEmpty)
+    }
+
+    func testLevenshtein() {
+        XCTAssertEqual(DictionaryCorrector.levenshtein("kitten", "sitting"), 3)
+        XCTAssertEqual(DictionaryCorrector.levenshtein("", "abc"), 3)
+        XCTAssertEqual(DictionaryCorrector.levenshtein("same", "same"), 0)
+    }
+}
+
+// MARK: - Pipeline
+
+@MainActor
+final class DictionaryPipelineTests: XCTestCase {
+
+    private func run(_ text: String, format: WritingStyle = .plain, cleanup: WritingCleanupPolicy = .inherit,
+                     dictionary: DictionaryContext) async -> String {
+        let pipeline = DictationOutputPipeline(cleaner: MockTranscriptCleanup(), snippets: SnippetExpander())
+        let profile = WritingProfile(format: format, rules: format.defaultRules, cleanup: cleanup)
+        return await pipeline.process(
+            text, profile: profile, snippetList: [], cleanupEnabled: false, rewritingEnabled: false,
+            model: .defaultKind, customPrompt: "", language: "en", autoCapitalize: true,
+            trailingSpace: false, dictionary: dictionary
+        ).text
+    }
+
+    private func dictionary(vocabulary: [String] = [], replacements: [WordReplacement] = []) -> DictionaryContext {
+        DictionaryContext(vocabulary: vocabulary, replacements: replacements, contextTerms: [],
+                          isKnownWord: { TestWords.common.contains($0.lowercased()) })
+    }
+
+    func testTermAtSentenceStartKeepsItsCasing() async {
+        let output = await run("iphone is great", dictionary: dictionary(vocabulary: ["iPhone"]))
+        XCTAssertTrue(output.hasPrefix("iPhone"), output)
+    }
+
+    func testRawDictationSkipsTheDictionary() async {
+        let output = await run("get hub", cleanup: .raw,
+                               dictionary: dictionary(replacements: [WordReplacement(heard: "get hub", replacement: "GitHub")]))
+        XCTAssertEqual(output, "get hub")
+    }
+}

--- a/Tests/VocaMacTests/HotKeyShortcutTests.swift
+++ b/Tests/VocaMacTests/HotKeyShortcutTests.swift
@@ -1,0 +1,106 @@
+// HotKeyShortcutTests.swift
+// VocaMac
+//
+// Extra shortcuts, the Escape cancel key, and the mouse trigger.
+
+import XCTest
+@testable import VocaMac
+
+final class HotKeyShortcutTests: XCTestCase {
+
+    private func keyEvent(_ keyCode: CGKeyCode, down: Bool, flags: CGEventFlags = []) throws -> CGEvent {
+        guard let event = CGEvent(keyboardEventSource: nil, virtualKey: keyCode, keyDown: down) else {
+            throw XCTSkip("Could not create keyboard event")
+        }
+        event.setIntegerValueField(.eventSourceUnixProcessID, value: 0)
+        event.flags = flags
+        return event
+    }
+
+    private func mouseEvent(_ type: CGEventType, button: CGMouseButton) throws -> CGEvent {
+        guard let event = CGEvent(mouseEventSource: nil, mouseType: type,
+                                  mouseCursorPosition: .zero, mouseButton: button) else {
+            throw XCTSkip("Could not create mouse event")
+        }
+        event.setIntegerValueField(.eventSourceUnixProcessID, value: 0)
+        return event
+    }
+
+    func testShortcutFiresAndConsumesItsKeys() throws {
+        let manager = HotKeyManager()
+        manager.updateShortcuts([.pasteLastDictation: .defaultPasteLast])
+        let fired = expectation(description: "Shortcut fires")
+        manager.onShortcut = { action in
+            XCTAssertEqual(action, .pasteLastDictation)
+            fired.fulfill()
+        }
+
+        XCTAssertTrue(manager._handleTestEvent(type: .keyDown, event: try keyEvent(9, down: true, flags: [.maskControl, .maskCommand])))
+        XCTAssertTrue(manager._handleTestEvent(type: .keyUp, event: try keyEvent(9, down: false, flags: [.maskControl, .maskCommand])))
+        wait(for: [fired], timeout: 1)
+    }
+
+    func testShortcutNeedsExactModifiers() throws {
+        let manager = HotKeyManager()
+        manager.updateShortcuts([.pasteLastDictation: .defaultPasteLast])
+        manager.onShortcut = { _ in XCTFail("⌘V alone must reach the app") }
+
+        XCTAssertFalse(manager._handleTestEvent(type: .keyDown, event: try keyEvent(9, down: true, flags: .maskCommand)))
+        XCTAssertFalse(manager._handleTestEvent(type: .keyUp, event: try keyEvent(9, down: false, flags: .maskCommand)))
+    }
+
+    func testShortcutMatchingTheActivationHotkeyIsIgnored() throws {
+        let manager = HotKeyManager()
+        manager.updateConfiguration(keyCode: 49, mode: .pushToTalk, safetyTimeout: 5, modifiers: .command)
+        manager.updateShortcuts([.handsFreeToggle: HotKeyCombo(keyCode: 49, modifiers: .command)])
+        let started = expectation(description: "Activation hotkey still starts recording")
+        manager.onRecordingStart = { started.fulfill() }
+        manager.onShortcut = { _ in XCTFail("Shortcut must not shadow the hotkey") }
+
+        XCTAssertTrue(manager._handleTestEvent(type: .keyDown, event: try keyEvent(49, down: true, flags: .maskCommand)))
+        wait(for: [started], timeout: 1)
+        manager.resetKeyState()
+    }
+
+    func testEscapeOnlyCancelsWhileArmed() throws {
+        let manager = HotKeyManager()
+        manager.onCancel = { XCTFail("Escape must pass through when nothing is recording") }
+        XCTAssertFalse(manager._handleTestEvent(type: .keyDown, event: try keyEvent(53, down: true)))
+        XCTAssertFalse(manager._handleTestEvent(type: .keyUp, event: try keyEvent(53, down: false)))
+
+        manager.setCancelKeyArmed(true)
+        let cancelled = expectation(description: "Escape cancels")
+        manager.onCancel = { cancelled.fulfill() }
+        // Held modifiers (push-to-talk) don't stop Escape from cancelling.
+        XCTAssertTrue(manager._handleTestEvent(type: .keyDown, event: try keyEvent(53, down: true, flags: .maskAlternate)))
+        manager.setCancelKeyArmed(false)
+        XCTAssertTrue(manager._handleTestEvent(type: .keyUp, event: try keyEvent(53, down: false)),
+                      "The release of a consumed Escape is consumed too")
+        wait(for: [cancelled], timeout: 1)
+    }
+
+    func testMouseButtonActsAsPushToTalk() throws {
+        let manager = HotKeyManager()
+        manager.updateConfiguration(mode: .pushToTalk, safetyTimeout: 5)
+        let started = expectation(description: "Start")
+        let stopped = expectation(description: "Stop")
+        manager.onRecordingStart = { started.fulfill() }
+        manager.onRecordingStop = { stopped.fulfill() }
+
+        let down = try mouseEvent(.otherMouseDown, button: .center)
+        let up = try mouseEvent(.otherMouseUp, button: .center)
+        XCTAssertFalse(manager._handleTestEvent(type: .otherMouseDown, event: down), "Off by default")
+
+        manager.updateMouseTrigger(button: MouseTriggerButton.middle.rawValue)
+        XCTAssertTrue(manager._handleTestEvent(type: .otherMouseDown, event: down))
+        XCTAssertTrue(manager._handleTestEvent(type: .otherMouseUp, event: up))
+        wait(for: [started, stopped], timeout: 1, enforceOrder: true)
+    }
+
+    func testComboStorageRoundTrips() {
+        let combo = HotKeyCombo(keyCode: 9, modifiers: [.control, .command])
+        XCTAssertEqual(HotKeyCombo(storageString: combo.storageString), combo)
+        XCTAssertNil(HotKeyCombo(storageString: ""))
+        XCTAssertNil(HotKeyCombo(storageString: "garbage"))
+    }
+}

--- a/Tests/VocaMacTests/Mocks/MockServices.swift
+++ b/Tests/VocaMacTests/Mocks/MockServices.swift
@@ -165,7 +165,7 @@ final class MockAudioDucker: AudioDucking {
 
 // MARK: - MockHotKeyManager
 
-final class MockHotKeyManager: HotKeyMonitoring {
+final class MockHotKeyManager: HotKeyMonitoring, HotKeyShortcutMonitoring {
     var isListening = false
     var eventTap: CFMachPort? = nil
     var onRecordingStart: (() -> Void)?
@@ -206,6 +206,25 @@ final class MockHotKeyManager: HotKeyMonitoring {
 
     func resetKeyState() {
         resetKeyStateCallCount += 1
+    }
+
+    // HotKeyShortcutMonitoring
+    var onShortcut: ((HotKeyShortcutAction) -> Void)?
+    var onCancel: (() -> Void)?
+    var shortcuts: [HotKeyShortcutAction: HotKeyCombo] = [:]
+    var isCancelKeyArmed = false
+    var mouseTriggerButton = 0
+
+    func updateShortcuts(_ shortcuts: [HotKeyShortcutAction: HotKeyCombo]) {
+        self.shortcuts = shortcuts
+    }
+
+    func setCancelKeyArmed(_ armed: Bool) {
+        isCancelKeyArmed = armed
+    }
+
+    func updateMouseTrigger(button: Int) {
+        mouseTriggerButton = button
     }
 
     func _updateConfiguration(keyCode: Int?, mode: ActivationMode?, doubleTapThreshold: Double?, safetyTimeout: Double?, modifiers: HotKeyModifiers?) {
@@ -696,7 +715,10 @@ extension AppState {
     static func makeTestState(
         modelManager: MockModelManager = MockModelManager(),
         whisperService: MockWhisperService = MockWhisperService(),
-        transcriptCleanup: MockTranscriptCleanup? = nil
+        transcriptCleanup: MockTranscriptCleanup? = nil,
+        historyStore: DictationHistoryStore? = nil,
+        screenContextReader: (any ScreenContextReading)? = nil,
+        correctionObserver: (any CorrectionObserving)? = nil
     ) -> (appState: AppState, mocks: TestMocks) {
         UserDefaults.standard.removeObject(forKey: "vocamac.selectedAudioDeviceID")
         UserDefaults.standard.removeObject(forKey: "vocamac.selectedAudioDeviceName")
@@ -719,6 +741,15 @@ extension AppState {
         UserDefaults.standard.removeObject(forKey: PreferenceKey.transcriptCleanupEnabled)
         UserDefaults.standard.removeObject(forKey: PreferenceKey.transcriptCleanupModel)
         UserDefaults.standard.removeObject(forKey: PreferenceKey.transcriptCleanupPrompt)
+        for key in [
+            PreferenceKey.historyEnabled, PreferenceKey.historyKeepsAudio, PreferenceKey.historyRetention,
+            PreferenceKey.escapeCancelsDictation, PreferenceKey.pasteLastShortcut, PreferenceKey.handsFreeShortcut,
+            PreferenceKey.mouseTriggerButton, PreferenceKey.wordReplacements, PreferenceKey.dictionarySuggestions,
+            PreferenceKey.dismissedDictionarySuggestions, PreferenceKey.learnCorrectionsMode,
+            PreferenceKey.useScreenContext, "vocamac.customVocabulary",
+        ] {
+            UserDefaults.standard.removeObject(forKey: key)
+        }
 
         let audioEngine = MockAudioEngine()
         let soundManager = MockSoundManager()
@@ -759,8 +790,14 @@ extension AppState {
             transcriptCleanup: cleanup,
             permissionManager: permissionManager,
             frontmostAppResolver: frontmostAppResolver,
+            historyStore: historyStore,
+            screenContextReader: screenContextReader,
+            correctionObserver: correctionObserver,
             skipSystemIntegration: true
         )
+        // Spell checking depends on the machine's dictionaries; tests use a
+        // small fixed word list instead.
+        appState.isKnownWord = { word, _ in TestWords.common.contains(word.lowercased()) }
         // Bypass host free-RAM probe so mock loads are not refused on CI.
         appState.modelFitsInMemory = { _ in true }
         return (appState, mocks)
@@ -780,4 +817,48 @@ struct TestMocks {
     let statsManager: MockStatsManager
     let frontmostAppResolver: MockFrontmostAppResolver
     let transcriptCleanup: MockTranscriptCleanup
+}
+
+
+// MARK: - Test Words
+
+enum TestWords {
+    /// Stand-in for the system spell checker in tests.
+    static let common: Set<String> = [
+        "the", "a", "an", "and", "i", "to", "is", "it", "in", "on", "of", "for", "with", "my", "me",
+        "open", "file", "hello", "world", "cloud", "there", "their", "big", "large", "meet", "at",
+        "send", "email", "call", "please", "user", "id", "service", "super", "base", "post", "apple",
+        "notes", "mail", "check", "this", "that", "we", "should", "use", "set", "value", "ask",
+        "about", "project", "today", "tomorrow", "update", "code", "run", "tests", "get", "hub",
+    ]
+}
+
+// MARK: - Mock Screen Context and Correction Observer
+
+@MainActor
+final class MockScreenContextReader: ScreenContextReading {
+    var text: String?
+    var captureCallCount = 0
+
+    func captureFrontmostContext() async -> String? {
+        captureCallCount += 1
+        return text
+    }
+}
+
+@MainActor
+final class MockCorrectionObserver: CorrectionObserving {
+    var onCorrections: (([CorrectionLearner.Correction]) -> Void)?
+    var observedTexts: [String] = []
+    var flushCallCount = 0
+
+    func observe(insertedText text: String, processID: pid_t, isKnownWord: @escaping (String) -> Bool) {
+        observedTexts.append(text)
+    }
+
+    func flush() {
+        flushCallCount += 1
+    }
+
+    func cancel() {}
 }

--- a/Tests/VocaMacTests/ServiceTests.swift
+++ b/Tests/VocaMacTests/ServiceTests.swift
@@ -105,7 +105,7 @@ final class TextInjectorTests: XCTestCase {
     /// A delayed clipboard change must not become the value consumed by the
     /// paste event. This models a clipboard manager or an older restore task
     /// racing with the current transcription.
-    func testClipboardFallbackReassertsTranscriptionBeforePaste() {
+    func testClipboardFallbackReassertsTranscriptionBeforePaste() async {
         let pasteboard = NSPasteboard(name: NSPasteboard.Name(UUID().uuidString))
         defer { pasteboard.releaseGlobally() }
         pasteboard.clearContents()
@@ -113,7 +113,6 @@ final class TextInjectorTests: XCTestCase {
 
         var pastedTexts: [String] = []
         let pasteExpectation = expectation(description: "transcription paste event")
-        let finishedExpectation = expectation(description: "clipboard restoration")
 
         let injector = TextInjector(
             pasteboard: pasteboard,
@@ -135,11 +134,12 @@ final class TextInjectorTests: XCTestCase {
             pasteboard.clearContents()
             pasteboard.setString("clipboard manager value", forType: .string)
         }
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.35) {
-            finishedExpectation.fulfill()
-        }
 
-        wait(for: [pasteExpectation, finishedExpectation], timeout: 1.0)
+        await fulfillment(of: [pasteExpectation], timeout: 5.0)
+        // Wait for the injection to finish restoring the clipboard rather
+        // than a fixed delay: a busy CI runner can hold the main thread long
+        // enough for a timer to fire before the restore has run.
+        await TextInjector.waitForInjectionQueueIdleForTesting()
 
         XCTAssertEqual(pastedTexts, ["spoken transcription"])
         XCTAssertEqual(

--- a/docs/DATA_MODEL.md
+++ b/docs/DATA_MODEL.md
@@ -451,6 +451,10 @@ skipped. Then:
 - A recording is only deleted from disk after the journal or index write that
   drops it has succeeded. A deletion that can't be saved leaves the file in
   place, so the history on disk never points at audio that's already gone.
+- Deleting one dictation, Delete All, and Delete Audio are all-or-nothing. If
+  the change can't be saved, the history is restored in memory, nothing is
+  removed from disk, and the user sees an error. What's on screen always
+  matches what the next launch loads.
 
 Storage limits:
 

--- a/docs/DATA_MODEL.md
+++ b/docs/DATA_MODEL.md
@@ -455,6 +455,13 @@ skipped. Then:
   the change can't be saved, the history is restored in memory, nothing is
   removed from disk, and the user sees an error. What's on screen always
   matches what the next launch loads.
+- Other changes stay in memory even when the disk refuses both the journal and
+  the index. Examples are a dictation finishing, failing, or being retried,
+  and retention. History is then marked as having unsaved changes, and the
+  History page shows a warning. The next save, or quitting VocaMac, rewrites
+  the whole index, so the change is kept once writes work again.
+- If a new entry can't be saved at all, no audio is written for it and the
+  dictation runs without history.
 
 Storage limits:
 

--- a/docs/DATA_MODEL.md
+++ b/docs/DATA_MODEL.md
@@ -428,9 +428,15 @@ first. Each entry holds:
 - a status: `pending`, `completed`, `empty`, `failed`, `interrupted`, or `cancelled`
 - the name of its WAV file (16-bit mono 16 kHz), when audio is kept
 
-The entry and its audio are written **before** transcription starts. A
-`pending` entry found at launch becomes `interrupted`, so a crash
-mid-dictation still leaves the audio to retry.
+The WAV file is on disk **before** transcription starts. The index is written
+next. At launch:
+
+- A `pending` entry becomes `interrupted`, so a crash mid-dictation still
+  leaves the audio to retry.
+- A WAV file the index doesn't list comes back as an `interrupted` entry. That
+  covers a crash between the two writes.
+- An entry whose WAV file is missing, or whose write failed, is shown without
+  audio.
 
 Storage limits:
 

--- a/docs/DATA_MODEL.md
+++ b/docs/DATA_MODEL.md
@@ -448,6 +448,9 @@ skipped. Then:
   journaled, naming its WAV file, before the file is written, so such a file
   can only be audio whose deletion was saved before its removal ran. Deleted
   recordings never come back.
+- A recording is only deleted from disk after the journal or index write that
+  drops it has succeeded. A deletion that can't be saved leaves the file in
+  place, so the history on disk never points at audio that's already gone.
 
 Storage limits:
 

--- a/docs/DATA_MODEL.md
+++ b/docs/DATA_MODEL.md
@@ -442,10 +442,12 @@ skipped. Then:
 
 - A `pending` entry becomes `interrupted`, so a crash mid-dictation still
   leaves the audio to retry.
-- A WAV file the index doesn't list comes back as an `interrupted` entry. That
-  covers a crash between the two writes.
-- An entry whose WAV file is missing, or whose write failed, is shown without
-  audio.
+- An entry whose WAV file is missing is shown without audio. That covers a
+  crash during the audio write, and a failed write.
+- A file in `audio/` that no entry refers to is deleted. Each entry is
+  journaled, naming its WAV file, before the file is written, so such a file
+  can only be audio whose deletion was saved before its removal ran. Deleted
+  recordings never come back.
 
 Storage limits:
 

--- a/docs/DATA_MODEL.md
+++ b/docs/DATA_MODEL.md
@@ -314,6 +314,24 @@ struct UserSettings {
     var modelKeepAliveEnabled: Bool = false
     var modelKeepAliveIdleTimeoutSeconds: Double = 300
 
+    // History
+    var historyEnabled: Bool = true
+    var historyKeepsAudio: Bool = true
+    var historyRetention: HistoryRetention = .month   // day, week, month, forever
+
+    // Shortcuts beyond the activation hotkey
+    var escapeCancelsDictation: Bool = true
+    var pasteLastShortcut: String = "9:9"      // HotKeyCombo.storageString ("keyCode:modifiers"), ⌃⌘V; "" = off
+    var handsFreeShortcut: String = ""         // off until the user records one
+    var mouseTriggerButton: Int = 0            // CGEvent button number; 0 = off, 2 middle, 3 back, 4 forward
+
+    // Personal dictionary
+    var customVocabulary: String = ""          // terms, newline-separated; also the Whisper prompt
+    var wordReplacements: [WordReplacement] = []          // JSON in UserDefaults
+    var dictionarySuggestions: [CorrectionSuggestion] = [] // JSON in UserDefaults
+    var learnCorrectionsMode: LearnCorrectionsMode = .suggest
+    var useScreenContext: Bool = true
+
     // App Behavior
     var launchAtLogin: Bool = false
     var preserveClipboard: Bool = true          // Restore clipboard after text injection
@@ -336,6 +354,18 @@ vocamac.modelKeepAlive.idleTimeoutSeconds = 300
 vocamac.writingStyle.enabled = true
 vocamac.writingStyle.defaultStyle = "plain"
 vocamac.writingStyle.bindings = "{\"schemaVersion\":1,\"bindings\":[...]}"
+vocamac.history.enabled = true
+vocamac.history.keepAudio = true
+vocamac.history.retention = "month"
+vocamac.shortcuts.escapeCancels = true
+vocamac.shortcuts.pasteLast = "9:9"
+vocamac.shortcuts.handsFree = ""
+vocamac.shortcuts.mouseButton = 0
+vocamac.dictionary.replacements = <JSON [WordReplacement]>
+vocamac.dictionary.suggestions = <JSON [CorrectionSuggestion]>
+vocamac.dictionary.dismissedSuggestions = ["heard→Corrected", ...]
+vocamac.dictionary.learnMode = "suggest"
+vocamac.dictionary.screenContext = true
 ...
 ```
 
@@ -387,6 +417,56 @@ LLM-only, and hybrid outputs over three repeated passes. Automated guards and
 unit tests do not establish semantic equivalence or style quality; inspect the
 report before changing the experimental status. Browser-tab and field identity
 are not inferred from a bundle ID.
+
+### Dictation history
+
+`DictationHistoryStore` keeps a `DictationHistoryEntry` per dictation, newest
+first. Each entry holds:
+
+- the engine's raw text and the text that was typed, plus the pipeline summary
+- the target app, model, language, and timings
+- a status: `pending`, `completed`, `empty`, `failed`, `interrupted`, or `cancelled`
+- the name of its WAV file (16-bit mono 16 kHz), when audio is kept
+
+The entry and its audio are written **before** transcription starts. A
+`pending` entry found at launch becomes `interrupted`, so a crash
+mid-dictation still leaves the audio to retry.
+
+Storage limits:
+
+- A successful dictation drops its audio when "Keep audio recordings" is off.
+  Failed, interrupted, and cancelled dictations keep their audio until they are
+  retried or deleted.
+- At most 2,000 entries are kept.
+- Audio is capped at 1 GB. The oldest recordings lose their audio first; their
+  text stays.
+- Retention (1 day, 7 days, 30 days, or forever) is applied at launch, at each
+  dictation, and whenever the setting changes.
+
+### Personal dictionary
+
+`DictionaryCorrector` runs inside `DictationOutputPipeline`, after the Raw
+check and before snippets, styles, and cleanup. It does three things, in this
+order:
+
+1. **Replacements.** Case-insensitive, whole-word matching; longest spoken form first.
+2. **Vocabulary terms.** Letters are matched ignoring case, spaces, and
+   punctuation, over up to four spoken words. On top of that, a conservative
+   fuzzy match fixes terms of 5 or more letters: edit distance ≤ 1 (≤ 2 for 9
+   or more letters), same first sound. It never applies when every word in the
+   match is ordinary vocabulary according to the spell checker (English only).
+3. **Screen terms.** Letter match only, never fuzzy. Several words are joined
+   into a camelCase, snake_case, or kebab-case identifier only for the Code and
+   Terminal formats.
+
+A term whose casing formatting could change (`iPhone`, `kubectl`, `GitHub`)
+travels through the snippet mask, so neither sentence case nor cleanup alters it.
+
+`CorrectionObserver` reads the focused field about 0.8 s after injection. It
+reads it again when the next dictation starts, or after 20 s. The text itself
+is never stored. `CorrectionLearner` reduces the two readings to spelling-level
+substitutions inside the dictated span. Depending on
+`vocamac.dictionary.learnMode`, those become suggestions or are added directly.
 
 ### 3.8 `SystemCapabilities` — Hardware Detection Result
 
@@ -490,7 +570,7 @@ enum UpdateState: Equatable {
 | User settings | `UserDefaults` | Permanent (until app uninstall or reset) |
 | Model files | `~/Library/Application Support/VocaMac/models/` | Permanent (user can delete) |
 | Audio buffers | In-memory `[Float]` | Discarded after transcription |
-| Transcription results | In-memory (MVP) | Lost on app restart (MVP) |
+| Transcription results | `~/Library/Application Support/VocaMac/History/` (`index.json` + `audio/*.wav`) | Per the history retention setting; off when history is disabled |
 | App state | In-memory `AppState` | Rebuilt on each launch |
 | System capabilities | Computed at launch | Rebuilt on each launch |
 | Update check cache | `UserDefaults` (`vocamac.update.*`) | Persisted across launches |
@@ -505,6 +585,9 @@ enum UpdateState: Equatable {
 │   ├── openai_whisper-small         ← Optional (downloaded)
 │   ├── openai_whisper-medium        ← Optional (downloaded)
 │   └── openai_whisper-large-v3     ← Optional (downloaded)
+├── History/
+│   ├── index.json             ← Dictation history entries
+│   └── audio/<entry-id>.wav   ← Recordings kept for playback and retry
 └── logs/                      ← Future: debug logging
 ```
 

--- a/docs/DATA_MODEL.md
+++ b/docs/DATA_MODEL.md
@@ -428,8 +428,17 @@ first. Each entry holds:
 - a status: `pending`, `completed`, `empty`, `failed`, `interrupted`, or `cancelled`
 - the name of its WAV file (16-bit mono 16 kHz), when audio is kept
 
-The WAV file is on disk **before** transcription starts. The index is written
-next. At launch:
+The WAV file is on disk **before** transcription starts.
+
+Every change to an entry is appended synchronously to `journal.jsonl` as one
+line holding the entry's latest state, or its deletion. The line is on disk
+before VocaMac moves on, so a completed dictation survives a crash or force
+quit. `index.json` holds the full history. It is rewritten at launch, after
+bulk changes (Delete All, Delete Audio), and whenever the journal reaches 500
+lines, and the journal is then cleared.
+
+At launch the journal is replayed over the index, and a torn last line is
+skipped. Then:
 
 - A `pending` entry becomes `interrupted`, so a crash mid-dictation still
   leaves the audio to retry.
@@ -592,7 +601,8 @@ enum UpdateState: Equatable {
 │   ├── openai_whisper-medium        ← Optional (downloaded)
 │   └── openai_whisper-large-v3     ← Optional (downloaded)
 ├── History/
-│   ├── index.json             ← Dictation history entries
+│   ├── index.json             ← Dictation history snapshot
+│   ├── journal.jsonl          ← Changes since the snapshot (replayed at launch)
 │   └── audio/<entry-id>.wav   ← Recordings kept for playback and retry
 └── logs/                      ← Future: debug logging
 ```


### PR DESCRIPTION
Closes #23.

This closes the everyday gaps against Wispr Flow, Superwhisper, and VoiceInk. Everything stays on-device.

## Dictation history

- Every dictation is saved locally under `~/Library/Application Support/VocaMac/History/`. That includes the engine's raw text, the text that was typed, the target app, the model, and the audio.
- **The audio is on disk before transcription starts.** The entry is journaled first, naming its WAV file, and `begin()` then waits for the WAV write.
  - If VocaMac crashes mid-dictation, the entry is marked `interrupted` on the next launch.
  - A failed decode leaves a `failed` entry.
  - Interrupted and failed entries can be retried.
  - If the audio write fails, or VocaMac crashes during it, the entry simply has no audio.
- **Deleted audio never comes back.** Every recording on disk belongs to a journaled entry, so a file nothing refers to can only be leftover deleted audio. Launch deletes it. If the index is ever unreadable, recordings are kept for the set-aside copy. A recording is only deleted from disk after the journal or index write that drops it has succeeded. Deleting a dictation, Delete All, and Delete Audio are all-or-nothing: if the change can't be saved, it's undone and the user sees an error.
- **When the disk refuses writes,** completions, failures, and retries stay in memory and are marked unsaved, and the History page shows a warning. The next save, or quitting VocaMac, rewrites the full index. A new entry that can't be saved writes no audio and runs without history.
- **Every change is journaled synchronously:** each change appends one line to `journal.jsonl` before VocaMac moves on, so a completed dictation survives a crash or force quit. `index.json` is rewritten at launch, after bulk deletes, and every 500 lines.
- **Settings → History** has:
  - search
  - Copy, Copy original (when cleanup, a style, or the dictionary changed the words), Play, Retry, Delete
  - retention (1 day / 7 days / 30 days by default / forever), a keep-audio toggle, and Delete All
- Limits: 2,000 entries and 1 GB of audio. The oldest audio goes first; its text stays.
- The menu bar shows a **Retry** banner when the latest dictation failed or was interrupted. Retry transcribes the saved audio with the current model and copies the result.

## Shortcuts

- **Paste last dictation:** ⌃⌘V by default. It can be changed or cleared.
- **Escape cancels.** While recording, the audio is discarded. While transcribing, the result is dropped and the entry is kept for retry. Escape is only claimed during those two states.
- An optional **hands-free toggle shortcut** and a **mouse-button trigger** (middle, back, or forward button).
- **10- and 20-minute** recording limits.

## Personal dictionary

- **Replacements and vocabulary now apply to every engine**, not only Whisper. This runs inside `DictationOutputPipeline` after the Raw check.
  - **Letter matching** ignores case, spaces, and punctuation: "voca mac" → VocaMac.
  - **Fuzzy matching** only applies to terms of 5 or more letters, needs the same first sound, and never changes a word the spell checker knows. So "cloud" stays "cloud".
  - Terms with meaningful casing (`iPhone`, `kubectl`) pass through the snippet mask, so neither sentence case nor cleanup alters them.
- **Learn from corrections.** VocaMac reads the focused field shortly after injection, then again at the next dictation or after 20 s. It turns the difference into spelling-level suggestions: suggest (the default), add automatically, or off.
- **Spell names from the screen.** The focused field's visible text is read at record start and used only for exact letter matches. Joining several words into an identifier (`user id` → `userId`) only happens in Code and Terminal styles.
- Nothing read from other apps is stored, and password fields are never read.
- **Settings → Dictionary** replaces the Whisper-only vocabulary editor. Existing vocabulary carries over, and Whisper still uses it as a prompt.

## Notes for review

- `HotKeyManager` handles the extra shortcuts, Escape, and `otherMouseDown/Up` in the existing event tap. There's no new tap and no polling. The new API lives on a separate `HotKeyShortcutMonitoring` protocol, so existing conformances are unaffected.
- `AppState` gets an in-memory history store, and no screen or correction readers, when `skipSystemIntegration` is set. Tests never touch Application Support or other apps.
- Defaults to consider:
  - ⌃⌘V is claimed globally, which matches Wispr Flow.
  - Screen spelling and correction suggestions are on.
  - History is on, with 30-day retention.
- `docs/DATA_MODEL.md` documents the new preference keys and on-disk layout.

## Testing

- `swift test`: 996 tests, 0 failures. New suites:
  - `DictationHistoryStoreTests`, `AppStateHistoryTests`, `HotKeyShortcutTests`
  - `DictionaryCorrectorTests`, `DictionaryPipelineTests`, `CorrectionLearnerTests`, `ScreenContextTermsTests`
- `scripts/build.sh` builds the `.app`.
- Not yet exercised by hand in a running build.

## Also in this PR

- `test: wait for the injection queue instead of a fixed delay in the clipboard test`: `TextInjectorTests.testClipboardFallbackReassertsTranscriptionBeforePaste` asserted after a fixed 0.35 s, and failed intermittently whenever the runner stalled the main thread. It also failed on `fix/mute-other-audio` and `jmalik/chore-release-0.10.0`. It now waits for the injection queue to drain before asserting, and passed 15 runs in a row with every CPU core saturated.
